### PR TITLE
[11.0][base_tier_validation] add 'can_review' 

### DIFF
--- a/base_tier_validation/models/tier_validation.py
+++ b/base_tier_validation/models/tier_validation.py
@@ -33,6 +33,12 @@ class TierValidation(models.AbstractModel):
         compute="_compute_reviewer_ids",
         search="_search_reviewer_ids",
     )
+    can_review = fields.Boolean(compute="_compute_can_review")
+
+    @api.multi
+    def _compute_can_review(self):
+        for rec in self:
+            rec.can_review = self.env.user in rec.reviewer_ids
 
     @api.multi
     @api.depends('review_ids')


### PR DESCRIPTION
Add 'can_review' to tier.validation so that the buttons approve and reject can be hidden according to this computed field.