### PR TITLE
[12.0][FIX] date_range: at_install/post_install test decorators

### DIFF
--- a/date_range/tests/test_date_range.py
+++ b/date_range/tests/test_date_range.py
@@ -3,13 +3,13 @@
 
 import datetime
 
+import odoo
 from odoo.exceptions import ValidationError
 from odoo.tests.common import TransactionCase
 
 
+@odoo.tests.tagged('post_install', '-at_install')
 class DateRangeTest(TransactionCase):
-    post_install = True
-    at_install = False
 
     def setUp(self):
         super(DateRangeTest, self).setUp()

--- a/date_range/tests/test_date_range.py
+++ b/date_range/tests/test_date_range.py
@@ -3,12 +3,10 @@
 
 import datetime
 
-import odoo
 from odoo.exceptions import ValidationError
 from odoo.tests.common import TransactionCase
 
 
-@odoo.tests.tagged('post_install', '-at_install')
 class DateRangeTest(TransactionCase):
 
     def setUp(self):

--- a/date_range/tests/test_date_range_generator.py
+++ b/date_range/tests/test_date_range_generator.py
@@ -5,12 +5,10 @@ import datetime
 
 from dateutil.rrule import MONTHLY
 
-import odoo
 from odoo.exceptions import ValidationError
 from odoo.tests.common import TransactionCase
 
 
-@odoo.tests.tagged('post_install', '-at_install')
 class DateRangeGeneratorTest(TransactionCase):
 
     def setUp(self):

--- a/date_range/tests/test_date_range_generator.py
+++ b/date_range/tests/test_date_range_generator.py
@@ -5,13 +5,13 @@ import datetime
 
 from dateutil.rrule import MONTHLY
 
+import odoo
 from odoo.exceptions import ValidationError
 from odoo.tests.common import TransactionCase
 
 
+@odoo.tests.tagged('post_install', '-at_install')
 class DateRangeGeneratorTest(TransactionCase):
-    post_install = True
-    at_install = False
 
     def setUp(self):
         super(DateRangeGeneratorTest, self).setUp()

--- a/date_range/tests/test_date_range_type.py
+++ b/date_range/tests/test_date_range_type.py
@@ -3,14 +3,14 @@
 
 from psycopg2 import IntegrityError
 
+import odoo
 from odoo.exceptions import ValidationError
 from odoo.tests.common import TransactionCase
 from odoo.tools import mute_logger
 
 
+@odoo.tests.tagged('post_install', '-at_install')
 class DateRangeTypeTest(TransactionCase):
-    post_install = True
-    at_install = False
 
     def setUp(self):
         super(DateRangeTypeTest, self).setUp()

--- a/date_range/tests/test_date_range_type.py
+++ b/date_range/tests/test_date_range_type.py
@@ -3,13 +3,11 @@
 
 from psycopg2 import IntegrityError
 
-import odoo
 from odoo.exceptions import ValidationError
 from odoo.tests.common import TransactionCase
 from odoo.tools import mute_logger
 
 
-@odoo.tests.tagged('post_install', '-at_install')
 class DateRangeTypeTest(TransactionCase):
 
     def setUp(self):


### PR DESCRIPTION
Following https://github.com/odoo/odoo/issues/27471, here is the patch for the `at_install`/`post_install` test decorators, the V12.0 way.