### PR TITLE
[FIX] mass_editing: remove non existent field in tests

### DIFF
--- a/mass_editing/__manifest__.py
+++ b/mass_editing/__manifest__.py
@@ -2,7 +2,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 {
     'name': 'Mass Editing',
-    'version': '11.0.1.0.0',
+    'version': '11.0.1.0.1',
     'author': 'Serpent Consulting Services Pvt. Ltd., '
               'Tecnativa, '
               'Odoo Community Association (OCA)',

--- a/mass_editing/tests/test_mass_editing.py
+++ b/mass_editing/tests/test_mass_editing.py
@@ -56,7 +56,6 @@ class TestMassEditing(common.TransactionCase):
             'email': 'example@yourcompany.com',
             'phone': 123456,
             'category_id': [(6, 0, categ_ids)],
-            'notify_email': 'always'
         })
 
     def _create_partner_title(self):


### PR DESCRIPTION
`notify_email` doesn't exist in res.partner model,

cc @Tecnativa