### PR TITLE
mass_editing: protect against fields that start with 'selection_'

### DIFF
--- a/mass_editing/wizard/mass_editing_wizard.py
+++ b/mass_editing/wizard/mass_editing_wizard.py
@@ -242,7 +242,7 @@ class MassEditingWizard(models.TransientModel):
 
             values = {}
             for key, val in vals.items():
-                if key.startswith('selection_'):
+                if key.startswith('selection_') and '__' in key:
                     split_key = key.split('__', 1)[1]
                     if val == 'set':
                         values.update({split_key: vals.get(split_key, False)})


### PR DESCRIPTION
A field can start with `selection_` string and still not be a selection :) Protect against this by checking if a dunder is in the string. This isn't perfect but works, unless you name your field `selection__...`.