### PR TITLE
[FIX] travis error: duplicate implicit target name

### DIFF
--- a/base_technical_features/README.rst
+++ b/base_technical_features/README.rst
@@ -50,7 +50,7 @@ Additionally, users can check the *Technical feature* field in their
 preferences to gain permanent access to the menus and views that fall under
 this category.
 
-.. figure:: https://raw.githubusercontent.com/OCA/server-ux/12.0/base_technical_features/static/description/user_preferences.png
+.. figure:: static/description/user_preferences.png
    :alt: User preferences
 
 Upon installation of this module, this preference is already
@@ -81,9 +81,6 @@ Authors
 
 Contributors
 ~~~~~~~~~~~~
-
-Contributors
-------------
 
 * Stefan Rijnhart <stefan@opener.am>
 * Jeroen Evens <jeroen.evenss@dynapps.be>

--- a/base_technical_features/readme/CONTRIBUTORS.rst
+++ b/base_technical_features/readme/CONTRIBUTORS.rst
@@ -1,5 +1,2 @@
-Contributors
-------------
-
 * Stefan Rijnhart <stefan@opener.am>
 * Jeroen Evens <jeroen.evenss@dynapps.be>

--- a/base_technical_features/static/description/index.html
+++ b/base_technical_features/static/description/index.html
@@ -379,32 +379,29 @@ based on user preference.</p>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">
-<li><a class="reference internal" href="#usage" id="id2">Usage</a></li>
-<li><a class="reference internal" href="#configuration" id="id3">Configuration</a></li>
-<li><a class="reference internal" href="#bug-tracker" id="id4">Bug Tracker</a></li>
-<li><a class="reference internal" href="#credits" id="id5">Credits</a><ul>
-<li><a class="reference internal" href="#authors" id="id6">Authors</a></li>
-<li><a class="reference internal" href="#contributors" id="id7">Contributors</a><ul>
-<li><a class="reference internal" href="#id1" id="id8">Contributors</a></li>
-</ul>
-</li>
-<li><a class="reference internal" href="#maintainers" id="id9">Maintainers</a></li>
+<li><a class="reference internal" href="#usage" id="id1">Usage</a></li>
+<li><a class="reference internal" href="#configuration" id="id2">Configuration</a></li>
+<li><a class="reference internal" href="#bug-tracker" id="id3">Bug Tracker</a></li>
+<li><a class="reference internal" href="#credits" id="id4">Credits</a><ul>
+<li><a class="reference internal" href="#authors" id="id5">Authors</a></li>
+<li><a class="reference internal" href="#contributors" id="id6">Contributors</a></li>
+<li><a class="reference internal" href="#maintainers" id="id7">Maintainers</a></li>
 </ul>
 </li>
 </ul>
 </div>
 <div class="section" id="usage">
-<h2><a class="toc-backref" href="#id2">Usage</a></h2>
+<h2><a class="toc-backref" href="#id1">Usage</a></h2>
 </div>
 <div class="section" id="configuration">
-<h2><a class="toc-backref" href="#id3">Configuration</a></h2>
+<h2><a class="toc-backref" href="#id2">Configuration</a></h2>
 <p>After installation of this module, every employee can still access technical
 features for the applications that they have access to by enabling debug mode.
 Additionally, users can check the <em>Technical feature</em> field in their
 preferences to gain permanent access to the menus and views that fall under
 this category.</p>
 <div class="figure">
-<img alt="User preferences" src="https://raw.githubusercontent.com/OCA/server-ux/12.0/base_technical_features/static/description/user_preferences.png" />
+<img alt="User preferences" src="static/description/user_preferences.png" />
 </div>
 <p>Upon installation of this module, this preference is already
 set for the administrator user of the database.</p>
@@ -414,7 +411,7 @@ therefore manage this preference from the regular Users and Groups menu items.
 f it’s not unique.</p>
 </div>
 <div class="section" id="bug-tracker">
-<h2><a class="toc-backref" href="#id4">Bug Tracker</a></h2>
+<h2><a class="toc-backref" href="#id3">Bug Tracker</a></h2>
 <p>Bugs are tracked on <a class="reference external" href="https://github.com/OCA/server-ux/issues">GitHub Issues</a>.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us smashing it by providing a detailed and welcomed
@@ -422,25 +419,22 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">
-<h2><a class="toc-backref" href="#id5">Credits</a></h2>
+<h2><a class="toc-backref" href="#id4">Credits</a></h2>
 <div class="section" id="authors">
-<h3><a class="toc-backref" href="#id6">Authors</a></h3>
+<h3><a class="toc-backref" href="#id5">Authors</a></h3>
 <ul class="simple">
 <li>Opener B.V.</li>
 </ul>
 </div>
 <div class="section" id="contributors">
-<h3><a class="toc-backref" href="#id7">Contributors</a></h3>
-<div class="section" id="id1">
-<h4><a class="toc-backref" href="#id8">Contributors</a></h4>
+<h3><a class="toc-backref" href="#id6">Contributors</a></h3>
 <ul class="simple">
 <li>Stefan Rijnhart &lt;<a class="reference external" href="mailto:stefan&#64;opener.am">stefan&#64;opener.am</a>&gt;</li>
 <li>Jeroen Evens &lt;<a class="reference external" href="mailto:jeroen.evenss&#64;dynapps.be">jeroen.evenss&#64;dynapps.be</a>&gt;</li>
 </ul>
 </div>
-</div>
 <div class="section" id="maintainers">
-<h3><a class="toc-backref" href="#id9">Maintainers</a></h3>
+<h3><a class="toc-backref" href="#id7">Maintainers</a></h3>
 <p>This module is maintained by the OCA.</p>
 <a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose


### PR DESCRIPTION
This should fix build error that prevents from importing data_range translation.

https://travis-ci.org/OCA/server-ux/builds/470578531

