### PR TITLE
[FIX] date_range. Remove '\xc2' character from models/__init__.py

### DIFF
--- a/date_range/__init__.py
+++ b/date_range/__init__.py
@@ -1,5 +1,4 @@
-# © 2016 ACSONE SA/NV (<http://acsone.eu>)
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 from . import models
 from . import wizard

--- a/date_range/__manifest__.py
+++ b/date_range/__manifest__.py
@@ -1,5 +1,5 @@
-# © 2016 ACSONE SA/NV (<http://acsone.eu>)
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+# Copyright 2016 ACSONE SA/NV (<https://acsone.eu>)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 {
     "name": "Date Range",
     "summary": "Manage all kind of date range",

--- a/date_range/models/__init__.py
+++ b/date_range/models/__init__.py
@@ -1,5 +1,4 @@
-# © 2016 ACSONE SA/NV (<http://acsone.eu>)
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 from . import date_range_type
 from . import date_range

--- a/date_range/models/date_range.py
+++ b/date_range/models/date_range.py
@@ -1,5 +1,5 @@
-# © 2016 ACSONE SA/NV (<http://acsone.eu>)
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+# Copyright 2016 ACSONE SA/NV (<https://acsone.eu>)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 from odoo import api, fields, models
 from odoo.tools.translate import _

--- a/date_range/models/date_range_type.py
+++ b/date_range/models/date_range_type.py
@@ -1,5 +1,5 @@
-# © 2016 ACSONE SA/NV (<http://acsone.eu>)
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+# Copyright 2016 ACSONE SA/NV (<https://acsone.eu>)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 from odoo import api, fields, models
 from odoo.tools.translate import _

--- a/date_range/tests/__init__.py
+++ b/date_range/tests/__init__.py
@@ -1,5 +1,4 @@
-# © 2016 ACSONE SA/NV (<http://acsone.eu>)
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 from . import test_date_range_type
 from . import test_date_range

--- a/date_range/tests/test_date_range.py
+++ b/date_range/tests/test_date_range.py
@@ -1,5 +1,5 @@
-# © 2016 ACSONE SA/NV (<http://acsone.eu>)
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+# Copyright 2016 ACSONE SA/NV (<https://acsone.eu>)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
 
 from odoo.tests.common import TransactionCase
 from odoo.exceptions import ValidationError

--- a/date_range/tests/test_date_range_generator.py
+++ b/date_range/tests/test_date_range_generator.py
@@ -1,5 +1,5 @@
-# © 2016 ACSONE SA/NV (<http://acsone.eu>)
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)nses/agpl).
+# Copyright 2016 ACSONE SA/NV (<https://acsone.eu>)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
 
 from odoo.tests.common import TransactionCase
 from odoo.exceptions import ValidationError

--- a/date_range/tests/test_date_range_type.py
+++ b/date_range/tests/test_date_range_type.py
@@ -1,5 +1,5 @@
-# © 2016 ACSONE SA/NV (<http://acsone.eu>)
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+# Copyright 2016 ACSONE SA/NV (<https://acsone.eu>)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
 
 from odoo.tests.common import TransactionCase
 from odoo.tools import mute_logger

--- a/date_range/wizard/__init__.py
+++ b/date_range/wizard/__init__.py
@@ -1,4 +1,3 @@
-# © 2016 ACSONE SA/NV (<http://acsone.eu>)
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 from . import date_range_generator

--- a/date_range/wizard/date_range_generator.py
+++ b/date_range/wizard/date_range_generator.py
@@ -1,5 +1,5 @@
-# © 2016 ACSONE SA/NV (<http://acsone.eu>)
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+# Copyright 2016 ACSONE SA/NV (<https://acsone.eu>)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 from odoo import api, fields, models
 from odoo.tools.translate import _


### PR DESCRIPTION
PR was at first motivated by errors in running a buildout. It failed because of the copyright character. On further analysis it became clear that the 11.0 code was being run on python2. I keep the PR because it still updates file headers accordig to latest conventions.