### PR TITLE
[11.0][FIX] base_tier_validation

### DIFF
--- a/base_tier_validation/models/tier_validation.py
+++ b/base_tier_validation/models/tier_validation.py
@@ -88,7 +88,7 @@ class TierValidation(models.AbstractModel):
             tiers = self.env[
                 'tier.definition'].search([('model', '=', self._name)])
             valid_tiers = any([self.evaluate_tier(tier) for tier in tiers])
-            rec.need_validation = not self.review_ids and valid_tiers and \
+            rec.need_validation = not rec.review_ids and valid_tiers and \
                 getattr(rec, self._state_field) in self._state_from
 
     @api.multi

--- a/base_tier_validation/views/tier_definition_view.xml
+++ b/base_tier_validation/views/tier_definition_view.xml
@@ -64,7 +64,7 @@
                 <separator/>
                 <filter string="All" name="all" domain="['|', ('active', '=', False), ('active', '=', True)]" />
                 <group expand="0" string="Group By">
-                    <filter string="Model" domain="[]" context="{'group_by':'model_id'}"/>
+                    <filter string="Model" name="model_id" domain="[]" context="{'group_by':'model_id'}"/>
                 </group>
             </search>
         </field>


### PR DESCRIPTION
Fix to the following error:

File "/opt/ao-odoo-buildout/parts/server-ux11/base_tier_validation/models/tier_validation.py", line 91, in _compute_need_validation
rec.need_validation = not self.review_ids and valid_tiers and \
File "/opt/ao-odoo-buildout/parts/oca11/odoo/fields.py", line 925, in get
record.ensure_one()
File "/opt/ao-odoo-buildout/parts/oca11/odoo/models.py", line 4371, in ensure_one
raise ValueError("Expected singleton: %s" % self)
ValueError: Expected singleton: stock.request(1, 2, 3)