### PR TITLE
[11.0] change minimum postgres version to 9.3 on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ python:
   - "3.5"
 
 addons:
-  postgresql: "9.3" # minimal postgresql version for the base_import_security_group module
+  postgresql: "9.6" # minimal postgresql version for the base_import_security_group module
                     # more info: https://github.com/OCA/maintainer-quality-tools/issues/432
   apt:
     packages:


### PR DESCRIPTION
Travis is getting :red_circle: because it is using xenial, not trusty and postgres 9.3 is no longer available on xenial.
I don't know why it happens, because the same commit on my repo uses trusty (https://travis-ci.org/etobella/server-ux/jobs/528707940#L8) and in OCA it uses xenial (https://travis-ci.org/OCA/server-ux/jobs/528697340#L9).
In order to solve the issue, I have fixed the version to postgres 9.6 and it works in both distributions on travis.