### PR TITLE
[11.0][FIX] base_tier_validation: translation fixes

### DIFF
--- a/base_tier_validation/README.rst
+++ b/base_tier_validation/README.rst
@@ -52,7 +52,10 @@ To configure this module, you need to:
 Known issues / Roadmap
 ======================
 
-* In odoo v11 it would be interesting to try to take advantage of ``mail.activity.mixin``.
+* It would be interesting to improve the current tooltip to display reviews
+  to make it responsible and more "Odoo-ish". For instance, to use a
+  widget capable to display a tree view as a drop-down without needing
+  to navigate to a new screen.
 
 Bug Tracker
 ===========

--- a/base_tier_validation/__manifest__.py
+++ b/base_tier_validation/__manifest__.py
@@ -3,7 +3,7 @@
 {
     "name": "Base Tier Validation",
     "summary": "Implement a validation process based on tiers.",
-    "version": "11.0.2.0.1",
+    "version": "11.0.2.1.0",
     "development_status": "Mature",
     "maintainers": ['lreficent'],
     "category": "Tools",

--- a/base_tier_validation/models/res_users.py
+++ b/base_tier_validation/models/res_users.py
@@ -34,5 +34,12 @@ class Users(models.Model):
 
     @api.model
     def get_reviews(self, data):
-        return self.env['tier.review'].search_read(
-            [('id', 'in', data.get('res_ids'))])
+        review_obj = self.env['tier.review'].with_context(
+            lang=self.env.user.lang)
+        res = review_obj.search_read([('id', 'in', data.get('res_ids'))])
+        for r in res:
+            # Get the translated status value.
+            r['display_status'] = dict(
+                review_obj.fields_get('status')['status']['selection']
+            ).get(r.get('status'))
+        return res

--- a/base_tier_validation/models/tier_definition.py
+++ b/base_tier_validation/models/tier_definition.py
@@ -1,7 +1,7 @@
 # Copyright 2017 Eficent Business and IT Consulting Services S.L.
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
-from odoo import api, fields, models
+from odoo import api, fields, models, _
 
 
 class TierDefinition(models.Model):
@@ -10,7 +10,7 @@ class TierDefinition(models.Model):
 
     @api.model
     def _get_default_name(self):
-        return "New Tier Validation"
+        return _("New Tier Validation")
 
     @api.model
     def _get_tier_validation_model_names(self):
@@ -18,7 +18,11 @@ class TierDefinition(models.Model):
         return res
 
     name = fields.Char(
-        'Description', required=True, default=_get_default_name)
+        string='Description',
+        required=True,
+        default=_get_default_name,
+        translate=True,
+    )
     model_id = fields.Many2one(
         comodel_name="ir.model",
         string="Referenced Model",

--- a/base_tier_validation/readme/ROADMAP.rst
+++ b/base_tier_validation/readme/ROADMAP.rst
@@ -1,1 +1,4 @@
-* In odoo v11 it would be interesting to try to take advantage of ``mail.activity.mixin``.
+* It would be interesting to improve the current tooltip to display reviews
+  to make it responsible and more "Odoo-ish". For instance, to use a
+  widget capable to display a tree view as a drop-down without needing
+  to navigate to a new screen.

--- a/base_tier_validation/static/description/index.html
+++ b/base_tier_validation/static/description/index.html
@@ -400,7 +400,10 @@ functionality.</li>
 <div class="section" id="known-issues-roadmap">
 <h1><a class="toc-backref" href="#id2">Known issues / Roadmap</a></h1>
 <ul class="simple">
-<li>In odoo v11 it would be interesting to try to take advantage of <tt class="docutils literal">mail.activity.mixin</tt>.</li>
+<li>It would be interesting to improve the current tooltip to display reviews
+to make it responsible and more “Odoo-ish”. For instance, to use a
+widget capable to display a tree view as a drop-down without needing
+to navigate to a new screen.</li>
 </ul>
 </div>
 <div class="section" id="bug-tracker">

--- a/base_tier_validation/static/src/xml/tier_review_template.xml
+++ b/base_tier_validation/static/src/xml/tier_review_template.xml
@@ -44,7 +44,7 @@
                             <span t-esc="review.name"/>
                         </td>
                         <td class="text-right">
-                            <span t-esc="review.status"/>
+                            <span t-esc="review.display_status"/>
                         </td>
                         <td class="text-right">
                             <span t-esc="review.done_by[1]"/>


### PR DESCRIPTION
Now review name and status is translated:
![image](https://user-images.githubusercontent.com/23449160/57772795-b1f32a80-7716-11e9-9359-6642ff395483.png)

@Eficent

cc @ageficent 