### PR TITLE
[FIX] base_optional_quick_create: Add tests as post_install

### DIFF
--- a/base_optional_quick_create/tests/test_quick_create.py
+++ b/base_optional_quick_create/tests/test_quick_create.py
@@ -1,10 +1,12 @@
 # Copyright 2018 Simone Rubino - Agile Business Group
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
-
+from odoo.tests import common
 from odoo.exceptions import UserError
 from odoo.tests.common import TransactionCase
 
 
+@common.at_install(False)
+@common.post_install(True)
 class TestQuickCreate(TransactionCase):
 
     def setUp(self, *args, **kwargs):


### PR DESCRIPTION
This PR changes the behavior of the tests (when are executed, but not the results) in order to make #72 work.
I did not dump the version, as it only affects tests