### PR TITLE
[11.0][IMP] base_tier_validation module

### DIFF
--- a/base_tier_validation/README.rst
+++ b/base_tier_validation/README.rst
@@ -49,14 +49,6 @@ To configure this module, you need to:
 #. Create as many tiers as you want for any model having tier validation
    functionality.
 
-Known issues / Roadmap
-======================
-
-* It would be interesting to improve the current tooltip to display reviews
-  to make it responsible and more "Odoo-ish". For instance, to use a
-  widget capable to display a tree view as a drop-down without needing
-  to navigate to a new screen.
-
 Bug Tracker
 ===========
 

--- a/base_tier_validation/__manifest__.py
+++ b/base_tier_validation/__manifest__.py
@@ -3,7 +3,7 @@
 {
     "name": "Base Tier Validation",
     "summary": "Implement a validation process based on tiers.",
-    "version": "11.0.2.1.0",
+    "version": "11.0.3.0.0",
     "development_status": "Mature",
     "maintainers": ['lreficent'],
     "category": "Tools",

--- a/base_tier_validation/readme/ROADMAP.rst
+++ b/base_tier_validation/readme/ROADMAP.rst
@@ -1,4 +1,0 @@
-* It would be interesting to improve the current tooltip to display reviews
-  to make it responsible and more "Odoo-ish". For instance, to use a
-  widget capable to display a tree view as a drop-down without needing
-  to navigate to a new screen.

--- a/base_tier_validation/static/description/index.html
+++ b/base_tier_validation/static/description/index.html
@@ -378,12 +378,11 @@ development.</p>
 <div class="contents local topic" id="contents">
 <ul class="simple">
 <li><a class="reference internal" href="#configuration" id="id1">Configuration</a></li>
-<li><a class="reference internal" href="#known-issues-roadmap" id="id2">Known issues / Roadmap</a></li>
-<li><a class="reference internal" href="#bug-tracker" id="id3">Bug Tracker</a></li>
-<li><a class="reference internal" href="#credits" id="id4">Credits</a><ul>
-<li><a class="reference internal" href="#authors" id="id5">Authors</a></li>
-<li><a class="reference internal" href="#contributors" id="id6">Contributors</a></li>
-<li><a class="reference internal" href="#maintainers" id="id7">Maintainers</a></li>
+<li><a class="reference internal" href="#bug-tracker" id="id2">Bug Tracker</a></li>
+<li><a class="reference internal" href="#credits" id="id3">Credits</a><ul>
+<li><a class="reference internal" href="#authors" id="id4">Authors</a></li>
+<li><a class="reference internal" href="#contributors" id="id5">Contributors</a></li>
+<li><a class="reference internal" href="#maintainers" id="id6">Maintainers</a></li>
 </ul>
 </li>
 </ul>
@@ -397,17 +396,8 @@ development.</p>
 functionality.</li>
 </ol>
 </div>
-<div class="section" id="known-issues-roadmap">
-<h1><a class="toc-backref" href="#id2">Known issues / Roadmap</a></h1>
-<ul class="simple">
-<li>It would be interesting to improve the current tooltip to display reviews
-to make it responsible and more “Odoo-ish”. For instance, to use a
-widget capable to display a tree view as a drop-down without needing
-to navigate to a new screen.</li>
-</ul>
-</div>
 <div class="section" id="bug-tracker">
-<h1><a class="toc-backref" href="#id3">Bug Tracker</a></h1>
+<h1><a class="toc-backref" href="#id2">Bug Tracker</a></h1>
 <p>Bugs are tracked on <a class="reference external" href="https://github.com/OCA/server-ux/issues">GitHub Issues</a>.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us smashing it by providing a detailed and welcomed
@@ -415,22 +405,22 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">
-<h1><a class="toc-backref" href="#id4">Credits</a></h1>
+<h1><a class="toc-backref" href="#id3">Credits</a></h1>
 <div class="section" id="authors">
-<h2><a class="toc-backref" href="#id5">Authors</a></h2>
+<h2><a class="toc-backref" href="#id4">Authors</a></h2>
 <ul class="simple">
 <li>Eficent</li>
 </ul>
 </div>
 <div class="section" id="contributors">
-<h2><a class="toc-backref" href="#id6">Contributors</a></h2>
+<h2><a class="toc-backref" href="#id5">Contributors</a></h2>
 <ul class="simple">
 <li>Lois Rilo &lt;<a class="reference external" href="mailto:lois.rilo&#64;eficent.com">lois.rilo&#64;eficent.com</a>&gt;</li>
 <li>Adrià Gil Sorribes &lt;<a class="reference external" href="mailto:adria.gil&#64;eficent.com">adria.gil&#64;eficent.com</a>&gt;</li>
 </ul>
 </div>
 <div class="section" id="maintainers">
-<h2><a class="toc-backref" href="#id7">Maintainers</a></h2>
+<h2><a class="toc-backref" href="#id6">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
 <a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose

--- a/base_tier_validation/static/src/js/tier_review_widget.js
+++ b/base_tier_validation/static/src/js/tier_review_widget.js
@@ -11,14 +11,15 @@ odoo.define('base_tier_validation.ReviewField', function (require) {
     var QWeb = core.qweb;
 
     var ReviewField = AbstractField.extend({
-        template: 'tier.review.ReviewPopUp',
+        template: 'tier.review.Collapse',
         events: {
             'click .o_info_btn': '_onButtonClicked',
+            'show.bs.collapse': '_showCollapse',
+            'hide.bs.collapse': '_hideCollapse'
         },
         start: function () {
             var self = this;
-            console.log(self)
-
+            self._renderDropdown();
         },
         /**
          * Make RPC and get current user's activity details
@@ -27,7 +28,7 @@ odoo.define('base_tier_validation.ReviewField', function (require) {
         _getReviewData: function(res_ids){
             var self = this;
 
-            return self._rpc({
+            return this._rpc({
                 model: 'res.users',
                 method: 'get_reviews',
                 args: [res_ids],
@@ -38,7 +39,7 @@ odoo.define('base_tier_validation.ReviewField', function (require) {
         _renderDropdown: function () {
             var self = this;
             return this._getReviewData(self.value).then(function (){
-                self.$('.o_review').html(QWeb.render("tier.review.ReviewDropDown", {
+                self.$('.o_review').html(QWeb.render("tier.review.ReviewsTable", {
                     reviews : self.reviews
                 }));
             });
@@ -49,9 +50,15 @@ odoo.define('base_tier_validation.ReviewField', function (require) {
                 this._renderDropdown();
             }
         },
+        _showCollapse: function () {
+            this.$el.find('.panel-heading').addClass('active');
+        },
+        _hideCollapse: function () {
+            this.$el.find('.panel-heading').removeClass('active');
+        }
     });
 
-    field_registry.add('review_popup', ReviewField);
+    field_registry.add('tier_validation', ReviewField);
 
     return ReviewField;
 

--- a/base_tier_validation/static/src/less/review.less
+++ b/base_tier_validation/static/src/less/review.less
@@ -2,3 +2,43 @@ ul.o_review {
     min-width: 600px;
     max-width: 800px
 }
+
+.panel-group {
+    min-height: auto !important;
+    margin-top: -12px !important;
+    padding: 6px !important;
+}
+
+.panel-review {
+
+    .panel-heading {
+        background-color: initial !important;
+    }
+
+    .panel {
+        border: 0px !important;
+    }
+
+    .collapse > .panel-body {
+        overflow-y: hidden;
+        overflow-x: auto;
+    }
+
+    .panel-title>a, .panel-title>a:active{
+        display:block;
+    }
+
+    .panel-heading  a:before {
+       font-family: FontAwesome;
+       content: "\f0d7";
+       float: right;
+       transition: all 0.5s;
+    }
+
+    .panel-heading.active a:before {
+        -webkit-transform: rotate(180deg);
+        -moz-transform: rotate(180deg);
+        transform: rotate(180deg);
+    }
+
+}

--- a/base_tier_validation/static/src/xml/tier_review_template.xml
+++ b/base_tier_validation/static/src/xml/tier_review_template.xml
@@ -1,22 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates>
 
-    <t t-name="tier.review.ReviewPopUp">
-        <div class="dropdown btn btn-sm oe_stat_button">
-            <div class="dropdown-toggle o_info_btn" data-toggle="dropdown" style="height:100%;width:100%;display:table">
-                <div style="display:table-cell;vertical-align:middle">
-                    <div class="fa fa-fw o_button_icon fa-pencil-square-o"/>
-                    <div class="o_field_widget o_stat_info o_readonly_modifier">
-                        <span class="o_stat_text">Reviews</span>
-                    </div>
+    <t t-name="tier.review.Collapse">
+        <div class="o_form_sheet panel-group panel-review">
+            <div class="panel panel-default">
+                <div class="panel-heading">
+                    <h4 class="panel-title">
+                        <a class="o_info_btn" data-toggle="collapse" href="#" data-target="#collapse1">Reviews</a>
+                    </h4>
+                </div>
+                <div id="collapse1" class="panel-collapse collapse">
+                    <div class="panel-body o_review"></div>
                 </div>
             </div>
-            <ul class="dropdown-menu o_review" role="menu" style="right:0;left: auto">
-            </ul>
         </div>
     </t>
 
-    <t t-name="tier.review.ReviewDropDown">
+    <t t-name="tier.review.ReviewsTable">
         <table class="oe_mt32 table table-condensed">
             <thead>
                 <tr>

--- a/base_tier_validation/views/assets_backend.xml
+++ b/base_tier_validation/views/assets_backend.xml
@@ -4,7 +4,7 @@
               inherit_id="web.assets_backend">
         <xpath expr="." position="inside">
             <script type="text/javascript" src="/base_tier_validation/static/src/js/systray.js"/>
-            <script type="text/javascript" src="/base_tier_validation/static/src/js/review_widget.js"/>
+            <script type="text/javascript" src="/base_tier_validation/static/src/js/tier_review_widget.js"/>
 
             <link rel="stylesheet" href="/base_tier_validation/static/src/less/systray.less" type="text/less"/>
             <link rel="stylesheet" href="/base_tier_validation/static/src/less/review.less" type="text/less"/>


### PR DESCRIPTION
This PR intends to make some improvements on base_tier_validation module:
* The review information is now available between the form and the chatter in a collapse object:
![image](https://user-images.githubusercontent.com/44768500/59422461-b885c800-8dd0-11e9-9e9c-2b39e994bf86.png)
![image](https://user-images.githubusercontent.com/44768500/59422469-bcb1e580-8dd0-11e9-8b76-ac5f65745d7f.png)

In order for the new widget to appear correctly some changes need to be done in the modules that inherit from this one. (This will be done in new PRs in the corresponding repositories)
Replace this:
```
<div name="button_box" position="inside">
    <field name="review_ids" widget="review_popup" attrs="{'invisible':[('review_ids', '=', [])]}"/>
</div>
```
With this:
```
<xpath expr="//form/div[hasclass('oe_chatter')]" position="before">
    <field name="review_ids" widget="tier_validation" attrs="{'invisible':[('review_ids', '=', [])]}"/>
</xpath>
```

cc ~ @Eficent @lreficent @etobella 