### PR TITLE
[12.0][IMP] base_tier_validation

### DIFF
--- a/base_tier_validation/README.rst
+++ b/base_tier_validation/README.rst
@@ -73,6 +73,7 @@ Contributors
 * Lois Rilo <lois.rilo@eficent.com>
 * Naglis Jonaitis <naglis@versada.eu>
 * Adrià Gil Sorribes <adria.gil@eficent.com>
+* Pimolnat Suntian <pimolnats@ecosoft.co.th>
 
 Maintainers
 ~~~~~~~~~~~

--- a/base_tier_validation/__manifest__.py
+++ b/base_tier_validation/__manifest__.py
@@ -21,6 +21,7 @@
         "views/tier_definition_view.xml",
         "views/tier_review_view.xml",
         "views/assets_backend.xml",
+        "wizard/comment_wizard_view.xml",
     ],
     'qweb': [
         'static/src/xml/systray.xml',

--- a/base_tier_validation/models/tier_definition.py
+++ b/base_tier_validation/models/tier_definition.py
@@ -63,6 +63,15 @@ class TierDefinition(models.Model):
         help="If set, all possible reviewers will be notified by email when "
              "this definition is triggered."
     )
+    has_comment = fields.Boolean(
+        string='Comment',
+        default=False,
+    )
+    approve_sequence = fields.Boolean(
+        string='Approve by sequence',
+        default=False,
+        help="Approval order by the specified sequence number",
+    )
 
     @api.onchange('model_id')
     def onchange_model_id(self):

--- a/base_tier_validation/models/tier_review.py
+++ b/base_tier_validation/models/tier_review.py
@@ -41,6 +41,17 @@ class TierReview(models.Model):
         comodel_name="res.users",
     )
     reviewed_date = fields.Datetime(string='Validation Date')
+    has_comment = fields.Boolean(
+        related='definition_id.has_comment',
+        readonly=True,
+    )
+    comment = fields.Char(
+        string='Comments',
+    )
+    approve_sequence = fields.Boolean(
+        related='definition_id.approve_sequence',
+        readonly=True,
+    )
 
     @api.model
     def _get_reviewer_fields(self):

--- a/base_tier_validation/models/tier_validation.py
+++ b/base_tier_validation/models/tier_validation.py
@@ -35,11 +35,43 @@ class TierValidation(models.AbstractModel):
         search="_search_reviewer_ids",
     )
     can_review = fields.Boolean(compute="_compute_can_review")
+    has_comment = fields.Boolean(
+        compute='_compute_has_comment',
+    )
+    approve_sequence = fields.Boolean(
+        compute='_compute_approve_sequence',
+    )
+
+    @api.multi
+    def _compute_approve_sequence(self):
+        for rec in self:
+            approve_sequence = rec.review_ids.filtered(
+                lambda r: r.status in ('pending', 'rejected') and
+                (self.env.user in r.reviewer_ids)).mapped('approve_sequence')
+            rec.approve_sequence = True in approve_sequence
+
+    @api.multi
+    def _compute_has_comment(self):
+        for rec in self:
+            has_comment = rec.review_ids.filtered(
+                lambda r: r.status in ('pending', 'rejected') and
+                (self.env.user in r.reviewer_ids)).mapped('has_comment')
+            rec.has_comment = True in has_comment
 
     @api.multi
     def _compute_can_review(self):
         for rec in self:
             rec.can_review = self.env.user in rec.reviewer_ids
+            if rec.can_review and rec.approve_sequence:
+                sequence = rec.review_ids.filtered(
+                    lambda r: r.status in ('pending', 'rejected') and
+                    (self.env.user in r.reviewer_ids)).mapped('sequence')
+                sequence.sort()
+                my_sequence = sequence[0]
+                tier_bf = rec.review_ids.filtered(
+                    lambda r: r.status != 'approved' and r.sequence < my_sequence)
+                if tier_bf:
+                    rec.can_review = False
 
     @api.multi
     @api.depends('review_ids')
@@ -166,25 +198,46 @@ class TierValidation(models.AbstractModel):
     def _notify_accepted_reviews_body(self):
         return _('A review was accepted')
 
+    def _add_comment(self, validate_reject):
+        wizard = self.env.ref(
+            'base_tier_validation.view_comment_wizard')
+        definition_ids = self.env['tier.definition'].search([
+            ('model', '=', self._name),
+            '|', ('reviewer_id', '=', self.env.user.id),
+                 ('reviewer_group_id', 'in',
+                  self.env.user.groups_id.ids)
+        ])
+        return {
+            'name': _('Comment'),
+            'type': 'ir.actions.act_window',
+            'view_type': 'form',
+            'view_mode': 'form',
+            'res_model': 'comment.wizard',
+            'views': [(wizard.id, 'form')],
+            'view_id': wizard.id,
+            'target': 'new',
+            'context': {
+                'default_res_id': self.id,
+                'default_res_model': self._name,
+                'default_definition_ids': definition_ids.ids,
+                'default_validate_reject': validate_reject
+            },
+        }
+
     @api.multi
     def validate_tier(self):
-        for rec in self:
-            rec._validate_tier()
+        self.ensure_one()
+        if self.has_comment:
+            return self._add_comment('validate')
+        self._validate_tier()
         self._update_counter()
 
     @api.multi
     def reject_tier(self):
-        for rec in self:
-            user_reviews = rec.review_ids.filtered(
-                lambda r: r.status in ('pending', 'approved') and
-                (r.reviewer_id == self.env.user or
-                 r.reviewer_group_id in self.env.user.groups_id))
-            user_reviews.write({
-                'status': 'rejected',
-                'done_by': self.env.user.id,
-                'reviewed_date': fields.Datetime.now(),
-            })
-            rec._notify_rejected_review()
+        self.ensure_one()
+        if self.has_comment:
+            return self._add_comment('reject')
+        self._rejected_tier()
         self._update_counter()
 
     def _notify_rejected_review_body(self):
@@ -197,6 +250,22 @@ class TierValidation(models.AbstractModel):
                 subtype='mt_comment',
                 body=self._notify_rejected_review_body()
             )
+
+    def _rejected_tier(self, tiers=False):
+        self.ensure_one()
+        tier_reviews = tiers or self.review_ids
+        user_reviews = tier_reviews.filtered(
+            lambda r: r.status in ('pending', 'approved') and
+            (r.reviewer_id == self.env.user or
+             r.reviewer_group_id in self.env.user.groups_id))
+        user_reviews.write({
+            'status': 'rejected',
+            'done_by': self.env.user.id,
+            'reviewed_date': fields.Datetime.now(),
+        })
+        for review in user_reviews:
+            rec = self.env[review.model].browse(review.res_id)
+            rec._notify_rejected_review()
 
     def _notify_requested_review_body(self):
         return _('A review has been requested by %s.') % (self.env.user.name)

--- a/base_tier_validation/readme/CONTRIBUTORS.rst
+++ b/base_tier_validation/readme/CONTRIBUTORS.rst
@@ -1,3 +1,4 @@
 * Lois Rilo <lois.rilo@eficent.com>
 * Naglis Jonaitis <naglis@versada.eu>
 * Adrià Gil Sorribes <adria.gil@eficent.com>
+* Pimolnat Suntian <pimolnats@ecosoft.co.th>

--- a/base_tier_validation/static/description/index.html
+++ b/base_tier_validation/static/description/index.html
@@ -418,6 +418,7 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 <li>Lois Rilo &lt;<a class="reference external" href="mailto:lois.rilo&#64;eficent.com">lois.rilo&#64;eficent.com</a>&gt;</li>
 <li>Naglis Jonaitis &lt;<a class="reference external" href="mailto:naglis&#64;versada.eu">naglis&#64;versada.eu</a>&gt;</li>
 <li>Adrià Gil Sorribes &lt;<a class="reference external" href="mailto:adria.gil&#64;eficent.com">adria.gil&#64;eficent.com</a>&gt;</li>
+<li>Pimolnat Suntian &lt;<a class="reference external" href="mailto:pimolnats&#64;ecosoft.co.th">pimolnats&#64;ecosoft.co.th</a>&gt;</li>
 </ul>
 </div>
 <div class="section" id="maintainers">

--- a/base_tier_validation/views/tier_definition_view.xml
+++ b/base_tier_validation/views/tier_definition_view.xml
@@ -56,6 +56,8 @@
                                    options="{'no_create': True}"/>
                             <field name="sequence"/>
                             <field name="notify_on_create"/>
+                            <field name="has_comment"/>
+                            <field name="approve_sequence"/>
                         </group>
                     </group>
                     <group name="bottom">

--- a/base_tier_validation/views/tier_review_view.xml
+++ b/base_tier_validation/views/tier_review_view.xml
@@ -17,6 +17,7 @@
                 <field name="status"/>
                 <field name="done_by"/>
                 <field name="reviewed_date"/>
+                <field name="comment"/>
             </tree>
         </field>
     </record>

--- a/base_tier_validation/wizard/__init__.py
+++ b/base_tier_validation/wizard/__init__.py
@@ -1,4 +1,3 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
-from . import models
-from . import wizard
+from . import comment_wizard

--- a/base_tier_validation/wizard/comment_wizard.py
+++ b/base_tier_validation/wizard/comment_wizard.py
@@ -1,0 +1,39 @@
+# Copyright 2019 Ecosoft Co., Ltd. (http://ecosoft.co.th)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import api, fields, models
+
+
+class CommentWizard(models.TransientModel):
+    _name = 'comment.wizard'
+    _description = 'Comment Wizard'
+
+    object = fields.Char()
+    validate_reject = fields.Char()
+    res_model = fields.Char()
+    res_id = fields.Integer()
+    definition_ids = fields.Many2many(
+        comodel_name='tier.definition',
+    )
+    comment = fields.Char(
+        required=True,
+    )
+
+    @api.multi
+    def add_comment(self):
+        self.ensure_one()
+        rec = self.env[self.res_model].browse(self.res_id)
+        user_reviews = self.env['tier.review'].search([
+            ('model', '=', self.res_model),
+            ('res_id', '=', self.res_id),
+            ('definition_id', 'in', self.definition_ids.ids)
+        ])
+        for user_review in user_reviews:
+            user_review.write({
+                'comment': self.comment,
+            })
+        if self.validate_reject == 'validate':
+            rec._validate_tier()
+        if self.validate_reject == 'reject':
+            rec._rejected_tier()
+        rec._update_counter()

--- a/base_tier_validation/wizard/comment_wizard_view.xml
+++ b/base_tier_validation/wizard/comment_wizard_view.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2019 Ecosoft Co., Ltd. (http://ecosoft.co.th)
+     License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl). -->
+<odoo>
+
+    <record id="view_comment_wizard" model="ir.ui.view">
+        <field name="name">Comment Wizard</field>
+        <field name="model">comment.wizard</field>
+        <field name="type">form</field>
+        <field name="arch" type="xml">
+             <form string="Comment">
+                 <group>
+                     <field name="comment" nolabel="1"/>
+                 </group>
+                 <footer>
+                     <button name="add_comment"
+                             string="Comment" type="object"
+                             class="oe_highlight"/>
+                     <button special="cancel" string="Cancel" class="oe_link"/>
+                 </footer>
+            </form>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
- Add comment on validation
- Add approve by sequence

![Selection_106](https://user-images.githubusercontent.com/51266019/68282714-bc322800-00ac-11ea-8949-e2b86f121a5f.png)

1. If you check **Comment**, you can add comment on reviews table by wizard comment after 'validate' or 'reject'.
![Selection_097](https://user-images.githubusercontent.com/51266019/67063898-9a6f1080-f192-11e9-9234-0ba1482a4798.png)
![Selection_098](https://user-images.githubusercontent.com/51266019/67063901-9e029780-f192-11e9-93fc-70cbb7fb646f.png)

2. If you check **Approve by sequence**, approval will order by sequence.