### PR TITLE
[11.0][FIX] document_quick_access: do not propagate click event

### DIFF
--- a/document_quick_access/__manifest__.py
+++ b/document_quick_access/__manifest__.py
@@ -9,6 +9,8 @@
     'license': 'AGPL-3',
     'author': 'Creu Blanca,Odoo Community Association (OCA)',
     'website': 'https://github.com/OCA/server-ux',
+    'development_status': 'Beta',
+    'maintainers': ['etobella'],
     'depends': [
         'web',
         'barcode_action',

--- a/document_quick_access/static/src/js/document_quick_access_launcher.js
+++ b/document_quick_access/static/src/js/document_quick_access_launcher.js
@@ -9,7 +9,9 @@ odoo.define('document_quick_access.document_quick_access_launcher', function (re
             "click": "on_click_find_document",
         },
 
-        on_click_find_document: function () {
+        on_click_find_document: function (event) {
+            event.preventDefault();
+            event.stopPropagation();
             var context = {};
             context.default_model = 'document.quick.access.rule';
             context.default_method ='read_code_action';


### PR DESCRIPTION
in Odoo EE this was opening and focusing the home menu, as a consequence the scan read was being "typed" in the menu search of the home page.

cc @etobella @jarroyomorales 

@Eficent