### PR TITLE
[12.0][IMP]base_tchnical_features. Assign automatically to admin not to root

### DIFF
--- a/base_technical_features/data/res_users.xml
+++ b/base_technical_features/data/res_users.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <odoo noupdate="1">
-    <record model="res.users" id="base.user_root">
-        <field name="technical_features" eval="True" />
+    <record model="res.users" id="base.user_admin">
+        <field name="technical_features" eval="True"/>
     </record>
 </odoo>


### PR DESCRIPTION
There is no sense of root to be assigned to this group. 