### PR TITLE
[13.0][FIX] Tier validation - note subtype for accept and reject

### DIFF
--- a/base_tier_validation/models/tier_validation.py
+++ b/base_tier_validation/models/tier_validation.py
@@ -206,7 +206,7 @@ class TierValidation(models.AbstractModel):
         if hasattr(self, post):
             # Notify state change
             getattr(self, post)(
-                subtype="mt_comment", body=self._notify_accepted_reviews_body()
+                subtype="mt_note", body=self._notify_accepted_reviews_body()
             )
 
     def _notify_accepted_reviews_body(self):
@@ -274,7 +274,7 @@ class TierValidation(models.AbstractModel):
         if hasattr(self, post):
             # Notify state change
             getattr(self, post)(
-                subtype="mt_comment", body=self._notify_rejected_review_body()
+                subtype="mt_note", body=self._notify_rejected_review_body()
             )
 
     def _rejected_tier(self, tiers=False):


### PR DESCRIPTION
[FIX] When accepting or rejecting a review followers should not be notified. A customer or supplier can be a follower of the object and should not receive internal messages about the tier validation. 

Fixes #125

@LoisRForgeFlow 