### PR TITLE
[11.0][FIX] base_tier_validation: When accepting or rejecting a review followers should not be no…

### DIFF
--- a/base_tier_validation/models/tier_validation.py
+++ b/base_tier_validation/models/tier_validation.py
@@ -162,7 +162,7 @@ class TierValidation(models.AbstractModel):
         if hasattr(self, 'message_post'):
             # Notify state change
             getattr(self, 'message_post')(
-                subtype='mt_comment',
+                subtype='mt_note',
                 body=self._notify_accepted_reviews_body()
             )
 
@@ -197,7 +197,7 @@ class TierValidation(models.AbstractModel):
         if hasattr(self, 'message_post'):
             # Notify state change
             getattr(self, 'message_post')(
-                subtype='mt_comment',
+                subtype='mt_note',
                 body=self._notify_rejected_review_body()
             )
 


### PR DESCRIPTION
…tified. A customer or supplier can be a follower of the object and should not receive internal messages about the tier validation.

Backport of #126.

Fixes #125.

cc @CasVissers @HviorForgeFlow