### PR TITLE
[13.0][FIX] mass_editing: allow change readonly fields.

### DIFF
--- a/mass_editing/models/mass_editing_line.py
+++ b/mass_editing/models/mass_editing_line.py
@@ -23,7 +23,6 @@ class MassEditingLine(models.Model):
         string="Field",
         domain="["
         "('name', '!=', '__last_update'),"
-        "('readonly', '=', False),"
         "('ttype', 'not in', ['reference', 'function']),"
         "('model_id', '=', model_id)"
         "]",


### PR DESCRIPTION
With this solution it is possible to select read-only fields again.
Fixes https://github.com/OCA/server-ux/issues/142