### PR TITLE
[12.0][FIX] base_tier_validation : convert datetime timezone

### DIFF
--- a/base_tier_validation/models/res_users.py
+++ b/base_tier_validation/models/res_users.py
@@ -50,4 +50,8 @@ class Users(models.Model):
             r['display_status'] = dict(
                 review_obj.fields_get('status')['status']['selection']
             ).get(r.get('status'))
+            # Convert to datetime timezone
+            if r['reviewed_date']:
+                r['reviewed_date'] = \
+                    fields.Datetime.context_timestamp(self, r['reviewed_date'])
         return res

--- a/base_tier_validation/readme/CONTRIBUTORS.rst
+++ b/base_tier_validation/readme/CONTRIBUTORS.rst
@@ -2,3 +2,4 @@
 * Naglis Jonaitis <naglis@versada.eu>
 * Adrià Gil Sorribes <adria.gil@eficent.com>
 * Pimolnat Suntian <pimolnats@ecosoft.co.th>
+* Saran Lim. <saranl@ecosoft.co.th>


### PR DESCRIPTION
FIX bug from issue https://github.com/OCA/server-ux/issues/130

- Convert datetime field Validation Date to timezone.