### PR TITLE
[12.0][FIX] tier validation

### DIFF
--- a/base_tier_validation/models/res_users.py
+++ b/base_tier_validation/models/res_users.py
@@ -17,22 +17,27 @@ class Users(models.Model):
         to_review_docs = {}
         for review in self.env.user.review_ids.filtered(
                 lambda r: r.status == 'pending'):
-            record = review.env[review.model].browse(review.res_id)
-            can_review = record.sudo(self.env.user).can_review
-            if can_review:
-                if not user_reviews.get(review['model']):
-                    user_reviews[review.model] = {
-                        'name': record._description,
-                        'model': review.model,
-                        'icon': modules.module.get_module_icon(
-                            self.env[review.model]._original_module),
-                        'pending_count': 0
-                    }
-                docs = to_review_docs.get(review.model)
-                if (docs and record not in docs) or not docs:
-                    user_reviews[review.model]['pending_count'] += 1
-                review.can_review = True
-                to_review_docs.setdefault(review.model, []).append(record)
+            record = review.env[review.model].sudo(
+                self.env.user
+            ).search([('id', '=', review.res_id)])
+            if not record:
+                # Checking that the review is accessible with the permissions
+                continue
+            can_review = record.can_review
+            if not can_review:
+                continue
+            if not user_reviews.get(review['model']):
+                user_reviews[review.model] = {
+                    'name': record._description,
+                    'model': review.model,
+                    'icon': modules.module.get_module_icon(
+                        self.env[review.model]._original_module),
+                    'pending_count': 0
+                }
+            docs = to_review_docs.get(review.model)
+            if (docs and record not in docs) or not docs:
+                user_reviews[review.model]['pending_count'] += 1
+            to_review_docs.setdefault(review.model, []).append(record)
         return list(user_reviews.values())
 
     @api.model

--- a/base_tier_validation/models/tier_review.py
+++ b/base_tier_validation/models/tier_review.py
@@ -41,7 +41,12 @@ class TierReview(models.Model):
         comodel_name="res.users",
     )
     reviewed_date = fields.Datetime(string='Validation Date')
-    can_review = fields.Boolean()
+    can_review = fields.Boolean(
+        compute='_compute_can_review',
+        store=True,
+        help="""Can review will be marked if the review is pending and the 
+        approve sequence has been achieved""",
+    )
     has_comment = fields.Boolean(
         related='definition_id.has_comment',
         readonly=True,
@@ -53,6 +58,26 @@ class TierReview(models.Model):
         related='definition_id.approve_sequence',
         readonly=True,
     )
+
+    @api.depends('definition_id.approve_sequence')
+    def _compute_can_review(self):
+        for record in self:
+            record.can_review = record._can_review_value()
+
+    def _can_review_value(self):
+        if self.status != 'pending':
+            return False
+        if not self.approve_sequence:
+            return True
+        resource = self.env[self.model].browse(self.res_id)
+        reviews = resource.review_ids.filtered(
+            lambda r: r.status in ('pending', 'rejected'))
+        if not reviews:
+            return True
+        sequence = reviews.mapped('sequence')
+        sequence.sort()
+        current_sequence = sequence[0]
+        return self.sequence == current_sequence
 
     @api.model
     def _get_reviewer_fields(self):

--- a/base_tier_validation/models/tier_review.py
+++ b/base_tier_validation/models/tier_review.py
@@ -44,7 +44,7 @@ class TierReview(models.Model):
     can_review = fields.Boolean(
         compute='_compute_can_review',
         store=True,
-        help="""Can review will be marked if the review is pending and the 
+        help="""Can review will be marked if the review is pending and the
         approve sequence has been achieved""",
     )
     has_comment = fields.Boolean(


### PR DESCRIPTION
Fixing permissions on viewing. It could affect multicompany environments
Fixing the usage of can_review from tier.review. It was being rewritten every time. Now it is True if it can be reviewed by someone (checks the sequence if necessary)

@ps-tubtim @LoisRForgeFlow 