### PR TITLE
[FIX] base_import_security_group browser test

### DIFF
--- a/base_import_security_group/tests/test_base_import_security_group.py
+++ b/base_import_security_group/tests/test_base_import_security_group.py
@@ -28,8 +28,8 @@ class TestImportSecurityGroup(common.HttpCase):
         """ % ('!' if falsify else '')
         action = self.env.ref('base.action_partner_category_form').id
         link = '/web#action=%s' % action
-        self.phantom_js(
-            link, code, "",
+        self.browser_js(
+            link, code, 'Boolean($(".o_list_button_add"))',
             login=user.login)
 
     def test_01_load(self):


### PR DESCRIPTION
The browser wait code was removed in the migration to 12.0: https://github.com/OCA/server-ux/pull/152/commits/55af0ca4d4544c352e947b27dccaae6d7a75d57d#diff-42657ea13cced82fd0efda56ecf8fef0R32
Indeed tests did not run with that line because the modified API of the browser tests now requires the waiting code to return a boolean True instead of just a truthy value. Fact that the tests succeeded at the time of merging could be a timing issue but as of late the tests seem to fail consistently.