### PR TITLE
[13.0][FIX] base_tier_validation: All models are visible when create a new definition

### DIFF
--- a/base_tier_validation/models/tier_definition.py
+++ b/base_tier_validation/models/tier_definition.py
@@ -23,7 +23,11 @@ class TierDefinition(models.Model):
         default=lambda self: self._get_default_name(),
         translate=True,
     )
-    model_id = fields.Many2one(comodel_name="ir.model", string="Referenced Model")
+    model_id = fields.Many2one(
+        comodel_name="ir.model",
+        string="Referenced Model",
+        domain=lambda self: [("model", "in", self._get_tier_validation_model_names())],
+    )
     model = fields.Char(related="model_id.model", index=True, store=True)
     review_type = fields.Selection(
         string="Validated by",
@@ -59,14 +63,6 @@ class TierDefinition(models.Model):
         default=False,
         help="Approval order by the specified sequence number",
     )
-
-    @api.onchange("model_id")
-    def onchange_model_id(self):
-        return {
-            "domain": {
-                "model_id": [("model", "in", self._get_tier_validation_model_names())]
-            }
-        }
 
     @api.onchange("review_type")
     def onchange_review_type(self):

--- a/base_tier_validation/tests/test_tier_validation.py
+++ b/base_tier_validation/tests/test_tier_validation.py
@@ -156,8 +156,6 @@ class TierTierValidation(common.SavepointCase):
         """Test tier.definition methods."""
         res = self.tier_def_obj._get_tier_validation_model_names()
         self.assertEqual(res, [])
-        res = self.tier_def_obj.onchange_model_id()
-        self.assertTrue(res)
 
     def test_10_systray_counter(self):
         # Create new test record


### PR DESCRIPTION
cc @Tecnativa TT23936
This fix https://github.com/OCA/sale-workflow/pull/1152#issuecomment-633880654

@HaraldPanten Can you reviw??