### PR TITLE
[12.0] Reject Tier Validation

### DIFF
--- a/base_tier_validation/models/tier_validation.py
+++ b/base_tier_validation/models/tier_validation.py
@@ -267,8 +267,7 @@ class TierValidation(models.AbstractModel):
         tier_reviews = tiers or self.review_ids
         user_reviews = tier_reviews.filtered(
             lambda r: r.status in ('pending', 'approved') and
-            (r.reviewer_id == self.env.user or
-             r.reviewer_group_id in self.env.user.groups_id))
+            (self.env.user in r.reviewer_ids))
         user_reviews.write({
             'status': 'rejected',
             'done_by': self.env.user.id,

--- a/base_tier_validation_formula/tests/test_tier_validation.py
+++ b/base_tier_validation_formula/tests/test_tier_validation.py
@@ -171,7 +171,7 @@ class TierTierValidation(common.SavepointCase):
             'rec.env["res.users"].browse([{user_id}])'
         ).format(user_id=user_id)
 
-        definition = self.tier_def_obj.create({
+        self.tier_def_obj.create({
             'name': 'Over 10',
             'model_id': self.tester_model.id,
             'review_type': 'expression',


### PR DESCRIPTION
- Fix a bug when a definition's review_type is set to expression, the
user(s) are unable to reject the record.

When rejecting a record, the reviews are filtered using the records
reviewer_id and reviewer_group_id which are only set when the review
type is set to individual or group. To support other review types,
the filter is being changed to check the current user against the
review_ids field instead.

Fixes #168 

I wasn't able to find a way to create a test for this inside of the `base_tier_validation` module but I was able to write a test for it in the `base_tier_validation_formula` modules. If there is a way to test this please let me know and I'll update this PR.