### PR TITLE
[IMP] base_tier_validation: notification hook

### DIFF
--- a/base_tier_validation/__manifest__.py
+++ b/base_tier_validation/__manifest__.py
@@ -13,10 +13,10 @@
     "application": False,
     "installable": True,
     "depends": [
-        "web",
-        "bus",
+        "mail"
     ],
     "data": [
+        "data/mail_data.xml",
         "security/ir.model.access.csv",
         "views/tier_definition_view.xml",
         "views/tier_review_view.xml",

--- a/base_tier_validation/data/mail_data.xml
+++ b/base_tier_validation/data/mail_data.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo noupdate="1">
+    <record id="mt_tier_validation_accepted" model="mail.message.subtype" forcecreate="1">
+        <field name="name">Tier Validation Accepted Notification</field>
+        <field name="default" eval="True"/>
+        <field name="internal" eval="True"/>
+        <field name="hidden" eval="True"/>
+    </record>
+
+    <record id="mt_tier_validation_rejected" model="mail.message.subtype" forcecreate="1">
+        <field name="name">Tier Validation Rejected Notification</field>
+        <field name="default" eval="True"/>
+        <field name="internal" eval="True"/>
+        <field name="hidden" eval="True"/>
+    </record>
+</odoo>

--- a/base_tier_validation/models/tier_validation.py
+++ b/base_tier_validation/models/tier_validation.py
@@ -187,11 +187,17 @@ class TierValidation(models.AbstractModel):
             rec = self.env[review.model].browse(review.res_id)
             rec._notify_accepted_reviews()
 
+    def _get_accepted_notification_subtype(self):
+        return 'base_tier_validation.mt_tier_validation_accepted'
+
+    def _get_rejected_notification_subtype(self):
+        return 'base_tier_validation.mt_tier_validation_rejected'
+
     def _notify_accepted_reviews(self):
         if hasattr(self, 'message_post'):
             # Notify state change
             getattr(self, 'message_post')(
-                subtype='mt_note',
+                subtype=self._get_accepted_notification_subtype(),
                 body=self._notify_accepted_reviews_body()
             )
 
@@ -258,7 +264,7 @@ class TierValidation(models.AbstractModel):
         if hasattr(self, 'message_post'):
             # Notify state change
             getattr(self, 'message_post')(
-                subtype='mt_note',
+                subtype=self._get_rejected_notification_subtype(),
                 body=self._notify_rejected_review_body()
             )
 


### PR DESCRIPTION
This PR adds a hook so everyone can customize the notification subtype they prefer. While I understand this commit https://github.com/OCA/server-ux/commit/b9dc12fc8496f53f58ae9c663d6210a55430af24 , we were used to the notifications and now we have lost this funtionality.

@LoisRForgeFlow @CasVissers @etobella 