### PR TITLE
Adding the main attachment to the exceptions

### DIFF
--- a/base_tier_validation/models/tier_validation.py
+++ b/base_tier_validation/models/tier_validation.py
@@ -134,7 +134,7 @@ class TierValidation(models.AbstractModel):
     @api.model
     def _get_under_validation_exceptions(self):
         """Extend for more field exceptions."""
-        return ['message_follower_ids']
+        return ['message_follower_ids', 'message_main_attachment_id']
 
     @api.multi
     def _check_allow_write_under_validation(self, vals):


### PR DESCRIPTION
Without the added exception, it wouldn't be possible to add messages/notes with attachments, since it would raise a validation exception informing that the operation is under validation.