### PR TITLE
[IMP] base_tier_validation: Make test more resilient with sales and purchase modules installed

### DIFF
--- a/base_tier_validation/tests/test_tier_validation.py
+++ b/base_tier_validation/tests/test_tier_validation.py
@@ -155,7 +155,14 @@ class TierTierValidation(common.SavepointCase):
     def test_09_dummy_tier_definition(self):
         """Test tier.definition methods."""
         res = self.tier_def_obj._get_tier_validation_model_names()
-        self.assertEqual(res, [])
+        expected_tier_validation_model_name = []
+        module_id = self.env.ref("base.module_sale_tier_validation")
+        if module_id.state == "installed":
+            expected_tier_validation_model_name.append("sale.order")
+        module_id = self.env.ref("base.module_purchase_tier_validation")
+        if module_id.state == "installed":
+            expected_tier_validation_model_name.append("purchase.order")
+        self.assertSetEqual(set(res), set(expected_tier_validation_model_name))
 
     def test_10_systray_counter(self):
         # Create new test record

--- a/base_tier_validation/tests/test_tier_validation.py
+++ b/base_tier_validation/tests/test_tier_validation.py
@@ -152,22 +152,6 @@ class TierTierValidation(common.SavepointCase):
         )
         self.assertTrue(res)
 
-    def test_09_dummy_tier_definition(self):
-        """Test tier.definition methods."""
-        res = self.tier_def_obj._get_tier_validation_model_names()
-        expected_tier_validation_model_name = []
-        module = self.env.ref(
-            "base.module_sale_tier_validation", raise_if_not_found=False
-        )
-        if module and module.state == "installed":
-            expected_tier_validation_model_name.append("sale.order")
-        module = self.env.ref(
-            "base.module_purchase_tier_validation", raise_if_not_found=False
-        )
-        if module and module.state == "installed":
-            expected_tier_validation_model_name.append("purchase.order")
-        self.assertSetEqual(set(res), set(expected_tier_validation_model_name))
-
     def test_10_systray_counter(self):
         # Create new test record
         test_record = self.test_model.create({"test_field": 2.5})

--- a/base_tier_validation/tests/test_tier_validation.py
+++ b/base_tier_validation/tests/test_tier_validation.py
@@ -156,11 +156,15 @@ class TierTierValidation(common.SavepointCase):
         """Test tier.definition methods."""
         res = self.tier_def_obj._get_tier_validation_model_names()
         expected_tier_validation_model_name = []
-        module_id = self.env.ref("base.module_sale_tier_validation")
-        if module_id.state == "installed":
+        module = self.env.ref(
+            "base.module_sale_tier_validation", raise_if_not_found=False
+        )
+        if module and module.state == "installed":
             expected_tier_validation_model_name.append("sale.order")
-        module_id = self.env.ref("base.module_purchase_tier_validation")
-        if module_id.state == "installed":
+        module = self.env.ref(
+            "base.module_purchase_tier_validation", raise_if_not_found=False
+        )
+        if module and module.state == "installed":
             expected_tier_validation_model_name.append("purchase.order")
         self.assertSetEqual(set(res), set(expected_tier_validation_model_name))
 


### PR DESCRIPTION
When run test with sales and purchases tier validation modules installed the base_tier_Validation test fail because the other modules add elements to validation model names list.

cc @Tecnativa

ping @carlosdauden ping @HviorForgeFlow 