### PR TITLE
[13.0][FIX] base_tier_validation, fix approve by sequence problem

### DIFF
--- a/base_tier_validation/models/res_users.py
+++ b/base_tier_validation/models/res_users.py
@@ -13,19 +13,22 @@ class Users(models.Model):
     def review_user_count(self):
         user_reviews = {}
         to_review_docs = {}
-        for review in self.env.user.review_ids.filtered(
-            lambda r: r.status == "pending"
-        ):
+        reviews = self.env["tier.review"].search(
+            [
+                ("status", "=", "pending"),
+                ("can_review", "=", True),
+                ("id", "in", self.env.user.review_ids.ids),
+            ]
+        )
+        for review in reviews:
             record = (
                 review.env[review.model]
                 .with_user(self.env.user)
                 .search([("id", "=", review.res_id)])
             )
-            if not record:
+            if not record or record.rejected or not record.can_review:
                 # Checking that the review is accessible with the permissions
-                continue
-            can_review = record.can_review
-            if not can_review:
+                # and to review condition is valid
                 continue
             if not user_reviews.get(review["model"]):
                 user_reviews[review.model] = {

--- a/base_tier_validation/models/tier_review.py
+++ b/base_tier_validation/models/tier_review.py
@@ -58,15 +58,11 @@ class TierReview(models.Model):
         if not self.approve_sequence:
             return True
         resource = self.env[self.model].browse(self.res_id)
-        reviews = resource.review_ids.filtered(
-            lambda r: r.status in ("pending", "rejected")
-        )
+        reviews = resource.review_ids.filtered(lambda r: r.status == "pending")
         if not reviews:
             return True
-        sequence = reviews.mapped("sequence")
-        sequence.sort()
-        current_sequence = sequence[0]
-        return self.sequence == current_sequence
+        sequence = min(reviews.mapped("sequence"))
+        return self.sequence == sequence
 
     @api.model
     def _get_reviewer_fields(self):

--- a/base_tier_validation/readme/CONTRIBUTORS.rst
+++ b/base_tier_validation/readme/CONTRIBUTORS.rst
@@ -3,3 +3,4 @@
 * Adrià Gil Sorribes <adria.gil@forgeflow.com>
 * Pimolnat Suntian <pimolnats@ecosoft.co.th>
 * Pedro Gonzalez <pedro.gonzalez@pesol.es>
+* Kitti U. <kittiu@ecosoft.co.th>

--- a/base_tier_validation/readme/HISTORY.rst
+++ b/base_tier_validation/readme/HISTORY.rst
@@ -1,3 +1,11 @@
+13.0.1.2.2 (2020-08-30)
+~~~~~~~~~~~~~~~~~~~~~~~
+
+Fixes:
+
+- When using approve_sequence option in any tier.definition there can be inconsistencies in the systray notifications
+- When using approve_sequence, still not approve only the needed sequence, but also other sequence for the same approver
+
 12.0.3.3.1 (2019-12-02)
 ~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/base_tier_validation/static/src/js/systray.js
+++ b/base_tier_validation/static/src/js/systray.js
@@ -148,6 +148,7 @@ odoo.define("tier_validation.systray", function(require) {
                     ["review_ids.reviewer_ids", "=", session.uid],
                     ["review_ids.status", "=", "pending"],
                     ["review_ids.can_review", "=", true],
+                    ["rejected", "=", false],
                 ],
                 context: context,
             });

--- a/base_tier_validation/wizard/comment_wizard.py
+++ b/base_tier_validation/wizard/comment_wizard.py
@@ -8,27 +8,18 @@ class CommentWizard(models.TransientModel):
     _name = "comment.wizard"
     _description = "Comment Wizard"
 
-    object = fields.Char()
     validate_reject = fields.Char()
     res_model = fields.Char()
     res_id = fields.Integer()
-    definition_ids = fields.Many2many(comodel_name="tier.definition")
+    review_ids = fields.Many2many(comodel_name="tier.review")
     comment = fields.Char(required=True)
 
     def add_comment(self):
         self.ensure_one()
         rec = self.env[self.res_model].browse(self.res_id)
-        user_reviews = self.env["tier.review"].search(
-            [
-                ("model", "=", self.res_model),
-                ("res_id", "=", self.res_id),
-                ("definition_id", "in", self.definition_ids.ids),
-            ]
-        )
-        for user_review in user_reviews:
-            user_review.write({"comment": self.comment})
+        self.review_ids.write({"comment": self.comment})
         if self.validate_reject == "validate":
-            rec._validate_tier()
+            rec._validate_tier(self.review_ids)
         if self.validate_reject == "reject":
-            rec._rejected_tier()
+            rec._rejected_tier(self.review_ids)
         rec._update_counter()


### PR DESCRIPTION
- When use approve by sequence, still approve tier of the same reviewer https://github.com/OCA/server-ux/issues/195
- When using approve_sequence option in any tier.definition there can be inconsistencies in the systray notifications