### PR TITLE
[FIX] mass_editing: Reference to unexisting view type

### DIFF
--- a/mass_editing/models/mass_object.py
+++ b/mass_editing/models/mass_object.py
@@ -58,7 +58,7 @@ class MassObject(models.Model):
             'src_model': src_obj,
             'view_type': 'form',
             'context': "{'mass_editing_object' : %d}" % (self.id),
-            'view_mode': 'form, tree',
+            'view_mode': 'form',
             'target': 'new',
             'binding_model_id': self.model_id.id,
             'binding_type': 'action',


### PR DESCRIPTION
The model `mass.editing.wizard` doesn't have a tree view, which causes a
JS error.