### PR TITLE
[13.0][IMP] base_tier_validation, auto validate & action

### DIFF
--- a/base_tier_validation/__manifest__.py
+++ b/base_tier_validation/__manifest__.py
@@ -15,6 +15,7 @@
     "depends": ["mail"],
     "data": [
         "data/mail_data.xml",
+        "data/cron_data.xml",
         "security/ir.model.access.csv",
         "views/tier_definition_view.xml",
         "views/tier_review_view.xml",

--- a/base_tier_validation/data/cron_data.xml
+++ b/base_tier_validation/data/cron_data.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo noupdate="1">
+    <record id="ir_cron_auto_tier_validation" model="ir.cron">
+        <field name="name">Automatic Tier Validation</field>
+        <field name="interval_number">1</field>
+        <field name="interval_type">hours</field>
+        <field name="numbercall">-1</field>
+        <field
+            name="nextcall"
+            eval="(datetime.now() + timedelta(minutes=5)).strftime('%Y-%m-%d %H:%M:%S')"
+        />
+        <field name="doall" eval="False" />
+        <field name="model_id" ref="model_tier_definition" />
+        <field name="code">model._cron_auto_tier_validation()</field>
+        <field name="state">code</field>
+    </record>
+</odoo>

--- a/base_tier_validation/models/tier_definition.py
+++ b/base_tier_validation/models/tier_definition.py
@@ -1,7 +1,11 @@
 # Copyright 2017 ForgeFlow S.L. (https://www.forgeflow.com)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+import logging
+from ast import literal_eval
 
 from odoo import _, api, fields, models
+
+_logger = logging.getLogger(__name__)
 
 
 class TierDefinition(models.Model):
@@ -63,8 +67,56 @@ class TierDefinition(models.Model):
         default=False,
         help="Approval order by the specified sequence number",
     )
+    server_action_id = fields.Many2one(
+        comodel_name="ir.actions.server",
+        string="Post Review Action",
+        domain=[("usage", "=", "ir_actions_server")],
+        help="Server action triggered as soon as this step is approved",
+    )
+    auto_validate = fields.Boolean(
+        string="Auto Validate",
+        help="Use schedule job to auto validate if condition is met.\n"
+        "- If no user specified, use job's system user to validate\n"
+        "- If 1 user matched as reviewer, use the user to validate\n"
+        "- If > 1 user matched as reviewer, do not auto validate",
+    )
+    auto_validate_domain = fields.Char()
 
     @api.onchange("review_type")
     def onchange_review_type(self):
         self.reviewer_id = None
         self.reviewer_group_id = None
+
+    def _evaluate_review(self, review):
+        domain = [("id", "=", review.res_id)]
+        auto_domain = review.definition_id.auto_validate_domain
+        if auto_domain:
+            domain += literal_eval(auto_domain)
+        return self.env[review.model].search(domain)
+
+    @api.model
+    def _cron_auto_tier_validation(self):
+        reviews = self.env["tier.review"].search(
+            [("status", "=", "pending"), ("definition_id.auto_validate", "=", True)]
+        )
+        for review in reviews:
+            doc = self._evaluate_review(review)
+            if not doc:
+                continue
+            try:
+                reviewer = review.reviewer_ids or self.env.user
+                if len(reviewer) > 1:
+                    _logger.warn(
+                        "Cannot auto tier validate {}: "
+                        "too many reviewers".format(doc)
+                    )
+                    continue
+                review_doc = doc.with_user(reviewer)
+                if review_doc.can_review:
+                    sequences = review_doc._get_sequences_to_approve(reviewer)
+                    if review.sequence in sequences:
+                        review_doc._validate_tier(review)
+                        review_doc._update_counter()
+                        _logger.info("Auto tier validate on %s" % review_doc)
+            except Exception as e:
+                _logger.error("Cannot auto tier validate {}: {}".format(doc, e))

--- a/base_tier_validation/models/tier_review.py
+++ b/base_tier_validation/models/tier_review.py
@@ -75,3 +75,11 @@ class TierReview(models.Model):
 
     def _get_reviewers(self):
         return self.reviewer_id + self.reviewer_group_id.users
+
+    @api.constrains("status")
+    def _trigger_server_action(self):
+        for rec in self.filtered(lambda l: l.status == "approved"):
+            if not rec.definition_id.server_action_id:
+                continue
+            ctx = {"active_model": rec.model, "active_id": rec.res_id}
+            rec.definition_id.server_action_id.with_context(ctx).run()

--- a/base_tier_validation/readme/HISTORY.rst
+++ b/base_tier_validation/readme/HISTORY.rst
@@ -1,3 +1,12 @@
+
+13.0.1.3.0 (2020-09-17)
+~~~~~~~~~~~~~~~~~~~~~~~
+
+New features:
+
+- Tier Definition option to auto validation by cron job
+- Tier Definition option to trigger server action on approved
+
 13.0.1.2.2 (2020-08-30)
 ~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/base_tier_validation/tests/test_tier_validation.py
+++ b/base_tier_validation/tests/test_tier_validation.py
@@ -51,12 +51,16 @@ class TierTierValidation(common.SavepointCase):
         )
 
         # Create users:
-        group_ids = cls.env.ref("base.group_system").ids
+        cls.group_system = cls.env.ref("base.group_system")
+        group_ids = cls.group_system.ids
         cls.test_user_1 = cls.env["res.users"].create(
             {"name": "John", "login": "test1", "groups_id": [(6, 0, group_ids)]}
         )
         cls.test_user_2 = cls.env["res.users"].create(
             {"name": "Mike", "login": "test2"}
+        )
+        cls.test_user_3 = cls.env["res.users"].create(
+            {"name": "John Wick", "login": "test3", "groups_id": [(6, 0, group_ids)]}
         )
 
         # Create tier definitions:
@@ -466,3 +470,115 @@ class TierTierValidation(common.SavepointCase):
         self.assertFalse(
             self.test_user_2.with_user(self.test_user_2).review_user_count()
         )
+
+    def test_17_auto_validation(self):
+        # Create new test record
+        test_record = self.test_model.create({"test_field": 2.5})
+        # Create tier definitions
+        self.tier_def_obj.create(
+            {
+                "model_id": self.tester_model.id,
+                "review_type": "individual",
+                "reviewer_id": self.test_user_1.id,
+                "sequence": 20,
+                "approve_sequence": True,
+                "auto_validate": True,
+            }
+        )
+        self.tier_def_obj.create(
+            {
+                "model_id": self.tester_model.id,
+                "review_type": "individual",
+                "reviewer_id": self.test_user_1.id,
+                "sequence": 10,
+                "approve_sequence": True,
+                "auto_validate": True,
+                "auto_validate_domain": "[('test_field', '>', 3)]",
+            }
+        )
+        # Request validation
+        test_record.with_user(self.test_user_2).request_validation()
+        record = test_record.with_user(self.test_user_1)
+        record.invalidate_cache()
+        # Auto validate, 1st tier, not auto validated
+        self.tier_def_obj._cron_auto_tier_validation()
+        self.assertEqual(
+            record.review_ids.mapped("status"), ["pending", "pending", "pending"]
+        )
+        # Manual validate 2nd tier -> OK
+        record.validate_tier()
+        self.assertEqual(
+            record.review_ids.mapped("status"), ["approved", "pending", "pending"]
+        )
+        # Auto validate, 2nd tier -> OK
+        self.tier_def_obj._cron_auto_tier_validation()
+        self.assertEqual(
+            record.review_ids.mapped("status"), ["approved", "approved", "pending"]
+        )
+        # Auto validate, 3rd tier -> Not pass validate domain
+        self.tier_def_obj._cron_auto_tier_validation()
+        self.assertEqual(
+            record.review_ids.mapped("status"), ["approved", "approved", "pending"]
+        )
+        # Manual validate 3rd tier -> OK
+        record.validate_tier()
+        self.assertEqual(
+            record.review_ids.mapped("status"), ["approved", "approved", "approved"]
+        )
+
+    def test_18_auto_validation_exception(self):
+        # Create new test record
+        test_record = self.test_model.create({"test_field": 2.5})
+        # Create tier definitions
+        self.tier_def_obj.create(
+            {
+                "model_id": self.tester_model.id,
+                "review_type": "individual",
+                "reviewer_group_id": self.group_system.id,
+                "sequence": 20,
+                "approve_sequence": True,
+                "auto_validate": True,
+            }
+        )
+        # Request validation
+        test_record.with_user(self.test_user_2).request_validation()
+        record = test_record.with_user(self.test_user_1)
+        record.invalidate_cache()
+        # Auto validate, 1st tier, not auto validated
+        self.tier_def_obj._cron_auto_tier_validation()
+        self.assertEqual(record.review_ids.mapped("status"), ["pending", "pending"])
+        # Manual validate 2nd tier -> OK
+        record.validate_tier()
+        self.assertEqual(record.review_ids.mapped("status"), ["approved", "pending"])
+        # Auto validate, 2nd tier -> Not OK, before len(reviewers) > 1
+        self.tier_def_obj._cron_auto_tier_validation()
+        self.assertEqual(record.review_ids.mapped("status"), ["approved", "pending"])
+
+    def test_19_trigger_server_action(self):
+        # Create new test record
+        test_record = self.test_model.create({"test_field": 2.5})
+        # Create server action
+        server_action = self.env["ir.actions.server"].create(
+            {
+                "name": "Set test_bool = True",
+                "model_id": self.tester_model.id,
+                "state": "code",
+                "code": "record.write({'test_bool': True})",
+            }
+        )
+        # Create tier definitions
+        self.tier_def_obj.create(
+            {
+                "model_id": self.tester_model.id,
+                "review_type": "individual",
+                "reviewer_id": self.test_user_1.id,
+                "sequence": 20,
+                "server_action_id": server_action.id,  # Server Action
+            }
+        )
+        # Request validation
+        test_record.with_user(self.test_user_2).request_validation()
+        record = test_record.with_user(self.test_user_1)
+        record.invalidate_cache()
+        record.validate_tier()
+        self.assertTrue(record.test_bool)

--- a/base_tier_validation/tests/tier_validation_tester.py
+++ b/base_tier_validation/tests/tier_validation_tester.py
@@ -19,9 +19,13 @@ class TierValidationTester(models.Model):
     )
     test_field = fields.Float()
     user_id = fields.Many2one(string="Assigned to:", comodel_name="res.users")
+    test_bool = fields.Boolean()
 
     def action_confirm(self):
         self.write({"state": "confirmed"})
+
+    def _get_under_validation_exceptions(self):
+        return super()._get_under_validation_exceptions() + ["test_bool"]
 
 
 class TierValidationTester2(models.Model):

--- a/base_tier_validation/views/tier_definition_view.xml
+++ b/base_tier_validation/views/tier_definition_view.xml
@@ -63,20 +63,41 @@
                                 options="{'no_create': True}"
                             />
                             <field name="sequence" />
-                            <field name="notify_on_create" />
-                            <field name="has_comment" />
                             <field name="approve_sequence" />
                         </group>
                     </group>
-                    <group name="bottom">
-                        <field name="definition_type" />
-                        <field
-                            name="definition_domain"
-                            widget="domain"
-                            options="{'model': 'model'}"
-                            attrs="{'invisible': [('definition_type', '!=', 'domain')]}"
-                        />
-                    </group>
+                    <notebook>
+                        <page name="apply" string="Apply On">
+                            <group name="bottom">
+                                <field name="definition_type" />
+                                <field
+                                    name="definition_domain"
+                                    widget="domain"
+                                    options="{'model': 'model'}"
+                                    attrs="{'invisible': [('definition_type', '!=', 'domain')]}"
+                                />
+                            </group>
+                        </page>
+                        <page name="options" string="More Options">
+                            <group>
+                                <group>
+                                    <field name="notify_on_create" />
+                                    <field name="has_comment" />
+                                </group>
+                                <group>
+                                    <field name="server_action_id" />
+                                    <field name="auto_validate" />
+                                    <field
+                                        name="auto_validate_domain"
+                                        string="if pass condition"
+                                        widget="domain"
+                                        options="{'model': 'model'}"
+                                        attrs="{'invisible': [('auto_validate', '=', False)]}"
+                                    />
+                                </group>
+                            </group>
+                        </page>
+                    </notebook>
                 </sheet>
             </form>
         </field>


### PR DESCRIPTION
Supersede -- https://github.com/OCA/server-ux/pull/196

This PR add 2 more option to definition:
1. Trigger server action after validate a tier
2. Auto validate tier

These enhancement should complete the use case like,

After validate the last step of PO, do "Confirm" the PO too.
If user is on vacation and the amount is less than 1000, auto validate the PO.
etc.