### PR TITLE
[FIX] mass_editing migration V12 

### DIFF
--- a/mass_editing/migrations/12.0.2.0.1/post-migration.py
+++ b/mass_editing/migrations/12.0.2.0.1/post-migration.py
@@ -3,10 +3,11 @@
 # @author: Sylvain LE GAL (https://twitter.com/legalsylvain)
 # Copyright 2017 ACSONE SA/NV (<http://acsone.eu>)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from openupgradelib import openupgrade
 
 
 def migrate(cr, version):
-    if not version:
+    if not version or openupgrade.table_exists(cr, 'mass_editing'):
         return
     # Move field_ids to mass_editing_line
     cr.execute(

--- a/mass_editing/migrations/12.0.2.0.1/pre-migration.py
+++ b/mass_editing/migrations/12.0.2.0.1/pre-migration.py
@@ -7,7 +7,7 @@ from openupgradelib import openupgrade
 
 
 def migrate(cr, installed_version):
-    if not installed_version:
+    if not installed_version or openupgrade.table_exists(cr, 'mass_editing'):
         return
 
     openupgrade.rename_tables(cr, [('mass_object', 'mass_editing')])


### PR DESCRIPTION
avoid to run migration script, if mass_editing table exists, that case can occure if the V10 migration has been executed.

Introduced recently by #211 

CC : @simahawk , @lmignon, @Yajo, @HaraldPanten 