### PR TITLE
[FIX] mass_editing: Add company field in wizard to avoid error for fields with attribute check_company

### DIFF
--- a/mass_editing/wizard/mass_editing_wizard.py
+++ b/mass_editing/wizard/mass_editing_wizard.py
@@ -3,13 +3,21 @@
 
 from lxml import etree
 
-from odoo import _, api, models
+from odoo import _, api, fields, models
 
 
 class MassEditingWizard(models.TransientModel):
     _name = "mass.editing.wizard"
     _inherit = "mass.operation.wizard.mixin"
     _description = "Wizard for mass edition"
+
+    # need for fields with attribute check_company
+    # See: odoo/fields.py#L2350
+    company_id = fields.Many2one(
+        comodel_name="res.company",
+        string="Company",
+        default=lambda self: self.env.company,
+    )
 
     @api.model
     def _prepare_fields(self, line, field, field_info):

--- a/mass_editing/wizard/mass_editing_wizard.py
+++ b/mass_editing/wizard/mass_editing_wizard.py
@@ -3,21 +3,13 @@
 
 from lxml import etree
 
-from odoo import _, api, fields, models
+from odoo import _, api, models
 
 
 class MassEditingWizard(models.TransientModel):
     _name = "mass.editing.wizard"
     _inherit = "mass.operation.wizard.mixin"
     _description = "Wizard for mass edition"
-
-    # need for fields with attribute check_company
-    # See: odoo/fields.py#L2350
-    company_id = fields.Many2one(
-        comodel_name="res.company",
-        string="Company",
-        default=lambda self: self.env.company,
-    )
 
     @api.model
     def _prepare_fields(self, line, field, field_info):
@@ -80,7 +72,9 @@ class MassEditingWizard(models.TransientModel):
         for line in mass_editing.mapped("line_ids"):
             # Field part
             field = line.field_id
-            field_info = fields_info[field.name]
+            field_info = self._clean_check_company_field_domain(
+                TargetModel, field, fields_info[field.name]
+            )
             all_fields.update(self._prepare_fields(line, field, field_info))
 
             # XML Part
@@ -89,6 +83,20 @@ class MassEditingWizard(models.TransientModel):
         result["arch"] = etree.tostring(arch, encoding="unicode")
         result["fields"] = all_fields
         return result
+
+    @api.model
+    def _clean_check_company_field_domain(self, TargetModel, field, field_info):
+        """
+        This method remove the field view domain added by Odoo for relational
+        fields with check_company attribute to avoid error for non exists
+        company_id or company_ids fields in wizard view.
+        See _description_domain method in _Relational Class
+        """
+        field_class = TargetModel._fields[field.name]
+        if not field_class.relational or not field_class.check_company or field.domain:
+            return field_info
+        field_info["domain"] = "[]"
+        return field_info
 
     @api.model
     def create(self, vals):

--- a/mass_editing/wizard/view_mass_editing_wizard.xml
+++ b/mass_editing/wizard/view_mass_editing_wizard.xml
@@ -14,15 +14,6 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
         <field name="mode">primary</field>
         <field name="arch" type="xml">
             <xpath expr="//group[@name='custom_info']" position="inside">
-                <!--
-                In v13.0 any field can be have the attribute "check_company"
-                that adds an extra domain in field view so we need the
-                company_id field in mass editing wizard view.
-                As example see location_id from stock.location model.
-                The extra domain is added here:
-                odoo/fields.py#L2350
-                -->
-                <field name="company_id" invisible="1" />
                 <group name="group_field_list" colspan="4" col="6">
                 </group>
             </xpath>

--- a/mass_editing/wizard/view_mass_editing_wizard.xml
+++ b/mass_editing/wizard/view_mass_editing_wizard.xml
@@ -14,6 +14,15 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
         <field name="mode">primary</field>
         <field name="arch" type="xml">
             <xpath expr="//group[@name='custom_info']" position="inside">
+                <!--
+                In v13.0 any field can be have the attribute "check_company"
+                that adds an extra domain in field view so we need the
+                company_id field in mass editing wizard view.
+                As example see location_id from stock.location model.
+                The extra domain is added here:
+                odoo/fields.py#L2350
+                -->
+                <field name="company_id" invisible="1" />
                 <group name="group_field_list" colspan="4" col="6">
                 </group>
             </xpath>


### PR DESCRIPTION
cc @Tecnativa TT26036
In v13.0 any field can be have the attribute "check_company" that adds an extra domain in field view so we need the company_id field in mass editing wizard view.
As example see location_id from stock.location model.
The extra domain is added here:
https://github.com/odoo/odoo/blob/b9201ebdd65eaabab9257cf97c58410681783fa6/odoo/fields.py#L2350

ping @carlosdauden @Tardo 