### PR TITLE
[FIX] mass_editing: Unsatisfied NOT NULL constraint on action name

### DIFF
--- a/mass_editing/migrations/12.0.2.0.1/pre-migration.py
+++ b/mass_editing/migrations/12.0.2.0.1/pre-migration.py
@@ -11,3 +11,6 @@ def migrate(cr, installed_version):
         return
 
     openupgrade.rename_tables(cr, [('mass_object', 'mass_editing')])
+    if not openupgrade.column_exists(cr, 'mass_editing', 'action_name'):
+        copy_vals = {'mass_editing': [('name', 'action_name', None)]}
+        openupgrade.copy_columns(cr, copy_vals)


### PR DESCRIPTION
Since this module was refactored and it now depends on
`mass_operation_abstract`, a new required field `action_name` is
introduced, that might not be already filled. That causes the SQL
constraint to fail to be applied, showing the following message:

    odoo.modules.loading: Table 'mass_editing': column 'action_name': unable to set constraint NOT NULL
    column "action_name" contains null values

To solve the above, the new field is initialized with the same value as
name, in case it's not filled yet.