### PR TITLE
[14.0][FIX] date_range: typo in date_start field name

### DIFF
--- a/date_range/wizard/date_range_generator.py
+++ b/date_range/wizard/date_range_generator.py
@@ -17,7 +17,7 @@ class DateRangeGenerator(models.TransientModel):
         return self.env.company
 
     name_prefix = fields.Char("Range name prefix", required=True)
-    date_start = fields.Date(strint="Start date", required=True)
+    date_start = fields.Date(required=True)
     type_id = fields.Many2one(
         comodel_name="date.range.type",
         string="Type",


### PR DESCRIPTION
There's a typo ("`strint`" instead of "`string`") in the definition of field `date_start`.

This generated following error in runbot:

`2020-10-22 09:48:42,986 160 WARNING openerp_test odoo.fields: Field date.range.generator.date_start: unknown parameter 'strint', if this is an actual parameter you may want to override the method _valid_field_parameter on the relevant model in order to allow it`