### PR TITLE
[FIX] mass_operation_abstract : return True to allow call from xml-rpc

### DIFF
--- a/mass_operation_abstract/models/mass_operation_mixin.py
+++ b/mass_operation_abstract/models/mass_operation_mixin.py
@@ -67,9 +67,11 @@ class MassOperationMixin(models.AbstractModel):
         for mixin in self:
             if not mixin.ref_ir_act_window_id:
                 mixin.ref_ir_act_window_id = action_obj.create(mixin._prepare_action())
+        return True
 
     def disable_mass_operation(self):
         self.mapped("ref_ir_act_window_id").unlink()
+        return True
 
     # Overload Section
     def unlink(self):


### PR DESCRIPTION
Trivial Patch.

add return True in two function to allow call from xml-rpc.