### PR TITLE
[12.0][IMP] base_tier_validation: state check

### DIFF
--- a/base_tier_validation/models/tier_validation.py
+++ b/base_tier_validation/models/tier_validation.py
@@ -149,8 +149,7 @@ class TierValidation(models.AbstractModel):
     @api.multi
     def write(self, vals):
         for rec in self:
-            if (getattr(rec, self._state_field) in self._state_from and
-                    vals.get(self._state_field) in self._state_to):
+            if rec._check_state_conditions(vals):
                 if rec.need_validation:
                     # try to validate operation
                     reviews = rec.request_validation()
@@ -171,6 +170,11 @@ class TierValidation(models.AbstractModel):
         if vals.get(self._state_field) in self._state_from:
             self.mapped('review_ids').unlink()
         return super(TierValidation, self).write(vals)
+
+    def _check_state_conditions(self, vals):
+        self.ensure_one()
+        return (getattr(self, self._state_field) in self._state_from and
+                vals.get(self._state_field) in self._state_to)
 
     def _validate_tier(self, tiers=False):
         self.ensure_one()


### PR DESCRIPTION
This commit splits the state condition checking
part into another method, allowing inheriting
modules to override the conditions as needed.

This can be useful when the state field of the
model is a compute field (e.g. stock.picking) and
therefore cannot be relied upon in the write
method.