### PR TITLE
[13.0][IMP] base_tier_validation: state check

### DIFF
--- a/base_tier_validation/models/tier_validation.py
+++ b/base_tier_validation/models/tier_validation.py
@@ -153,12 +153,8 @@ class TierValidation(models.AbstractModel):
         return True
 
     def write(self, vals):
-        state = self._state_field
         for rec in self:
-            if (
-                getattr(rec, state) in self._state_from
-                and vals.get(self._state_field) in self._state_to
-            ):
+            if rec._check_state_conditions(vals):
                 if rec.need_validation:
                     # try to validate operation
                     reviews = rec.request_validation()
@@ -188,6 +184,13 @@ class TierValidation(models.AbstractModel):
         if vals.get(self._state_field) in self._state_from:
             self.mapped("review_ids").unlink()
         return super(TierValidation, self).write(vals)
+
+    def _check_state_conditions(self, vals):
+        self.ensure_one()
+        return (
+            getattr(self, self._state_field) in self._state_from
+            and vals.get(self._state_field) in self._state_to
+        )
 
     def _validate_tier(self, tiers=False):
         self.ensure_one()


### PR DESCRIPTION
This commit splits the state condition checking
part into another method, allowing inheriting
modules to override the conditions as needed.

Forward port of https://github.com/OCA/server-ux/pull/230.

cc @yostashiro 

@ForgeFlow