### PR TITLE
[12.0] base_tier_validation  - Add security rule for multi-company environments

### DIFF
--- a/base_tier_validation/__manifest__.py
+++ b/base_tier_validation/__manifest__.py
@@ -17,6 +17,7 @@
     ],
     "data": [
         "data/mail_data.xml",
+        "security/tier_validation_security.xml",
         "security/ir.model.access.csv",
         "views/tier_definition_view.xml",
         "views/tier_review_view.xml",

--- a/base_tier_validation/security/tier_validation_security.xml
+++ b/base_tier_validation/security/tier_validation_security.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo noupdate="0">
+    <record id="tier_definition_comp_rule" model="ir.rule">
+        <field name="name">Tier Definition multi-company</field>
+        <field name="model_id" ref="model_tier_definition" />
+        <field name="global" eval="True" />
+        <field
+            name="domain_force"
+        >['|',('company_id','=',False),('company_id','child_of',[user.company_id.id])]</field>
+    </record>
+</odoo>


### PR DESCRIPTION
In a multi-company environment, tier definitions are applied regardless of the company they belong to. Only when the tier definition itself filters on company is there a company-related process. 
This pull request adds security rules similar to elsewhere in Odoo : if a company is defined on the tier definition, then it will only be applied to target objects of that company.