### PR TITLE
[14.0][FIX] base_technical_features: user setting in hidden group

### DIFF
--- a/base_technical_features/views/res_users.xml
+++ b/base_technical_features/views/res_users.xml
@@ -7,7 +7,7 @@
         <field name="model">res.users</field>
         <field name="inherit_id" ref="base.view_users_form_simple_modif" />
         <field name="arch" type="xml">
-            <field name="company_id" position="after">
+            <field name="tz_offset" position="after">
                 <field
                     name="technical_features"
                     readonly="0"


### PR DESCRIPTION
The company_id field on the users form is hidden by default now: https://github.com/odoo/odoo/blob/14.0/odoo/addons/base/views/res_users_views.xml#L458-L459