### PR TITLE
[14.0][ADD] server_action_domain : Module to filter server action records

### DIFF
--- a/server_action_domain/__init__.py
+++ b/server_action_domain/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/server_action_domain/__manifest__.py
+++ b/server_action_domain/__manifest__.py
@@ -1,0 +1,15 @@
+# Copyright 2020 Iván Todorovich (https://twitter.com/ivantodorovich)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+{
+    "name": "Server Action Domain",
+    "version": "14.0.1.0.0",
+    "summary": "Apply a domain filter before executing server actions on records",
+    "author": "Iván Todorovich, Odoo Community Association (OCA)",
+    "category": "Tools",
+    "website": "https://github.com/OCA/server-ux",
+    "license": "AGPL-3",
+    "depends": ["base"],
+    "data": [
+        "views/ir_actions_server.xml",
+    ],
+}

--- a/server_action_domain/models/__init__.py
+++ b/server_action_domain/models/__init__.py
@@ -1,0 +1,1 @@
+from . import ir_actions_server

--- a/server_action_domain/models/ir_actions_server.py
+++ b/server_action_domain/models/ir_actions_server.py
@@ -1,0 +1,59 @@
+# Copyright 2020 Iván Todorovich (https://twitter.com/ivantodorovich)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+from odoo.osv import expression
+from odoo.tools.safe_eval import safe_eval
+
+
+class IrActionsServer(models.Model):
+    _inherit = "ir.actions.server"
+
+    domain = fields.Text(
+        string="Domain",
+        help="Domain verified before executing the server action. The action "
+        "will only be executed on records filtered by this domain.",
+        default="[]",
+    )
+
+    def run(self):
+        # Overload to filter active_id and active_ids before running
+        res = False
+        active_model = self.env.context.get("active_model")
+        active_ids = self.env.context.get("active_ids")
+        active_id = self.env.context.get("active_id")
+        for action in self.sudo():
+            if action.domain not in (False, "[]"):
+                model_name = action.model_id.model
+                model = self.env[model_name]
+                new_ctx = dict(self.env.context)
+                new_ctx.update(
+                    original_active_ids=active_ids,
+                    original_active_id=active_id,
+                )
+                # Handle active_id
+                if active_model == model_name and active_id:
+                    new_active_id = list(
+                        model._search(
+                            expression.AND(
+                                [safe_eval(action.domain), [("id", "=", active_id)]]
+                            )
+                        )
+                    )
+                    new_active_id = new_active_id and new_active_id[0] or None
+                    new_ctx.update(active_id=new_active_id)
+                # Handle active_ids
+                if active_model == model_name and active_ids:
+                    new_active_ids = list(
+                        model._search(
+                            expression.AND(
+                                [safe_eval(action.domain), [("id", "in", active_ids)]]
+                            )
+                        )
+                    )
+                    new_ctx.update(active_ids=new_active_ids)
+                # Run action with filtered context
+                res = super(IrActionsServer, action.with_context(new_ctx)).run()
+            else:
+                res = super(IrActionsServer, action).run()
+        return res

--- a/server_action_domain/readme/CONTRIBUTORS.rst
+++ b/server_action_domain/readme/CONTRIBUTORS.rst
@@ -1,0 +1,1 @@
+* Iván Todorovich <ivan.todorovich@gmail.com>

--- a/server_action_domain/readme/DESCRIPTION.rst
+++ b/server_action_domain/readme/DESCRIPTION.rst
@@ -1,0 +1,2 @@
+Adds an extra setting to server actions, to apply a domain filter
+before executing the action on records.

--- a/server_action_domain/tests/__init__.py
+++ b/server_action_domain/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_server_action_domain

--- a/server_action_domain/tests/test_server_action_domain.py
+++ b/server_action_domain/tests/test_server_action_domain.py
@@ -1,0 +1,74 @@
+# Copyrithg 2020 Iván Todorovich <ivan.todorovich@gmail.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo.tests import SavepointCase
+
+
+class TestServerActionDomain(SavepointCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
+        cls.partner_1, cls.partner_2 = cls.env["res.partner"].create(
+            [
+                {
+                    "name": "Partner with Country",
+                    "country_id": cls.env.ref("base.be").id,
+                },
+                {
+                    "name": "Partner without Country",
+                    "country_id": False,
+                },
+            ]
+        )
+        cls.server_action = cls.env["ir.actions.server"].create(
+            {
+                "name": "Anonymize",
+                "state": "code",
+                "code": "if records: records.write({'name': '** Anonymized **'})",
+                "model_id": cls.env.ref("base.model_res_partner").id,
+                "domain": "[('country_id', '=', False)]",
+            }
+        )
+        cls.server_action_single = cls.server_action.copy(
+            {
+                "code": "if record: record.write({'name': '** Anonymized **'})",
+            }
+        )
+
+    def test_00_action_with_domain(self):
+        self.server_action.with_context(
+            active_model="res.partner",
+            active_ids=(self.partner_1 | self.partner_2).ids,
+        ).run()
+        self.assertEqual(self.partner_1.name, "Partner with Country")
+        self.assertEqual(self.partner_2.name, "** Anonymized **")
+
+    def test_01_action_without_domain(self):
+        self.server_action.domain = False
+        self.server_action.with_context(
+            active_model="res.partner",
+            active_ids=(self.partner_1 | self.partner_2).ids,
+        ).run()
+        self.assertEqual(self.partner_1.name, "** Anonymized **")
+        self.assertEqual(self.partner_2.name, "** Anonymized **")
+
+    def test_02_action_single(self):
+        self.server_action_single.with_context(
+            active_model="res.partner",
+            active_id=self.partner_1.id,
+        ).run()
+        self.assertEqual(self.partner_1.name, "Partner with Country")
+        self.server_action_single.with_context(
+            active_model="res.partner",
+            active_id=self.partner_2.id,
+        ).run()
+        self.assertEqual(self.partner_2.name, "** Anonymized **")
+
+    def test_03_action_single_without_domain(self):
+        self.server_action_single.domain = False
+        self.server_action_single.with_context(
+            active_model="res.partner",
+            active_id=self.partner_1.id,
+        ).run()
+        self.assertEqual(self.partner_1.name, "** Anonymized **")

--- a/server_action_domain/views/ir_actions_server.xml
+++ b/server_action_domain/views/ir_actions_server.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+
+    <record id="view_server_action_form" model="ir.ui.view">
+        <field name="model">ir.actions.server</field>
+        <field name="inherit_id" ref="base.view_server_action_form" />
+        <field name="arch" type="xml">
+            <field name="model_id" position="after">
+                <field
+                    name="domain"
+                    widget="domain"
+                    options="{'model': 'model_name', 'in_dialog': True}"
+                />
+            </field>
+        </field>
+    </record>
+
+</odoo>

--- a/setup/server_action_domain/odoo/addons/server_action_domain
+++ b/setup/server_action_domain/odoo/addons/server_action_domain
@@ -1,0 +1,1 @@
+../../../../server_action_domain

--- a/setup/server_action_domain/setup.py
+++ b/setup/server_action_domain/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
Adds an extra setting to server actions, to apply a domain filter before executing the action on records.
This feature has been retrieved from the 13.0 `mass_editing` module, see: https://github.com/OCA/server-ux/pull/255