### PR TITLE
[12.0] Mass editing does not work correctly with one2many fields

### DIFF
--- a/mass_editing/__manifest__.py
+++ b/mass_editing/__manifest__.py
@@ -2,7 +2,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 {
     "name": "Mass Editing",
-    "version": "12.0.2.2.0",
+    "version": "12.0.2.2.1",
     "author": "Serpent Consulting Services Pvt. Ltd., "
     "Tecnativa, "
     "GRAP, "

--- a/mass_editing/__manifest__.py
+++ b/mass_editing/__manifest__.py
@@ -2,7 +2,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 {
     "name": "Mass Editing",
-    "version": "12.0.2.2.1",
+    "version": "12.0.2.2.0",
     "author": "Serpent Consulting Services Pvt. Ltd., "
     "Tecnativa, "
     "GRAP, "

--- a/mass_editing/i18n/es.po
+++ b/mass_editing/i18n/es.po
@@ -8,8 +8,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 10.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-05-17 21:08+0000\n"
-"PO-Revision-Date: 2020-02-04 22:13+0000\n"
+"POT-Creation-Date: 2021-01-28 16:20+0000\n"
+"PO-Revision-Date: 2021-01-28 16:20+0000\n"
 "Last-Translator: Nelson Ramírez Sánchez <info@konos.cl>\n"
 "Language-Team: Spanish (https://www.transifex.com/oca/teams/23907/es/)\n"
 "Language: es\n"
@@ -187,7 +187,8 @@ msgstr ""
 
 #. module: mass_editing
 #: code:addons/mass_editing/wizard/mass_editing_wizard.py:22
-#: code:addons/mass_editing/wizard/mass_editing_wizard.py:26
+#: code:addons/mass_editing/wizard/mass_editing_wizard.py:28
+#: code:addons/mass_editing/wizard/mass_editing_wizard.py:31
 #, python-format
 msgid "Remove"
 msgstr ""
@@ -204,7 +205,8 @@ msgstr ""
 
 #. module: mass_editing
 #: code:addons/mass_editing/wizard/mass_editing_wizard.py:21
-#: code:addons/mass_editing/wizard/mass_editing_wizard.py:26
+#: code:addons/mass_editing/wizard/mass_editing_wizard.py:27
+#: code:addons/mass_editing/wizard/mass_editing_wizard.py:31
 #, python-format
 msgid "Set"
 msgstr ""
@@ -224,62 +226,3 @@ msgstr ""
 msgid "Wizard for mass edition"
 msgstr "Asistente para edición masiva"
 
-#~ msgid "%s (copy)"
-#~ msgstr "%s (copia)"
-
-#~ msgid "Add Sidebar Button"
-#~ msgstr "Agregar botón de barra lateral"
-
-#~ msgid "Advanced"
-#~ msgstr "Avanzado"
-
-#~ msgid ""
-#~ "Display a button in the sidebar of related documents to open a "
-#~ "composition wizard"
-#~ msgstr ""
-#~ "Mostrar un botón en el menú contextual de los documentos relacionados "
-#~ "para abrir un asistente de composición"
-
-#~ msgid "Fields"
-#~ msgstr "Campos"
-
-#~ msgid "Mass Editing (%s)"
-#~ msgstr "Edición Masiva (%s)"
-
-#~ msgid "Mass Editing Object"
-#~ msgstr "Objeto de Edición Masiva"
-
-#~ msgid "Model List"
-#~ msgstr "Lista de modelos"
-
-#~ msgid ""
-#~ "Model is used for Selecting Fields. This is editable until Sidebar menu "
-#~ "is not created."
-#~ msgstr ""
-#~ "El modelo se utiliza para Seleccionar Campos. Esto se puede editar hasta "
-#~ "que no se cree el menú de la barra lateral."
-
-#~ msgid "Name must be unique!"
-#~ msgstr "¡El nombre debe ser único!"
-
-#~ msgid "Object"
-#~ msgstr "Objeto"
-
-#~ msgid "Remove Sidebar Button"
-#~ msgstr "Eliminar el botón de la barra lateral"
-
-#~ msgid ""
-#~ "Remove the contextual action to use this template on related documents"
-#~ msgstr ""
-#~ "Elimine la acción contextual para usar esta plantilla en documentos "
-#~ "relacionados"
-
-#~ msgid "Sidebar action"
-#~ msgstr "Acción de la barra lateral"
-
-#~ msgid ""
-#~ "Sidebar action to make this template available on records of the related "
-#~ "document model."
-#~ msgstr ""
-#~ "Acción de la barra lateral para hacer que esta plantilla esté disponible "
-#~ "en los registros del modelo de documento relacionado."

--- a/mass_editing/i18n/mass_editing.pot
+++ b/mass_editing/i18n/mass_editing.pot
@@ -6,6 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 12.0\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2021-01-28 16:19+0000\n"
+"PO-Revision-Date: 2021-01-28 16:19+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -176,7 +178,8 @@ msgstr ""
 
 #. module: mass_editing
 #: code:addons/mass_editing/wizard/mass_editing_wizard.py:22
-#: code:addons/mass_editing/wizard/mass_editing_wizard.py:26
+#: code:addons/mass_editing/wizard/mass_editing_wizard.py:28
+#: code:addons/mass_editing/wizard/mass_editing_wizard.py:31
 #, python-format
 msgid "Remove"
 msgstr ""
@@ -193,7 +196,8 @@ msgstr ""
 
 #. module: mass_editing
 #: code:addons/mass_editing/wizard/mass_editing_wizard.py:21
-#: code:addons/mass_editing/wizard/mass_editing_wizard.py:26
+#: code:addons/mass_editing/wizard/mass_editing_wizard.py:27
+#: code:addons/mass_editing/wizard/mass_editing_wizard.py:31
 #, python-format
 msgid "Set"
 msgstr ""

--- a/mass_editing/tests/test_mass_editing.py
+++ b/mass_editing/tests/test_mass_editing.py
@@ -174,21 +174,21 @@ class TestMassEditing(common.SavepointCase):
             "User's category should be removed.",
         )
 
-    def test_mass_edit_log_ids(self):
+    def test_mass_edit_o2m_log_ids(self):
         """Test Case for MASS EDITING which will remove and after add
         User's log_ids and will assert the same."""
         # Add one log_ids
         self.env['res.users.log'].sudo(self.user).create({})
         self.assertTrue(self.user.log_ids)
         # Remove one log_ids
-        vals = {"selection__log_ids": "remove"}
+        vals = {"selection__log_ids": "remove_o2m"}
         self._create_wizard_and_apply_values(
             self.mass_editing_user, self.user, vals)
         self.assertFalse(
             self.user.log_ids.exists(), "User's log_ids should be removed.")
         # Set one log_ids
         vals = {
-            'selection__log_ids': 'set',
+            'selection__log_ids': 'set_o2m',
             'log_ids': [[
                 0,
                 0,

--- a/mass_editing/tests/test_mass_editing.py
+++ b/mass_editing/tests/test_mass_editing.py
@@ -174,6 +174,31 @@ class TestMassEditing(common.SavepointCase):
             "User's category should be removed.",
         )
 
+    def test_mass_edit_log_ids(self):
+        """Test Case for MASS EDITING which will remove and after add
+        User's log_ids and will assert the same."""
+        # Add one log_ids
+        self.env['res.users.log'].sudo(self.user).create({})
+        self.assertTrue(self.user.log_ids)
+        # Remove one log_ids
+        vals = {"selection__log_ids": "remove"}
+        self._create_wizard_and_apply_values(
+            self.mass_editing_user, self.user, vals)
+        self.assertFalse(
+            self.user.log_ids.exists(), "User's log_ids should be removed.")
+        # Set one log_ids
+        vals = {
+            'selection__log_ids': 'set',
+            'log_ids': [[
+                0,
+                0,
+                {}
+            ]]}
+        self._create_wizard_and_apply_values(
+            self.mass_editing_user, self.user, vals)
+        self.assertTrue(
+            self.user.log_ids, "User's log_ids should be set.")
+
     def test_sidebar_action(self):
         """Test if Sidebar Action is added / removed to / from give object."""
 

--- a/mass_editing/tests/test_mass_editing.py
+++ b/mass_editing/tests/test_mass_editing.py
@@ -188,7 +188,7 @@ class TestMassEditing(common.SavepointCase):
             self.user.log_ids.exists(), "User's log_ids should be removed.")
         # Set one log_ids
         vals = {
-            'selection__log_ids': 'set_o2m',
+            'selection__log_ids': "set_o2m",
             'log_ids': [[
                 0,
                 0,

--- a/mass_editing/wizard/mass_editing_wizard.py
+++ b/mass_editing/wizard/mass_editing_wizard.py
@@ -101,10 +101,17 @@ class MassEditingWizard(models.TransientModel):
                 if key.startswith("selection_"):
                     split_key = key.split("__", 1)[1]
                     if val == "set":
-                        values.update({split_key: vals.get(split_key, False)})
-
+                        if TargetModel._fields[split_key].type == 'one2many':
+                            values.update({
+                                split_key: vals.get(split_key, [(6, 0, [])])})
+                        else:
+                            values.update({
+                                split_key: vals.get(split_key, False)})
                     elif val == "remove":
-                        values.update({split_key: False})
+                        if TargetModel._fields[split_key].type == 'one2many':
+                            values.update({split_key: [(6, 0, [])]})
+                        else:
+                            values.update({split_key: False})
 
                         # If field to remove is translatable,
                         # its translations have to be removed

--- a/mass_editing/wizard/mass_editing_wizard.py
+++ b/mass_editing/wizard/mass_editing_wizard.py
@@ -23,7 +23,10 @@ class MassEditingWizard(models.TransientModel):
                 ("add", _("Add")),
             ]
         elif field.ttype == "one2many":
-            selection = [("set_o2m", _("Set")), ("remove_o2m", _("Remove"))]
+            selection = [
+                ("set_o2m", _("Set")),
+                ("remove_o2m", _("Remove")),
+            ]
         else:
             selection = [("set", _("Set")), ("remove", _("Remove"))]
         result["selection__" + field.name] = {

--- a/mass_editing/wizard/mass_editing_wizard.py
+++ b/mass_editing/wizard/mass_editing_wizard.py
@@ -23,10 +23,7 @@ class MassEditingWizard(models.TransientModel):
                 ("add", _("Add")),
             ]
         elif field.ttype == "one2many":
-            selection = [
-                ("set_o2m", _("Set")),
-                ("remove_o2m", _("Remove")),
-            ]
+            selection = [("set_o2m", _("Set")), ("remove_o2m", _("Remove"))]
         else:
             selection = [("set", _("Set")), ("remove", _("Remove"))]
         result["selection__" + field.name] = {

--- a/mass_editing/wizard/mass_editing_wizard.py
+++ b/mass_editing/wizard/mass_editing_wizard.py
@@ -22,6 +22,11 @@ class MassEditingWizard(models.TransientModel):
                 ("remove_m2m", _("Remove")),
                 ("add", _("Add")),
             ]
+        elif field.ttype == "one2many":
+            selection = [
+                ("set_o2m", _("Set")),
+                ("remove_o2m", _("Remove")),
+            ]
         else:
             selection = [("set", _("Set")), ("remove", _("Remove"))]
         result["selection__" + field.name] = {
@@ -101,17 +106,14 @@ class MassEditingWizard(models.TransientModel):
                 if key.startswith("selection_"):
                     split_key = key.split("__", 1)[1]
                     if val == "set":
-                        if TargetModel._fields[split_key].type == 'one2many':
-                            values.update({
-                                split_key: vals.get(split_key, [(6, 0, [])])})
-                        else:
-                            values.update({
-                                split_key: vals.get(split_key, False)})
+                        values.update({split_key: vals.get(split_key, False)})
+
+                    elif val == "set_o2m":
+                        values.update({
+                            split_key: vals.get(split_key, [(6, 0, [])])})
+
                     elif val == "remove":
-                        if TargetModel._fields[split_key].type == 'one2many':
-                            values.update({split_key: [(6, 0, [])]})
-                        else:
-                            values.update({split_key: False})
+                        values.update({split_key: False})
 
                         # If field to remove is translatable,
                         # its translations have to be removed
@@ -146,6 +148,9 @@ class MassEditingWizard(models.TransientModel):
                             values.update({split_key: m2m_list})
                         else:
                             values.update({split_key: [(5, 0, [])]})
+
+                    elif val == "remove_o2m":
+                        values.update({split_key: [(6, 0, [])]})
 
                     elif val == "add":
                         m2m_list = []


### PR DESCRIPTION
ERRORS DETECTED (open in issue https://github.com/OCA/server-ux/issues/260):

When you select the "Set" option from the mass editing wizard and leave the one2many field empty with the aim that the empty value is assigned to all the selected records, that is, that their values are emptied, that assignment is not applied in the selected records. The value of the field is not modified.

When you select the "Remove" option from the mass editing wizard, leaving the one2many field empty so that all records associated with said field are deleted, this deletion does not apply. The value of the field is not removed.

CAUSE:

Is being assigned False value in the writing of the one2many field instead of the empty assignment for this type of fields: [(6, 0, [])].

SOLUTION:

Detect if the field is of type one2many, and if so, assign [(6, 0, [])] instead of False.

