### PR TITLE
[14.0][FIX] base_tier_validation : Error "The operation is under validation"

### DIFF
--- a/base_tier_validation/models/tier_validation.py
+++ b/base_tier_validation/models/tier_validation.py
@@ -184,6 +184,7 @@ class TierValidation(models.AbstractModel):
             if (
                 rec.review_ids
                 and getattr(rec, self._state_field) in self._state_from
+                and vals.get(self._state_field)
                 and not vals.get(self._state_field)
                 in (self._state_to + [self._cancel_state])
                 and not self._check_allow_write_under_validation(vals)


### PR DESCRIPTION
I'm migrating account_move_tier_validation https://github.com/OCA/account-invoicing/pull/853 and I tested `validate` by reviewers. It's not allow and throw error "The operation is under validation" always.
![Peek 2021-02-01 20-44](https://user-images.githubusercontent.com/24691983/106467288-0207b700-64cf-11eb-9e5f-746d65fc94e2.gif)

I check on log and found some vals (not state) pass in this function
![Selection_103](https://user-images.githubusercontent.com/24691983/106467514-5743c880-64cf-11eb-81f5-058854156522.png)

which this line check with state in vals and it will be True
![Selection_104](https://user-images.githubusercontent.com/24691983/106468451-873f9b80-64d0-11eb-9576-65970da5d2c4.png)

This PR is fix for if state not in vals will not throw error "The operation is under validation"