### PR TITLE
[14.0][FIX] base_tier_validation_forward, inverse value of related field cause wrong desc in tier.review.

### DIFF
--- a/base_tier_validation_forward/models/tier_review.py
+++ b/base_tier_validation_forward/models/tier_review.py
@@ -7,37 +7,32 @@ class TierReview(models.Model):
     _inherit = "tier.review"
     _order = "sequence"
 
-    name = fields.Char(compute="_compute_definition_data", store=True, readonly=False)
+    name = fields.Char(compute="_compute_definition_data", store=True)
     status = fields.Selection(
         selection_add=[("forwarded", "Forwarded")],
     )
     review_type = fields.Selection(
         compute="_compute_definition_data",
         store=True,
-        readonly=False,
     )
     reviewer_id = fields.Many2one(
         comodel_name="res.users",
         compute="_compute_definition_data",
         store=True,
-        readonly=False,
     )
     reviewer_group_id = fields.Many2one(
         comodel_name="res.groups",
         compute="_compute_definition_data",
         store=True,
-        readonly=False,
     )
     sequence = fields.Float()
     has_comment = fields.Boolean(
         compute="_compute_definition_data",
         store=True,
-        readonly=False,
     )
     approve_sequence = fields.Boolean(
         compute="_compute_definition_data",
         store=True,
-        readonly=False,
     )
 
     @api.depends(

--- a/base_tier_validation_forward/wizard/forward_wizard.py
+++ b/base_tier_validation_forward/wizard/forward_wizard.py
@@ -32,13 +32,18 @@ class ValidationForwardWizard(models.TransientModel):
             {"comment": _(">> %s") % self.forward_reviewer_id.display_name}
         )
         prev_reviews = prev_comment.add_comment()
-        self.env["tier.review"].create(
+        review = self.env["tier.review"].create(
             {
-                "name": self.forward_description,
                 "model": rec._name,
                 "res_id": rec.id,
                 "sequence": max(prev_reviews.mapped("sequence")) + 0.1,
                 "requested_by": self.env.uid,
+            }
+        )
+        # Because following fileds are readonly, we need to write after create
+        review.write(
+            {
+                "name": self.forward_description,
                 "review_type": "individual",
                 "reviewer_id": self.forward_reviewer_id.id,
                 "has_comment": self.has_comment,


### PR DESCRIPTION
Problem with related field and caching. Following problem can occur.

Given this module base_tier_validation_forward is installed. As this module overwrite the filed name in tier.review, as readonly=False. In some situation, the name of record to process tier validation will be used as the name of tier.review (because readonly=False, and it was related field before).

In any case, readonly=True is good as protection.

