### PR TITLE
[14.0][IMP] base_tier_validation_forward, allow backward tier

### DIFF
--- a/base_tier_validation_forward/models/tier_definition.py
+++ b/base_tier_validation_forward/models/tier_definition.py
@@ -14,5 +14,5 @@ class TierDefinition(models.Model):
     backward = fields.Boolean(
         string="Backward",
         help="If the forwarded step is approved, "
-        "auto forward back again to finish the step.",
+        "option to backward to finish the step.",
     )

--- a/base_tier_validation_forward/models/tier_definition.py
+++ b/base_tier_validation_forward/models/tier_definition.py
@@ -11,3 +11,8 @@ class TierDefinition(models.Model):
         default=False,
         help="Allow option to 'Forward' to different person.",
     )
+    backward = fields.Boolean(
+        string="Backward",
+        help="If the forwarded step is approved, "
+        "auto forward back again to finish the step.",
+    )

--- a/base_tier_validation_forward/models/tier_review.py
+++ b/base_tier_validation_forward/models/tier_review.py
@@ -34,6 +34,11 @@ class TierReview(models.Model):
         compute="_compute_definition_data",
         store=True,
     )
+    origin_id = fields.Many2one(
+        comodel_name="tier.review",
+        copy=False,
+        help="Reference to origin tier review that createก this tier.",
+    )
 
     @api.depends(
         "definition_id.name",

--- a/base_tier_validation_forward/models/tier_validation.py
+++ b/base_tier_validation_forward/models/tier_validation.py
@@ -6,17 +6,20 @@ from odoo import _, api, fields, models
 class TierValidation(models.AbstractModel):
     _inherit = "tier.validation"
 
-    can_forward = fields.Boolean(compute="_compute_can_forward")
+    can_forward = fields.Boolean(compute="_compute_forward_backward")
+    can_backward = fields.Boolean(compute="_compute_forward_backward")
 
-    def _compute_can_forward(self):
+    def _compute_forward_backward(self):
         for rec in self:
             if not rec.can_review:
                 rec.can_forward = False
+                rec.can_backward = False
                 continue
             sequences = self._get_sequences_to_approve(self.env.user)
             reviews = rec.review_ids.filtered(lambda l: l.sequence in sequences)
             definitions = reviews.mapped("definition_id")
             rec.can_forward = True in definitions.mapped("has_forward")
+            rec.can_backward = True in definitions.mapped("backward")
 
     @api.model
     def _calc_reviews_validated(self, reviews):

--- a/base_tier_validation_forward/readme/CONFIGURE.rst
+++ b/base_tier_validation_forward/readme/CONFIGURE.rst
@@ -1,1 +1,4 @@
-In any tier definition, check "Allow Forward" to enable this feature.
+In any tier definition,
+
+* Check "Allow Forward" to enable this feature
+* Check "​Option to backward after forwarded tier is reviewed" for option to "Ask for review"

--- a/base_tier_validation_forward/readme/CONTRIBUTORS.rst
+++ b/base_tier_validation_forward/readme/CONTRIBUTORS.rst
@@ -1,1 +1,2 @@
 * Kitti U. <kittiu@ecosoft.co.th>
+* Adria Gil Sorribes <adria.gil@forgeflow.com>

--- a/base_tier_validation_forward/readme/DESCRIPTION.rst
+++ b/base_tier_validation_forward/readme/DESCRIPTION.rst
@@ -9,3 +9,7 @@ for some reason, and want to pass/forward the decision to another person.
 
 User can then click on Forward instead of Approve. A new tier with minor sequence will be
 created on the reviewer table, and new user will be able to make approval decision.
+
+User has also the ability to ask for someone to review the tier before making
+the final decision, he/she forwards it to another user, after that user has
+validated the tier, the decision is back to the original user.

--- a/base_tier_validation_forward/readme/DESCRIPTION.rst
+++ b/base_tier_validation_forward/readme/DESCRIPTION.rst
@@ -1,6 +1,7 @@
 This module add an advance option to base_tier_validation.
 
 * To allow "Forward" the tier to different user.
+* Also allow optional "Backward" tier once the forwarded tier is reviewed.
 
 **Sample use case:**
 

--- a/base_tier_validation_forward/views/tier_definition_view.xml
+++ b/base_tier_validation_forward/views/tier_definition_view.xml
@@ -20,7 +20,7 @@
                     title="If the forwarded step is approved, auto forward back again to finish the step."
                 >
                     <field name="backward" />
-                    <span>Auto backward after the forward step is validated</span>
+                    <span>Allow backward after the forward step is validated</span>
                 </div>
             </field>
         </field>

--- a/base_tier_validation_forward/views/tier_definition_view.xml
+++ b/base_tier_validation_forward/views/tier_definition_view.xml
@@ -8,7 +8,20 @@
         <field name="inherit_id" ref="base_tier_validation.tier_definition_view_form" />
         <field name="arch" type="xml">
             <field name="approve_sequence" position="after">
-                <field name="has_forward" />
+                <label for="has_forward" />
+                <div name="has_forward_div" class="o_row">
+                    <field name="has_forward" />
+                </div>
+                <label for="backward" invisible="1" />
+                <div
+                    name="backward_div"
+                    class="o_row"
+                    attrs="{'invisible': [('has_forward', '=', False)]}"
+                    title="If the forwarded step is approved, auto forward back again to finish the step."
+                >
+                    <field name="backward" />
+                    <span>Auto backward after the forward step is validated</span>
+                </div>
             </field>
         </field>
     </record>

--- a/base_tier_validation_forward/views/tier_definition_view.xml
+++ b/base_tier_validation_forward/views/tier_definition_view.xml
@@ -20,7 +20,7 @@
                     title="If the forwarded step is approved, auto forward back again to finish the step."
                 >
                     <field name="backward" />
-                    <span>Allow backward after the forward step is validated</span>
+                    <span>Option to backward after forwarded tier is reviewed</span>
                 </div>
             </field>
         </field>

--- a/base_tier_validation_forward/wizard/forward_wizard.py
+++ b/base_tier_validation_forward/wizard/forward_wizard.py
@@ -32,12 +32,14 @@ class ValidationForwardWizard(models.TransientModel):
             {"comment": _(">> %s") % self.forward_reviewer_id.display_name}
         )
         prev_reviews = prev_comment.add_comment()
+        prev_review = prev_reviews.sorted("sequence")[-1:]  # Get max sequence
         review = self.env["tier.review"].create(
             {
                 "model": rec._name,
                 "res_id": rec.id,
-                "sequence": max(prev_reviews.mapped("sequence")) + 0.1,
+                "sequence": round(prev_review.sequence + 0.1, 2),
                 "requested_by": self.env.uid,
+                "origin_id": prev_review.id,
             }
         )
         # Because following fileds are readonly, we need to write after create

--- a/base_tier_validation_forward/wizard/forward_wizard.py
+++ b/base_tier_validation_forward/wizard/forward_wizard.py
@@ -1,6 +1,6 @@
 # Copyright 2020 Ecosoft Co., Ltd. (http://ecosoft.co.th)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
-from odoo import _, fields, models
+from odoo import _, api, fields, models
 
 
 class ValidationForwardWizard(models.TransientModel):
@@ -23,8 +23,13 @@ class ValidationForwardWizard(models.TransientModel):
     can_backward = fields.Boolean(
         string="Can ask for review", compute="_compute_can_backward"
     )
-    backward = fields.Boolean(string="Ask for review", default=False)
+    backward = fields.Boolean(
+        string="Ask for review",
+        default=False,
+        help="The forwarded tier is meant for reivew, once approved, it will be back.",
+    )
 
+    @api.depends("forward_reviewer_id")
     def _compute_can_backward(self):
         self.ensure_one()
         record = self.env[self.res_model].browse(self.res_id)

--- a/base_tier_validation_forward/wizard/forward_wizard_view.xml
+++ b/base_tier_validation_forward/wizard/forward_wizard_view.xml
@@ -12,7 +12,10 @@
                     <group>
                         <field name="forward_reviewer_id" />
                         <field name="forward_description" required="1" />
-                        <field name="backward" />
+                        <field
+                            name="backward"
+                            attrs="{'invisible': [('can_backward', '=', False)]}"
+                        />
                     </group>
                     <group>
                         <field name="has_comment" invisible="1" />

--- a/base_tier_validation_forward/wizard/forward_wizard_view.xml
+++ b/base_tier_validation_forward/wizard/forward_wizard_view.xml
@@ -12,9 +12,11 @@
                     <group>
                         <field name="forward_reviewer_id" />
                         <field name="forward_description" required="1" />
+                        <field name="backward" />
                     </group>
                     <group>
                         <field name="has_comment" invisible="1" />
+                        <field name="can_backward" invisible="1" />
                         <field name="approve_sequence" invisible="1" />
                     </group>
                 </group>

--- a/filter_multi_user/tests/test_filter_multi_user.py
+++ b/filter_multi_user/tests/test_filter_multi_user.py
@@ -88,24 +88,24 @@ class TestFilterMultiUser(common.SavepointCase):
         # User 1:
         res = self.filter_model.with_user(self.user_1).get_filters("ir.filters")
         result = []
-        for filter in res:
-            result.append(filter.get("id"))
+        for f in res:
+            result.append(f.get("id"))
         self.assertIn(test_filter_1.id, result)
         self.assertIn(test_filter_2.id, result)
         self.assertIn(test_filter_3.id, result)
         # User 2:
         res = self.filter_model.with_user(self.user_2).get_filters("ir.filters")
         result = []
-        for filter in res:
-            result.append(filter.get("id"))
+        for f in res:
+            result.append(f.get("id"))
         self.assertIn(test_filter_1.id, result)
         self.assertNotIn(test_filter_2.id, result)
         self.assertNotIn(test_filter_3.id, result)
         # User 3:
         res = self.filter_model.with_user(self.user_3).get_filters("ir.filters")
         result = []
-        for filter in res:
-            result.append(filter.get("id"))
+        for f in res:
+            result.append(f.get("id"))
         self.assertNotIn(test_filter_1.id, result)
         self.assertNotIn(test_filter_2.id, result)
         self.assertIn(test_filter_3.id, result)


### PR DESCRIPTION
**The Use Case**

Currently this module allow creating adhoc forward tier. But there are situation that the 1st user who forward to the 2nd user, may do it just to ask for affirmation. And if affirmed by, he still want to do the final approve by himself.

**In the Tier Definition**

1. Set allow forward
2. Also to backward

![image](https://user-images.githubusercontent.com/1973598/106881402-12f33b00-6710-11eb-8fe4-2f8b440908ca.png)

**In the Tier Reviews**

1. 1st user do forward
2. 2nd user affirmed it, system will auto copy the 1st tier as 1.2
3. 1st user will need to validate as the first time (of course, he can still forward again, according to 1st tier setting)

![image](https://user-images.githubusercontent.com/1973598/106881741-7da47680-6710-11eb-9cdd-85b695411412.png)

**TODO**

- [ ] Test Script