### PR TITLE
[14.0][FIX] base_tier_validation, improve accuracy of systray on case approve_sequence

### DIFF
--- a/base_tier_validation/models/tier_validation.py
+++ b/base_tier_validation/models/tier_validation.py
@@ -43,7 +43,9 @@ class TierValidation(models.AbstractModel):
         compute="_compute_reviewer_ids",
         search="_search_reviewer_ids",
     )
-    can_review = fields.Boolean(compute="_compute_can_review")
+    can_review = fields.Boolean(
+        compute="_compute_can_review", search="_search_can_review"
+    )
     has_comment = fields.Boolean(compute="_compute_has_comment")
 
     def _compute_has_comment(self):
@@ -72,6 +74,22 @@ class TierValidation(models.AbstractModel):
     def _compute_can_review(self):
         for rec in self:
             rec.can_review = rec._get_sequences_to_approve(self.env.user)
+
+    @api.model
+    def _search_can_review(self, operator, value):
+        res_ids = (
+            self.search(
+                [
+                    ("review_ids.reviewer_ids", "=", self.env.user.id),
+                    ("review_ids.status", "=", "pending"),
+                    ("review_ids.can_review", "=", True),
+                    ("rejected", "=", False),
+                ]
+            )
+            .filtered("can_review")
+            .ids
+        )
+        return [("id", "in", res_ids)]
 
     @api.depends("review_ids")
     def _compute_reviewer_ids(self):

--- a/base_tier_validation/static/src/js/systray.js
+++ b/base_tier_validation/static/src/js/systray.js
@@ -144,12 +144,7 @@ odoo.define("tier_validation.systray", function (require) {
                     [false, "form"],
                 ],
                 search_view_id: [false],
-                domain: [
-                    ["review_ids.reviewer_ids", "=", session.uid],
-                    ["review_ids.status", "=", "pending"],
-                    ["review_ids.can_review", "=", true],
-                    ["rejected", "=", false],
-                ],
+                domain: [["can_review", "=", true]],
                 context: context,
             });
         },


### PR DESCRIPTION
For case approve by sequence. At currently status,

* On the record, the button showing correctly on the next document to validate (thanks to rec.can_review)
* The systray count is already correct.
* But when click on systray to open the document list, still not taken sequence into account, and so it list also the document need approve in the future sequence. (i.e., systray says 2 docs, but it may open 3 docs)

This PR enhance that, to make sure that we use rec.can_review to help determine the correct document list.

Note: this fix should be applied to version 12.0 and 13.0 where we have approve by sequence feature.