### PR TITLE
[12.0][FIX] base_tier_validation, access_token as exception field

### DIFF
--- a/base_tier_validation/models/tier_validation.py
+++ b/base_tier_validation/models/tier_validation.py
@@ -134,7 +134,7 @@ class TierValidation(models.AbstractModel):
     @api.model
     def _get_under_validation_exceptions(self):
         """Extend for more field exceptions."""
-        return ['message_follower_ids', 'message_main_attachment_id']
+        return ['message_follower_ids', 'message_main_attachment_id', 'access_token']
 
     @api.multi
     def _check_allow_write_under_validation(self, vals):


### PR DESCRIPTION
Based on, https://github.com/OCA/sale-workflow/pull/1386#issuecomment-781371729