### PR TITLE
[13.0][FIX] base_tier_validation, access_token as exception field

### DIFF
--- a/base_tier_validation/models/tier_validation.py
+++ b/base_tier_validation/models/tier_validation.py
@@ -141,7 +141,7 @@ class TierValidation(models.AbstractModel):
     @api.model
     def _get_under_validation_exceptions(self):
         """Extend for more field exceptions."""
-        return ["message_follower_ids"]
+        return ["message_follower_ids", "access_token"]
 
     def _check_allow_write_under_validation(self, vals):
         """Allow to add exceptions for fields that are allowed to be written


### PR DESCRIPTION
Based on, https://github.com/OCA/sale-workflow/pull/1386#issuecomment-781371729