### PR TITLE
[13.0] [IMP] base_technical_features: use has_group instead of loading all users

### DIFF
--- a/base_technical_features/models/res_users.py
+++ b/base_technical_features/models/res_users.py
@@ -24,16 +24,16 @@ class ResUsers(models.Model):
     def _compute_show_technical_features(self):
         """ Only display the technical features checkbox in the user
         preferences if the user has access to them """
-        users = self.env.ref("base.group_no_one").users
         for user in self:
-            user.show_technical_features = user in users
+            user.show_technical_features = user.has_group("base.group_no_one")
 
     @api.depends("groups_id")
     def _compute_technical_features(self):
         """ Map user membership to boolean field value """
-        users = self.env.ref("base_technical_features.group_technical_features").users
         for user in self:
-            user.technical_features = user in users
+            user.technical_features = user.has_group(
+                "base_technical_features.group_technical_features"
+            )
 
     def _inverse_technical_features(self):
         """ Map boolean field value to group membership, but checking


### PR DESCRIPTION
On databases with a large number of users, loading all users of base.group_no_one can be slow.
Moreover, the 'technical_features' and 'show_technical_features' are always computed for a single record