### PR TITLE
[14.0][FIX] date_range: Refactor component with Owl framework

### DIFF
--- a/date_range/static/src/js/date_range.js
+++ b/date_range/static/src/js/date_range.js
@@ -1,132 +1,88 @@
-/* Copyright 2016 ACSONE SA/NV (<http://acsone.eu>)
- * License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). */
-odoo.define("date_range.search_filters", function (require) {
+/* Copyright 2016 ACSONE SA/NV (<https://acsone.eu>)
+ * Copyright 2021 Studio73 - Pablo Fuentes (https://www.studio73.es)
+ * License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl). */
+
+odoo.define("date_range.CustomFilterItem", function (require) {
     "use strict";
 
-    var filters = require("web.search_filters");
-    var rpc = require("web.rpc");
-    var framework = require("web.framework");
+    const {_lt} = require("web.core");
+    const session = require("web.session");
+    const {FIELD_OPERATORS, FIELD_TYPES} = require("web.searchUtils");
+    const CustomFilterItem = require("web.CustomFilterItem");
 
-    filters.ExtendedSearchProposition.include({
-        select_field: function (field) {
-            this._super.apply(this, arguments);
-            this.is_date_range_selected = false;
-            this.is_date = field.type === "date" || field.type === "datetime";
-            this.$value = this.$el.find(
-                ".searchview_extended_prop_value, .o_searchview_extended_prop_value"
-            );
-            if (this.is_date) {
-                this._rpc({
-                    model: "date.range.type",
-                    method: "search_read",
-                    fields: ["name"],
-                    context: this.context,
-                }).then(this.proxy("add_date_range_types_operator"));
-            }
-        },
-
-        add_date_range_types_operator: function (date_range_types) {
-            var self = this;
-            _.each(date_range_types, function (drt) {
-                var el = self.$el.find(
-                    ".searchview_extended_prop_op, .o_searchview_extended_prop_op"
-                );
-                $("<option>", {value: "drt_" + drt.id})
-                    .text(_("in ") + drt.name)
-                    .appendTo(el);
-            });
-        },
-
-        operator_changed: function (e) {
-            var val = $(e.target).val();
-            this.is_date_range_selected = val.startsWith("drt_");
-            if (this.is_date_range_selected) {
-                var type_id = val.replace("drt_", "");
-                this.date_range_type_operator_selected(type_id);
-                return;
-            }
-            this._super.apply(this, arguments);
-        },
-
-        date_range_type_operator_selected: function (type_id) {
-            this.$value.empty().show();
-            this._rpc({
-                model: "date.range",
-                method: "search_read",
-                fields: ["name", "date_start", "date_end"],
-                context: this.context,
-                domain: [["type_id", "=", parseInt(type_id, 10)]],
-            }).then(this.proxy("on_range_type_selected"));
-        },
-
-        on_range_type_selected: function (date_range_values) {
-            this.value = new filters.ExtendedSearchProposition.DateRange(
-                this,
-                this.value.field,
-                date_range_values
-            );
-            var self = this;
-            this.value.appendTo(this.$value).then(function () {
-                if (!self.$el.hasClass("o_filter_condition")) {
-                    self.$value.find(".date-range-select").addClass("form-control");
+    CustomFilterItem.patch(
+        "date_range.CustomFilterItem",
+        (T) =>
+            class extends T {
+                constructor() {
+                    super(...arguments);
+                    this._computeDateRangeOperators();
                 }
-                self.value.on_range_selected();
-            });
-        },
 
-        get_filter: function () {
-            var res = this._super.apply(this, arguments);
-            if (this.is_date_range_selected) {
-                // In case of date.range, the domain is provided by the server and we don't
-                // Want to put nest the returned value into an array.
-                res.attrs.domain = this.value.domain;
+                async _computeDateRangeOperators() {
+                    this.OPERATORS = Object.assign({}, FIELD_OPERATORS);
+                    this.OPERATORS.date = [...FIELD_OPERATORS.date];
+                    this.OPERATORS.datetime = [...FIELD_OPERATORS.datetime];
+                    this.date_ranges = {};
+                    const result = await this.rpc({
+                        model: "date.range",
+                        method: "search_read",
+                        fields: ["name", "type_id", "date_start", "date_end"],
+                        context: session.user_context,
+                    });
+                    result.forEach((range) => {
+                        const range_type = range.type_id[0];
+                        if (this.date_ranges[range_type] === undefined) {
+                            const r = {
+                                symbol: "between",
+                                description: `${_lt("in")} ${range.type_id[1]}`,
+                                date_range: true,
+                                date_range_type: range_type,
+                            };
+                            this.OPERATORS.date.push(r);
+                            this.OPERATORS.datetime.push(r);
+                            this.date_ranges[range_type] = [];
+                        }
+                        this.date_ranges[range_type].push(range);
+                    });
+                }
+
+                _setDefaultValue(condition) {
+                    const type = this.fields[condition.field].type;
+                    const operator = this.OPERATORS[FIELD_TYPES[type]][
+                        condition.operator
+                    ];
+                    if (operator.date_range) {
+                        const default_range = this.date_ranges[
+                            operator.date_range_type
+                        ][0];
+                        const d_start = moment(`${default_range.date_start} 00:00:00`);
+                        const d_end = moment(`${default_range.date_end} 23:59:59`);
+                        condition.value = [d_start, d_end];
+                    } else {
+                        super._setDefaultValue(...arguments);
+                    }
+                }
+
+                _onValueInput(condition, ev) {
+                    const type = this.fields[condition.field].type;
+                    const operator = this.OPERATORS[FIELD_TYPES[type]][
+                        condition.operator
+                    ];
+                    if (operator.date_range) {
+                        this.date_ranges[operator.date_range_type].forEach((range) => {
+                            if (range.id === ev.target.value) {
+                                const d_start = moment(`${range.date_start} 00:00:00`);
+                                const d_end = moment(`${range.date_end} 23:59:59`);
+                                condition.value = [d_start, d_end];
+                            }
+                        });
+                    } else {
+                        super._onValueInput(...arguments);
+                    }
+                }
             }
-            return res;
-        },
-    });
+    );
 
-    filters.ExtendedSearchProposition.DateRange = filters.Field.extend({
-        template: "SearchView.extended_search.dateRange.selection",
-        events: {
-            change: "on_range_selected",
-        },
-
-        init: function (parent, field, date_range_values) {
-            this._super(parent, field);
-            this.date_range_values = date_range_values;
-        },
-
-        toString: function () {
-            var select = this.$el[0];
-            var option = select.options[select.selectedIndex];
-            return option.label || option.text;
-        },
-
-        get_value: function () {
-            return parseInt(this.$el.val(), 10);
-        },
-
-        on_range_selected: function () {
-            var self = this;
-            self.domain = "";
-            framework.blockUI();
-            return rpc
-                .query({
-                    args: [this.get_value()],
-                    kwargs: {
-                        field_name: this.field.name,
-                    },
-                    model: "date.range",
-                    method: "get_domain",
-                })
-                .then(function (domain) {
-                    framework.unblockUI();
-                    self.domain = domain;
-                });
-        },
-
-        get_domain: function () {
-            return this.domain;
-        },
-    });
+    return CustomFilterItem;
 });

--- a/date_range/static/src/xml/date_range.xml
+++ b/date_range/static/src/xml/date_range.xml
@@ -1,12 +1,25 @@
 <?xml version="1.0" encoding="UTF-8" ?>
+<!-- Copyright 2021 Studio73 - Pablo Fuentes (https://www.studio73.es)
+     License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl). -->
 <template>
-    <t t-name="SearchView.extended_search.dateRange.selection">
-        <select class="date-range-select">
-            <t t-as="element" t-foreach="widget.date_range_values">
-                <option t-att-value="element.id">
-                    <t t-esc="element.name" />
-                </option>
+    <t t-inherit="web.CustomFilterItem" t-inherit-mode="extension">
+        <xpath expr="//span[hasclass('o_generator_menu_value')]" position="replace">
+            <t
+                t-if="(fieldType === 'date' || fieldType === 'datetime') &amp;&amp; selectedOperator.date_range"
+            >
+                <span class="o_generator_menu_value">
+                    <select class="o_input" t-on-change="_onValueInput(condition)">
+                        <option
+                            t-foreach="date_ranges[selectedOperator.date_range_type]"
+                            t-as="option"
+                            t-key="option_index"
+                            t-att-value="option.id"
+                            t-esc="option.name"
+                        />
+                    </select>
+                </span>
             </t>
-        </select>
+            <t t-else="">$0</t>
+        </xpath>
     </t>
 </template>


### PR DESCRIPTION
Currently this module isn't working in v14 
![Captura de pantalla 2021-03-17 a las 19 01 52](https://user-images.githubusercontent.com/4355395/111515579-408dc400-8753-11eb-8364-e89765d67b35.png)
![Captura de pantalla 2021-03-17 a las 18 57 24](https://user-images.githubusercontent.com/4355395/111515425-0f14f880-8753-11eb-8131-f8f6b18370a8.png)

This error is due to this [odoo commit](https://github.com/odoo/odoo/commit/fbf347498f1cc7b74ef373179b7bcae201715c24#diff-a7410c865d2ffe22962d16553e41f6bf0a0c3ccc84075fdcb0d965e22c6a3648) in which the web control panel have been refactored with the new Owl framework


**_Known issue_**
In previous versions the name of the range is shown in the description of the filter 
![Captura de pantalla 2021-03-17 a las 19 08 26](https://user-images.githubusercontent.com/4355395/111516437-302a1900-8754-11eb-8236-729064923117.png)

Now the date range is shown in the description
![Captura de pantalla 2021-03-17 a las 19 18 23](https://user-images.githubusercontent.com/4355395/111517768-bbf07500-8755-11eb-9cca-e9911ce0624d.png)

Can't be done like previous because the description is computed inside an [arrow function](https://github.com/odoo/odoo/blob/14.0/addons/web/static/src/js/control_panel/custom_filter_item.js#L161-L169) so we would have to c&p the whole function

