### PR TITLE
Fix avoid_quick_create with multiprocess

### DIFF
--- a/base_optional_quick_create/models/ir_model.py
+++ b/base_optional_quick_create/models/ir_model.py
@@ -50,4 +50,6 @@ class IrModel(models.Model):
     def write(self, vals):
         res = super().write(vals)
         self._patch_quick_create()
+        if 'avoid_quick_create' in vals:
+            self.pool.signal_registry_change()
         return res

--- a/base_optional_quick_create/models/ir_model.py
+++ b/base_optional_quick_create/models/ir_model.py
@@ -50,6 +50,7 @@ class IrModel(models.Model):
     def write(self, vals):
         res = super().write(vals)
         self._patch_quick_create()
-        if 'avoid_quick_create' in vals:
-            self.pool.signal_registry_change()
+        if "avoid_quick_create" in vals:
+            self.pool.registry_invalidated = True
+            self.pool.signal_changes()
         return res


### PR DESCRIPTION
Adding https://github.com/OCA/server-tools/pull/1454.
I think it has been lost when moving the module across repositories, or maybe has been merged after that because the commit simply does not exist in https://github.com/OCA/server-ux/commits/12.0/base_optional_quick_create but exists in https://github.com/OCA/server-tools/commits/10.0/base_optional_quick_create 