### PR TITLE
[13.0][UPD] base_tier_validation: add notification.

### DIFF
--- a/base_tier_validation/models/tier_definition.py
+++ b/base_tier_validation/models/tier_definition.py
@@ -63,6 +63,16 @@ class TierDefinition(models.Model):
         default=False,
         help="Approval order by the specified sequence number",
     )
+    notify_on_validation = fields.Boolean(
+        string="Notifiy asker on validation",
+        help="If set, user who requests the validation will be notified "
+        "on validation.",
+    )
+    notify_on_reject = fields.Boolean(
+        string="Notifiy asker on reject",
+        help="If set, user who requests the validation will be notified "
+        "when rejected.",
+    )
 
     @api.onchange("review_type")
     def onchange_review_type(self):

--- a/base_tier_validation/views/tier_definition_view.xml
+++ b/base_tier_validation/views/tier_definition_view.xml
@@ -64,6 +64,8 @@
                             />
                             <field name="sequence" />
                             <field name="notify_on_create" />
+                            <field name="notify_on_validation" />
+                            <field name="notify_on_reject" />
                             <field name="has_comment" />
                             <field name="approve_sequence" />
                         </group>


### PR DESCRIPTION
- Add possibility (into tier definition) to notify the asker of review when target is Accepted;
- Add possibility (into tier definition) to notify the asker of review when target is Rejected.


**Bonus:**
Extract params of `message_post(...)` to let others modules to add/edit/remove parameters.

