### PR TITLE
[FIX] date_range: typo in field keyword argument

### DIFF
--- a/date_range/wizard/date_range_generator.py
+++ b/date_range/wizard/date_range_generator.py
@@ -17,7 +17,7 @@ class DateRangeGenerator(models.TransientModel):
         return self.env['res.company']._company_default_get('date.range')
 
     name_prefix = fields.Char('Range name prefix', required=True)
-    date_start = fields.Date(strint='Start date', required=True)
+    date_start = fields.Date(required=True)
     type_id = fields.Many2one(
         comodel_name='date.range.type', string='Type', required=True,
         domain="['|', ('company_id', '=', company_id), "


### PR DESCRIPTION
The dumbest fix you'll see this day.
Still, this is annoying as it generates a WARNING dbname odoo.fields: Field date.range.generator.date_start: unknown parameter 'strint', if this is an actual parameter you may want to override the method _valid_field_parameter on the relevant model in order to allow it