### PR TITLE
[FIX] date_range: typo in field keyword argument

### DIFF
--- a/date_range/wizard/date_range_generator.py
+++ b/date_range/wizard/date_range_generator.py
@@ -17,7 +17,7 @@ class DateRangeGenerator(models.TransientModel):
         return self.env.company
 
     name_prefix = fields.Char("Range name prefix", required=True)
-    date_start = fields.Date(strint="Start date", required=True)
+    date_start = fields.Date(required=True)
     type_id = fields.Many2one(
         comodel_name="date.range.type",
         string="Type",


### PR DESCRIPTION
Forward-port of https://github.com/OCA/server-ux/pull/326.
Already fixed in 14.0