### PR TITLE
[FIX] date_range: make the range selector work

### DIFF
--- a/date_range/static/src/js/date_range.js
+++ b/date_range/static/src/js/date_range.js
@@ -70,13 +70,12 @@ odoo.define("date_range.CustomFilterItem", function (require) {
                         condition.operator
                     ];
                     if (operator.date_range) {
-                        this.date_ranges[operator.date_range_type].forEach((range) => {
-                            if (range.id === ev.target.value) {
-                                const d_start = moment(`${range.date_start} 00:00:00`);
-                                const d_end = moment(`${range.date_end} 23:59:59`);
-                                condition.value = [d_start, d_end];
-                            }
-                        });
+                        const eid = parseInt(ev.target.value);
+                        const ranges = this.date_ranges[operator.date_range_type];
+                        const range = ranges.find((x) => x.id == eid);
+                        const d_start = moment(`${range.date_start} 00:00:00`);
+                        const d_end = moment(`${range.date_end} 23:59:59`);
+                        condition.value = [d_start, d_end];
                     } else {
                         super._onValueInput(...arguments);
                     }


### PR DESCRIPTION
Because ev.target.value is a string and the range ids are integers,
comparison was always false, so the first range values were always used.

Fixes #329 