### PR TITLE
[13.0][IMP] base_tier_validation: support to search for records where validation has not yet started

### DIFF
--- a/base_tier_validation/models/tier_validation.py
+++ b/base_tier_validation/models/tier_validation.py
@@ -114,6 +114,12 @@ class TierValidation(models.AbstractModel):
 
     @api.model
     def _search_reviewer_ids(self, operator, value):
+        model_operator = "in"
+        if operator == "=" and value in ("[]", False):
+            # Search for records that have not yet been through a validation
+            # process.
+            operator = "!="
+            model_operator = "not in"
         reviews = self.env["tier.review"].search(
             [
                 ("model", "=", self._name),
@@ -122,7 +128,7 @@ class TierValidation(models.AbstractModel):
                 ("status", "=", "pending"),
             ]
         )
-        return [("id", "in", list(set(reviews.mapped("res_id"))))]
+        return [("id", model_operator, list(set(reviews.mapped("res_id"))))]
 
     def _compute_validated_rejected(self):
         for rec in self:

--- a/base_tier_validation/tests/test_tier_validation.py
+++ b/base_tier_validation/tests/test_tier_validation.py
@@ -466,3 +466,17 @@ class TierTierValidation(common.SavepointCase):
         self.assertFalse(
             self.test_user_2.with_user(self.test_user_2).review_user_count()
         )
+
+    def test_17_search_records_no_validation(self):
+        """Search for records that have no validation process started"""
+        records = self.env["tier.validation.tester"].search(
+            [("reviewer_ids", "=", False)]
+        )
+        self.assertEquals(len(records), 1)
+        self.test_record.with_user(self.test_user_2.id).request_validation()
+        record = self.test_record.with_user(self.test_user_1.id)
+        record.invalidate_cache()
+        records = self.env["tier.validation.tester"].search(
+            [("reviewer_ids", "=", False)]
+        )
+        self.assertEquals(len(records), 0)


### PR DESCRIPTION
Othewise this filter is not working in https://github.com/OCA/account-invoicing/tree/13.0/account_move_tier_validation

![image](https://user-images.githubusercontent.com/7683926/115228967-b7332e00-a112-11eb-9013-10867b1c76cc.png)

