### PR TITLE
[14.0][FIX] base_tier_validation: External users receive the internal notifications from requested tier validations

### DIFF
--- a/base_tier_validation/data/mail_data.xml
+++ b/base_tier_validation/data/mail_data.xml
@@ -1,6 +1,16 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <odoo noupdate="1">
     <record
+        id="mt_tier_validation_requested"
+        model="mail.message.subtype"
+        forcecreate="1"
+    >
+        <field name="name">Tier Validation Requested</field>
+        <field name="default" eval="True" />
+        <field name="internal" eval="True" />
+        <field name="hidden" eval="True" />
+    </record>
+    <record
         id="mt_tier_validation_accepted"
         model="mail.message.subtype"
         forcecreate="1"

--- a/base_tier_validation/models/tier_validation.py
+++ b/base_tier_validation/models/tier_validation.py
@@ -242,6 +242,9 @@ class TierValidation(models.AbstractModel):
             rec = self.env[review.model].browse(review.res_id)
             rec._notify_accepted_reviews()
 
+    def _get_requested_notification_subtype(self):
+        return "base_tier_validation.mt_tier_validation_requested"
+
     def _get_accepted_notification_subtype(self):
         return "base_tier_validation.mt_tier_validation_accepted"
 
@@ -355,7 +358,7 @@ class TierValidation(models.AbstractModel):
                     partner_ids=users_to_notify.mapped("partner_id").ids
                 )
                 getattr(rec, post)(
-                    subtype_xmlid="mail.mt_comment",
+                    subtype_xmlid=self._get_requested_notification_subtype(),
                     body=rec._notify_requested_review_body(),
                 )
 


### PR DESCRIPTION
TT29001

Forward port of https://github.com/OCA/server-ux/pull/330.

@ForgeFlow