### PR TITLE
[13.0][IMP] base_tier_validation: comment on rejection

### DIFF
--- a/base_tier_validation/__manifest__.py
+++ b/base_tier_validation/__manifest__.py
@@ -3,7 +3,7 @@
 {
     "name": "Base Tier Validation",
     "summary": "Implement a validation process based on tiers.",
-    "version": "13.0.1.5.0",
+    "version": "13.0.1.6.0",
     "development_status": "Mature",
     "maintainers": ["LoisRForgeFlow"],
     "category": "Tools",

--- a/base_tier_validation/migrations/13.0.1.6.0/post-migration.py
+++ b/base_tier_validation/migrations/13.0.1.6.0/post-migration.py
@@ -1,0 +1,23 @@
+# Copyright 2021 ForgeFlow, S.L. (<https://wwww.forgeflow.com>)
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
+from openupgradelib import openupgrade  # pylint: disable=W7936
+
+_options = [
+    (True, "all"),
+    (False, "none"),
+]
+
+
+def map_tier_definition_comment_option(env):
+    openupgrade.map_values(
+        env.cr,
+        openupgrade.get_legacy_name("has_comment"),
+        "comment_option",
+        _options,
+        table="tier_definition",
+    )
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    map_tier_definition_comment_option(env)

--- a/base_tier_validation/migrations/13.0.1.6.0/pre-migration.py
+++ b/base_tier_validation/migrations/13.0.1.6.0/pre-migration.py
@@ -1,0 +1,12 @@
+# Copyright 2021 ForgeFlow, S.L. (<https://wwww.forgeflow.com>)
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
+from openupgradelib import openupgrade
+
+_column_renames = {
+    "tier_definition": [("has_comment", None)],
+}
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    openupgrade.rename_columns(env.cr, _column_renames)

--- a/base_tier_validation/models/tier_definition.py
+++ b/base_tier_validation/models/tier_definition.py
@@ -57,11 +57,15 @@ class TierDefinition(models.Model):
         help="If set, all possible reviewers will be notified by email when "
         "this definition is triggered.",
     )
-    has_comment = fields.Boolean(string="Comment", default=False)
     comment_option = fields.Selection(
-        [("all", "Both Validation & Rejection"),
-         ("validate", "Validation Only"),
-         ("reject", "Rejection Only")], string="Comment only on rejection", default='all',
+        [
+            ("none", "No Comment"),
+            ("all", "Both Validation & Rejection"),
+            ("validate", "Validation Only"),
+            ("reject", "Rejection Only"),
+        ],
+        string="Comment after review",
+        default="none",
     )
     approve_sequence = fields.Boolean(
         string="Approve by sequence",

--- a/base_tier_validation/models/tier_definition.py
+++ b/base_tier_validation/models/tier_definition.py
@@ -58,8 +58,10 @@ class TierDefinition(models.Model):
         "this definition is triggered.",
     )
     has_comment = fields.Boolean(string="Comment", default=False)
-    comment_on_rejection = fields.Boolean(
-        string="Comment only on rejection", default=False
+    comment_option = fields.Selection(
+        [("all", "Both Validation & Rejection"),
+         ("validate", "Validation Only"),
+         ("reject", "Rejection Only")], string="Comment only on rejection", default='all',
     )
     approve_sequence = fields.Boolean(
         string="Approve by sequence",

--- a/base_tier_validation/models/tier_definition.py
+++ b/base_tier_validation/models/tier_definition.py
@@ -58,6 +58,9 @@ class TierDefinition(models.Model):
         "this definition is triggered.",
     )
     has_comment = fields.Boolean(string="Comment", default=False)
+    comment_on_rejection = fields.Boolean(
+        string="Comment only on rejection", default=False
+    )
     approve_sequence = fields.Boolean(
         string="Approve by sequence",
         default=False,

--- a/base_tier_validation/models/tier_review.py
+++ b/base_tier_validation/models/tier_review.py
@@ -37,7 +37,6 @@ class TierReview(models.Model):
     done_by = fields.Many2one(comodel_name="res.users")
     requested_by = fields.Many2one(comodel_name="res.users")
     reviewed_date = fields.Datetime(string="Validation Date")
-    has_comment = fields.Boolean(related="definition_id.has_comment", readonly=True)
     comment_option = fields.Selection(
         related="definition_id.comment_option", readonly=True
     )

--- a/base_tier_validation/models/tier_review.py
+++ b/base_tier_validation/models/tier_review.py
@@ -38,6 +38,9 @@ class TierReview(models.Model):
     requested_by = fields.Many2one(comodel_name="res.users")
     reviewed_date = fields.Datetime(string="Validation Date")
     has_comment = fields.Boolean(related="definition_id.has_comment", readonly=True)
+    comment_on_rejection = fields.Boolean(
+        related="definition_id.comment_on_rejection", readonly=True
+    )
     comment = fields.Char(string="Comments")
     can_review = fields.Boolean(
         compute="_compute_can_review",

--- a/base_tier_validation/models/tier_review.py
+++ b/base_tier_validation/models/tier_review.py
@@ -38,8 +38,8 @@ class TierReview(models.Model):
     requested_by = fields.Many2one(comodel_name="res.users")
     reviewed_date = fields.Datetime(string="Validation Date")
     has_comment = fields.Boolean(related="definition_id.has_comment", readonly=True)
-    comment_on_rejection = fields.Boolean(
-        related="definition_id.comment_on_rejection", readonly=True
+    comment_option = fields.Selection(
+        related="definition_id.comment_option", readonly=True
     )
     comment = fields.Char(string="Comments")
     can_review = fields.Boolean(

--- a/base_tier_validation/readme/HISTORY.rst
+++ b/base_tier_validation/readme/HISTORY.rst
@@ -1,3 +1,12 @@
+13.0.1.2.3 (2021-05-04)
+~~~~~~~~~~~~~~~~~~~~~~~
+
+New features:
+
+- Add the possibility to request feedback after validation only when a tier
+  validation has been rejected. The tier.definition now has a boolean
+  'comment_on_rejection'.
+
 13.0.1.2.2 (2020-08-30)
 ~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/base_tier_validation/readme/HISTORY.rst
+++ b/base_tier_validation/readme/HISTORY.rst
@@ -1,11 +1,10 @@
-13.0.1.2.3 (2021-05-04)
+13.0.1.6.0 (2021-05-04)
 ~~~~~~~~~~~~~~~~~~~~~~~
 
 New features:
 
-- Add the possibility to request feedback after validation only when a tier
-  validation has been rejected. The tier.definition now has a boolean
-  'comment_on_rejection'.
+- Allow to specify in the tier definition if you want to add a comment ony on
+  rejection, only on approval, always or never.
 
 13.0.1.2.2 (2020-08-30)
 ~~~~~~~~~~~~~~~~~~~~~~~

--- a/base_tier_validation/tests/test_tier_validation.py
+++ b/base_tier_validation/tests/test_tier_validation.py
@@ -484,17 +484,9 @@ class TierTierValidation(common.SavepointCase):
     def test_18_no_comment_on_approve(self):
         # Create new test record
         test_record = self.test_model.create({"test_field": 2.5})
-        # Create tier definitions
-        self.tier_def_obj.create(
-            {
-                "model_id": self.tester_model.id,
-                "review_type": "individual",
-                "reviewer_id": self.test_user_1.id,
-                "definition_domain": "[('test_field', '>', 1.0)]",
-                "has_comment": True,
-                "comment_on_rejection": True,
-            }
-        )
+        # Update all definitions to request commend only on reject
+        definitions = self.env['tier.definition'].search([])
+        definitions.write({'comment_option': 'reject'})
         # Request validation
         review = test_record.with_user(self.test_user_2.id).request_validation()
         self.assertTrue(review)

--- a/base_tier_validation/tests/test_tier_validation.py
+++ b/base_tier_validation/tests/test_tier_validation.py
@@ -485,8 +485,8 @@ class TierTierValidation(common.SavepointCase):
         # Create new test record
         test_record = self.test_model.create({"test_field": 2.5})
         # Update all definitions to request commend only on reject
-        definitions = self.env['tier.definition'].search([])
-        definitions.write({'comment_option': 'reject'})
+        definitions = self.env["tier.definition"].search([])
+        definitions.write({"comment_option": "reject"})
         # Request validation
         review = test_record.with_user(self.test_user_2.id).request_validation()
         self.assertTrue(review)

--- a/base_tier_validation/views/tier_definition_view.xml
+++ b/base_tier_validation/views/tier_definition_view.xml
@@ -66,7 +66,7 @@
                             <field name="notify_on_create" />
                             <field name="has_comment" />
                             <field
-                                name="comment_on_rejection"
+                                name="comment_option"
                                 attrs="{'invisible': [('has_comment', '=', False)]}"
                             />
                             <field name="approve_sequence" />

--- a/base_tier_validation/views/tier_definition_view.xml
+++ b/base_tier_validation/views/tier_definition_view.xml
@@ -65,6 +65,10 @@
                             <field name="sequence" />
                             <field name="notify_on_create" />
                             <field name="has_comment" />
+                            <field
+                                name="comment_on_rejection"
+                                attrs="{'invisible': [('has_comment', '=', False)]}"
+                            />
                             <field name="approve_sequence" />
                         </group>
                     </group>

--- a/base_tier_validation/views/tier_definition_view.xml
+++ b/base_tier_validation/views/tier_definition_view.xml
@@ -64,11 +64,7 @@
                             />
                             <field name="sequence" />
                             <field name="notify_on_create" />
-                            <field name="has_comment" />
-                            <field
-                                name="comment_option"
-                                attrs="{'invisible': [('has_comment', '=', False)]}"
-                            />
+                            <field name="comment_option" />
                             <field name="approve_sequence" />
                         </group>
                     </group>

--- a/base_tier_validation_forward/hooks.py
+++ b/base_tier_validation_forward/hooks.py
@@ -15,5 +15,4 @@ def uninstall_hook(cr, registry):
     cr.execute("alter table tier_review drop column review_type cascade;")
     cr.execute("alter table tier_review drop column reviewer_id cascade;")
     cr.execute("alter table tier_review drop column reviewer_group_id cascade;")
-    cr.execute("alter table tier_review drop column has_comment cascade;")
     cr.execute("alter table tier_review drop column approve_sequence cascade;")

--- a/base_tier_validation_forward/models/tier_review.py
+++ b/base_tier_validation_forward/models/tier_review.py
@@ -25,19 +25,19 @@ class TierReview(models.Model):
         readonly=False,
     )
     sequence = fields.Float()
-    has_comment = fields.Boolean(
-        compute="_compute_definition_data", store=True, readonly=False,
-    )
     approve_sequence = fields.Boolean(
         compute="_compute_definition_data", store=True, readonly=False,
+    )
+    comment_option = fields.Selection(
+        related="definition_id.comment_option", readonly=True
     )
 
     @api.depends(
         "definition_id.name",
         "definition_id.review_type",
         "definition_id.reviewer_id",
+        "definition_id.comment_option",
         "definition_id.reviewer_group_id",
-        "definition_id.has_comment",
         "definition_id.approve_sequence",
     )
     def _compute_definition_data(self):
@@ -46,5 +46,5 @@ class TierReview(models.Model):
             rec.review_type = rec.definition_id.review_type
             rec.reviewer_id = rec.definition_id.reviewer_id
             rec.reviewer_group_id = rec.definition_id.reviewer_group_id
-            rec.has_comment = rec.definition_id.has_comment
             rec.approve_sequence = rec.definition_id.approve_sequence
+            rec.comment_option = rec.definition_id.comment_option

--- a/base_tier_validation_forward/wizard/forward_wizard.py
+++ b/base_tier_validation_forward/wizard/forward_wizard.py
@@ -13,8 +13,14 @@ class ValidationForwardWizard(models.TransientModel):
         comodel_name="res.users", string="Next Reviewer", required=True,
     )
     forward_description = fields.Char()
-    has_comment = fields.Boolean(string="Allow Comment", default=True)
     approve_sequence = fields.Boolean(string="Approve by sequence", default=True,)
+    comment_option = fields.Selection(
+        string="Comment after review",
+        default="none",
+        selection=lambda self: self.env["tier.definition"]
+        ._columns["comment_option"]
+        .selection,
+    )
 
     def add_forward(self):
         """ Add extra step, with specific reviewer """
@@ -36,8 +42,8 @@ class ValidationForwardWizard(models.TransientModel):
                 "requested_by": self.env.uid,
                 "review_type": "individual",
                 "reviewer_id": self.forward_reviewer_id.id,
-                "has_comment": self.has_comment,
                 "approve_sequence": self.approve_sequence,
+                "comment_option": self.comment_option,
             }
         )
         rec.invalidate_cache()

--- a/base_tier_validation_forward/wizard/forward_wizard_view.xml
+++ b/base_tier_validation_forward/wizard/forward_wizard_view.xml
@@ -14,7 +14,7 @@
                         <field name="forward_description" required="1" />
                     </group>
                     <group>
-                        <field name="has_comment" invisible="1" />
+                        <field name="comment_option" />
                         <field name="approve_sequence" invisible="1" />
                     </group>
                 </group>


### PR DESCRIPTION
Add the possibility to request feedback after validation only when a tier
validation has been rejected. The tier.definition now has a boolean
'comment_on_rejection'.

![image](https://user-images.githubusercontent.com/7683926/116960550-0778c700-aca1-11eb-9485-8e071c1e04f0.png)

@ForgeFlow @GenisPForgeFlow