### PR TITLE
[13.0][FIX] base_substate: Fix archived button

### DIFF
--- a/base_substate/views/base_substate_views.xml
+++ b/base_substate/views/base_substate_views.xml
@@ -19,16 +19,14 @@
         <field name="arch" type="xml">
             <form string="Base Substate" name="base_substate">
                 <sheet>
-                    <div class="oe_button_box" name="button_box">
-                        <button
-                            name="toggle_active"
-                            type="object"
-                            class="oe_stat_button"
-                            icon="fa-archive"
-                        >
-                            <field name="active" widget="boolean_button" />
-                        </button>
-                    </div>
+                    <div class="oe_button_box" name="button_box" />
+                    <widget
+                        name="web_ribbon"
+                        title="Archived"
+                        bg_color="bg-danger"
+                        attrs="{'invisible': [('active', '=', True)]}"
+                    />
+                    <field name="active" invisible="1" />
                     <div class="oe_title">
                         <label for="name" class="oe_edit_only" />
                         <h1>


### PR DESCRIPTION
Archived button no show icon, I remove this and archived by `Action > Archive` the document will show red ribbon "ARCHIVED" on top right corner.
![Selection_462](https://user-images.githubusercontent.com/24691983/117531837-c10fc900-b00e-11eb-8bc2-03a007460b36.png)
![Selection_463](https://user-images.githubusercontent.com/24691983/117531866-e997c300-b00e-11eb-85d0-e78cb537e5a9.png)
