### PR TITLE
[13.0][IMP] base_tier_validation: Remove tier review when model state goes to cancel

### DIFF
--- a/base_tier_validation/models/tier_validation.py
+++ b/base_tier_validation/models/tier_validation.py
@@ -211,7 +211,7 @@ class TierValidation(models.AbstractModel):
                 and not self._check_allow_write_under_validation(vals)
             ):
                 raise ValidationError(_("The operation is under validation."))
-        if vals.get(self._state_field) in self._state_from:
+        if vals.get(self._state_field) in (self._state_from + [self._cancel_state]):
             self.mapped("review_ids").unlink()
         return super(TierValidation, self).write(vals)
 


### PR DESCRIPTION
If I have a review for a sale order and user cancel it for ever the review is pendig for ever.

cc @Tecnativa TT29643
ping @chienandalu @CarlosRoca13 