### PR TITLE
[14.0][FIX] base_cancel_confirm: No duplicate cancel confirm and cancel reason

### DIFF
--- a/base_cancel_confirm/model/base_cancel_confirm.py
+++ b/base_cancel_confirm/model/base_cancel_confirm.py
@@ -16,10 +16,12 @@ class BaseCancelConfirm(models.AbstractModel):
 
     cancel_confirm = fields.Boolean(
         string="Cancel Confirmed",
+        copy=False,
         help="A flag signify that this document is confirmed for cancellation",
     )
     cancel_reason = fields.Text(
         string="Cancel Reason",
+        copy=False,
         help="An optional cancel reason",
     )
 


### PR DESCRIPTION
This is a small fix, can be FFW.