### PR TITLE
[13.0][FIX] base_tier_validation: invalid review_user_count()

### DIFF
--- a/base_tier_validation/models/res_users.py
+++ b/base_tier_validation/models/res_users.py
@@ -26,7 +26,12 @@ class Users(models.Model):
                 .with_user(self.env.user)
                 .search([("id", "=", review.res_id)])
             )
-            if not record or record.rejected or not record.can_review:
+            if (
+                not record
+                or record.rejected
+                or not record.can_review
+                or not record.need_validation
+            ):
                 # Checking that the review is accessible with the permissions
                 # and to review condition is valid
                 continue

--- a/base_tier_validation/tests/test_tier_validation.py
+++ b/base_tier_validation/tests/test_tier_validation.py
@@ -422,10 +422,12 @@ class TierTierValidation(common.SavepointCase):
         self.assertTrue(self.test_user_1.get_reviews({"res_ids": review.ids}))
         self.assertTrue(self.test_user_1.review_ids)
         test_record.invalidate_cache()
+        self.assertFalse(test_record.can_review)
         self.assertTrue(test_record.review_ids)
+        self.assertFalse(test_record.need_validation)
         # Used by front-end
         count = self.test_user_1.with_user(self.test_user_1).review_user_count()
-        self.assertEqual(len(count), 1)
+        self.assertEqual(len(count), 0)
         # False Review
         self.assertFalse(self.test_record._calc_reviews_validated(False))
         self.assertIn("requested", self.test_record._notify_requested_review_body())
@@ -449,10 +451,11 @@ class TierTierValidation(common.SavepointCase):
         record1 = test_record.with_user(self.test_user_1)
         record1.invalidate_cache()
         self.assertTrue(record1.can_review)
-        self.assertTrue(
+        self.assertFalse(record1.need_validation)
+        self.assertFalse(
             self.test_user_1.with_user(self.test_user_1).review_user_count()
         )
-        self.assertTrue(
+        self.assertFalse(
             self.test_user_2.with_user(self.test_user_2).review_user_count()
         )
         # user 1 reject first tier


### PR DESCRIPTION
In some case, when the validation process is not really well processed (user click on standard 'cancel' button instead of 'reject', link between the record and reviewers still present and it's counted into the total of pending review instead of ignored them.

**How to reproduce:**
Just create a validation process on `purchase.order`.
Instead of validate the PO, click on the cancel button.
The user still have 1 PO to review (the review that we just cancel). If you click on the button, you'll be redirect to an empty PO tree view as the PO has been cancelled before.

**The fix:**
Now with the fix, PO (or others records) without validation needed are ignored