### PR TITLE
[13.0][IMP] mass_editing: improvement to apply update

### DIFF
--- a/mass_editing/wizard/mass_editing_wizard.py
+++ b/mass_editing/wizard/mass_editing_wizard.py
@@ -3,13 +3,19 @@
 
 from lxml import etree
 
-from odoo import _, api, models
+from odoo import _, api, fields, models
 
 
 class MassEditingWizard(models.TransientModel):
     _name = "mass.editing.wizard"
     _inherit = "mass.operation.wizard.mixin"
     _description = "Wizard for mass edition"
+
+    use_active_domain = fields.Boolean(
+        string="Search results",
+        help="Thick if you want to use the custom domain (+ domain of the "
+        "mass edition) instead of select all items manually.",
+    )
 
     @api.model
     def _prepare_fields(self, line, field, field_info):
@@ -100,14 +106,34 @@ class MassEditingWizard(models.TransientModel):
         field_info["domain"] = "[]"
         return field_info
 
-    @api.model
-    def create(self, vals):
+    @api.model_create_multi
+    def create(self, list_vals):
+        wizards = self.browse()
+        for vals in list_vals:
+            # Split values to extract values from the current wizard and
+            # values used to update target records.
+            wizard_vals = {k: vals.get(k) for k in vals.keys() if k in self._fields}
+            edition_vals = {k: vals.get(k) for k in vals.keys() if k not in wizard_vals}
+            wizard = super().create(wizard_vals)
+            wizards |= wizard
+            if not edition_vals:
+                continue
+            wizard._update_items(edition_vals)
+        return wizards
+
+    def _update_items(self, vals):
+        """
+
+        :param vals: dict
+        :return: None
+        """
+        self.ensure_one()
         mass_editing = self._get_mass_operation()
-        active_ids = self.env.context.get("active_ids", [])
-        if active_ids:
-            TargetModel = self.env[mass_editing.model_id.model]
+        items = self._get_remaining_items(force_active_domain=self.use_active_domain)
+        if items:
             IrModelFields = self.env["ir.model.fields"]
             IrTranslation = self.env["ir.translation"]
+            active_ids = items.ids
 
             values = {}
             for key, val in vals.items():
@@ -122,10 +148,7 @@ class MassEditingWizard(models.TransientModel):
                         # If field to remove is translatable,
                         # its translations have to be removed
                         model_field = IrModelFields.search(
-                            [
-                                ("model", "=", mass_editing.model_id.model),
-                                ("name", "=", split_key),
-                            ]
+                            [("model", "=", items._name), ("name", "=", split_key)]
                         )
                         if model_field and model_field.translate:
                             translations = IrTranslation.search(
@@ -159,8 +182,7 @@ class MassEditingWizard(models.TransientModel):
                             m2m_list.append((4, m2m_id))
                         values.update({split_key: m2m_list})
             if values:
-                TargetModel.browse(active_ids).write(values)
-        return super().create({})
+                items.write(values)
 
     def read(self, fields, load="_classic_read"):
         """ Without this call, dynamic fields build by fields_view_get()

--- a/mass_editing/wizard/view_mass_editing_wizard.xml
+++ b/mass_editing/wizard/view_mass_editing_wizard.xml
@@ -13,6 +13,14 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
         />
         <field name="mode">primary</field>
         <field name="arch" type="xml">
+            <xpath expr="//group[@name='custom_info']" position="before">
+                <group>
+                    <group>
+                        <field name="use_active_domain" />
+                    </group>
+                    <group />
+                </group>
+            </xpath>
             <xpath expr="//group[@name='custom_info']" position="inside">
                 <group name="group_field_list" colspan="4" col="6">
                 </group>


### PR DESCRIPTION
**Improvements:**
- mass_operation_abstract: let the possibility to use the `active_domain` (instead of always `active_ids`);
- mass_edition unit test: disable tracking (minor improvement);
- mass_edition code: split the update of target recordset into a new function to have an inherit point;
- mass_edition code: split the create to avoid mix values of the wizard and values of target records.

**Why using active_domain?**
In some case, when you select all items (the dedicated select-box item), Odoo fill `active_ids` with only the 80 items displayed into the tree view (even if you have thousands of records). And sometimes it's not possible to display all of them because there is too much records.