### PR TITLE
[12.0] FIX date_range Expected singleton while using advanced filter

### DIFF
--- a/date_range/static/src/js/date_range.js
+++ b/date_range/static/src/js/date_range.js
@@ -100,19 +100,22 @@ class
         on_range_selected: function (e) {
             var self = this;
             self.domain = '';
-            framework.blockUI();
-            return rpc.query({
-                args: [this.get_value()],
-                kwargs: {
-                    field_name: this.field.name,
-                },
-                model: 'date.range',
-                method: 'get_domain',
-            })
-                .then(function (domain) {
-                    framework.unblockUI();
-                    self.domain = domain;
-                });
+            var value = this.get_value();
+            if (value) {
+                framework.blockUI();
+                return rpc.query({
+                    args: [this.get_value()],
+                    kwargs: {
+                        field_name: this.field.name,
+                    },
+                    model: 'date.range',
+                    method: 'get_domain',
+                })
+                    .then(function (domain) {
+                        framework.unblockUI();
+                        self.domain = domain;
+                    });
+            }
         },
 
         get_domain: function (field, operator) {


### PR DESCRIPTION
Steps:

 - Create a new DB
 - Install date_range and account
 - Go to customer invoices and add an advanced filter on "invoice date" selecting "in month"

Get

```
  server-ux/date_range/models/date_range.py", line 91, in get_domain
    self.ensure_one()
  odoo/odoo/models.py", line 4768, in ensure_one
    raise ValueError("Expected singleton: %s" % self)
```