### PR TITLE
[14.0][IMP] base_tier_validation_server_action, use write to trigger action

### DIFF
--- a/base_tier_validation_server_action/models/tier_review.py
+++ b/base_tier_validation_server_action/models/tier_review.py
@@ -1,20 +1,24 @@
 # Copyright 2020 Ecosoft (http://ecosoft.co.th)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
-from odoo import api, models
+from odoo import models
 
 
 class TierReview(models.Model):
     _inherit = "tier.review"
 
-    @api.constrains("status")
-    def _trigger_server_action(self):
-        for rec in self.filtered(lambda l: l.status in ["approved", "rejected"]):
-            server_action = False
-            if rec.status == "approved":
-                server_action = rec.definition_id.server_action_id
-            if rec.status == "rejected":
-                server_action = rec.definition_id.rejected_server_action_id
-            if server_action:
-                ctx = {"active_model": rec.model, "active_id": rec.res_id}
-                server_action.with_context(ctx).run()
+    def write(self, vals):
+        res = super().write(vals)
+        if vals.get("status") in ["approved", "rejected"]:
+            for rec in self:
+                server_action = False
+                if rec.status == "approved":
+                    server_action = rec.definition_id.server_action_id
+                if rec.status == "rejected":
+                    server_action = rec.definition_id.rejected_server_action_id
+                if server_action:
+                    server_action.with_context(
+                        active_model=rec.model,
+                        active_id=rec.res_id,
+                    ).sudo().run()
+        return res


### PR DESCRIPTION
By using write() instead of @api.depends, it is better to accept context value for some situation.

This can be FFW.