### PR TITLE
[14.0][IMP] base_tier_validation, use sudo to post message

### DIFF
--- a/base_tier_validation/models/tier_validation.py
+++ b/base_tier_validation/models/tier_validation.py
@@ -255,7 +255,7 @@ class TierValidation(models.AbstractModel):
         post = "message_post"
         if hasattr(self, post):
             # Notify state change
-            getattr(self, post)(
+            getattr(self.sudo(), post)(
                 subtype_xmlid=self._get_accepted_notification_subtype(),
                 body=self._notify_accepted_reviews_body(),
             )
@@ -320,7 +320,7 @@ class TierValidation(models.AbstractModel):
         post = "message_post"
         if hasattr(self, post):
             # Notify state change
-            getattr(self, post)(
+            getattr(self.sudo(), post)(
                 subtype_xmlid=self._get_rejected_notification_subtype(),
                 body=self._notify_rejected_review_body(),
             )


### PR DESCRIPTION
We face problem for case when user has only readonly access to document, he still can't validate because after that it will post message to chatter (write access).

This PR resolve it by sudo()

@JordiBForgeFlow @LoisRForgeFlow do you think this can be FFW?