### PR TITLE
[14.0][ADD] sequence_range_end_buddhist_calendar

### DIFF
--- a/sequence_range_end_buddhist_calendar/__init__.py
+++ b/sequence_range_end_buddhist_calendar/__init__.py
@@ -1,0 +1,3 @@
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from . import models

--- a/sequence_range_end_buddhist_calendar/__manifest__.py
+++ b/sequence_range_end_buddhist_calendar/__manifest__.py
@@ -1,0 +1,16 @@
+# Copyright 2021 Ecosoft Co., Ltd. (http://ecosoft.co.th)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+{
+    "name": "Sequence Range End (Buddhist Calendar)",
+    "summary": "Add option 'Use B.E.' to change year from A.D. to B.E.",
+    "version": "14.0.1.0.0",
+    "category": "Usability",
+    "website": "https://github.com/OCA/server-ux",
+    "author": "Ecosoft, Odoo Community Association (OCA)",
+    "license": "AGPL-3",
+    "depends": ["sequence_range_end"],
+    "data": ["views/ir_sequence_views.xml"],
+    "installable": True,
+    "maintainers": ["newtratip"],
+}

--- a/sequence_range_end_buddhist_calendar/models/__init__.py
+++ b/sequence_range_end_buddhist_calendar/models/__init__.py
@@ -1,0 +1,3 @@
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from . import ir_sequence

--- a/sequence_range_end_buddhist_calendar/models/ir_sequence.py
+++ b/sequence_range_end_buddhist_calendar/models/ir_sequence.py
@@ -1,0 +1,22 @@
+# Copyright 2021 Ecosoft Co., Ltd. (http://ecosoft.co.th)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from dateutil.relativedelta import relativedelta
+
+from odoo import fields, models
+
+
+class IrSequence(models.Model):
+    _inherit = "ir.sequence"
+
+    use_be = fields.Boolean(
+        string="Use B.E.",
+        default=False,
+    )
+
+    def _get_prefix_suffix_range_end(self, date_range=None):
+        context = self.env.context.copy()
+        if self.use_be and context.get("ir_sequence_date_range_end"):
+            context["ir_sequence_date_range_end"] += relativedelta(years=+543)
+        self = self.with_context(context)
+        return super()._get_prefix_suffix_range_end(date_range=date_range)

--- a/sequence_range_end_buddhist_calendar/readme/CONTRIBUTORS.rst
+++ b/sequence_range_end_buddhist_calendar/readme/CONTRIBUTORS.rst
@@ -1,0 +1,1 @@
+* Tharathip Chaweewongphan <tharathipc@ecosoft.co.th>

--- a/sequence_range_end_buddhist_calendar/readme/DESCRIPTION.rst
+++ b/sequence_range_end_buddhist_calendar/readme/DESCRIPTION.rst
@@ -1,0 +1,1 @@
+When select option Use B.E., year in prefix / suffix will change from Anno Domini (A.D.) to Buddhist Calendar (B.E.)

--- a/sequence_range_end_buddhist_calendar/views/ir_sequence_views.xml
+++ b/sequence_range_end_buddhist_calendar/views/ir_sequence_views.xml
@@ -1,0 +1,15 @@
+<odoo>
+    <record id="sequence_view" model="ir.ui.view">
+        <field name="name">ir.sequence form</field>
+        <field name="model">ir.sequence</field>
+        <field name="inherit_id" ref="base.sequence_view" />
+        <field name="arch" type="xml">
+            <field name="use_date_range" position="after">
+                <field
+                    name="use_be"
+                    attrs="{'invisible': [('use_date_range', '=', False)]}"
+                />
+            </field>
+        </field>
+    </record>
+</odoo>

--- a/setup/sequence_range_end_buddhist_calendar/odoo/addons/sequence_range_end_buddhist_calendar
+++ b/setup/sequence_range_end_buddhist_calendar/odoo/addons/sequence_range_end_buddhist_calendar
@@ -1,0 +1,1 @@
+../../../../sequence_range_end_buddhist_calendar

--- a/setup/sequence_range_end_buddhist_calendar/setup.py
+++ b/setup/sequence_range_end_buddhist_calendar/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
This module is change year of sequence number from A.D. to B.E.

When select option Use B.E., year in prefix / suffix will change from Anno Domini (A.D.) to Buddhist Calendar (B.E.)

Depend on sequence_range_end module https://github.com/OCA/server-ux/pull/361

cc: @kittiu 