### PR TITLE
[12.0][IMP] base_tier_validation: add new review type

### DIFF
--- a/base_tier_validation/models/tier_definition.py
+++ b/base_tier_validation/models/tier_definition.py
@@ -34,14 +34,23 @@ class TierDefinition(models.Model):
         string="Validated by", default="individual",
         selection=[
             ("individual", "Specific user"),
-            ("group", "Any user in a specific group."),
-        ]
+            ("group", "Any user in a specific group"),
+            ("field", "Field in related record")
+        ],
     )
     reviewer_id = fields.Many2one(
         comodel_name="res.users", string="Reviewer",
     )
     reviewer_group_id = fields.Many2one(
         comodel_name="res.groups", string="Reviewer group",
+    )
+    reviewer_field_id = fields.Many2one(
+        comodel_name="ir.model.fields", string="Reviewer field",
+        domain="[('id', 'in', valid_reviewer_field_ids)]",
+    )
+    valid_reviewer_field_ids = fields.One2many(
+        comodel_name="ir.model.fields",
+        compute="_compute_domain_reviewer_field",
     )
     definition_type = fields.Selection(
         string="Definition",
@@ -83,3 +92,9 @@ class TierDefinition(models.Model):
     def onchange_review_type(self):
         self.reviewer_id = None
         self.reviewer_group_id = None
+
+    @api.depends("review_type", "model_id")
+    def _compute_domain_reviewer_field(self):
+        for rec in self:
+            rec.valid_reviewer_field_ids = self.env["ir.model.fields"].search(
+                [("model", "=", rec.model), ("relation", "=", "res.users")])

--- a/base_tier_validation/models/tier_review.py
+++ b/base_tier_validation/models/tier_review.py
@@ -2,6 +2,7 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 from odoo import _, api, fields, models
+from odoo.exceptions import ValidationError
 
 
 class TierReview(models.Model):
@@ -28,6 +29,9 @@ class TierReview(models.Model):
     )
     reviewer_group_id = fields.Many2one(
         related="definition_id.reviewer_group_id", readonly=True,
+    )
+    reviewer_field_id = fields.Many2one(
+        related="definition_id.reviewer_field_id", readonly=True
     )
     reviewer_ids = fields.Many2many(
         string="Reviewers", comodel_name="res.users",
@@ -112,4 +116,12 @@ class TierReview(models.Model):
             rec.todo_by = todo_by
 
     def _get_reviewers(self):
-        return self.reviewer_id + self.reviewer_group_id.users
+        if self.reviewer_id or self.reviewer_group_id.users:
+            return self.reviewer_id + self.reviewer_group_id.users
+        reviewer_field = self.env["res.users"]
+        if self.reviewer_field_id:
+            resource = self.env[self.model].browse(self.res_id)
+            reviewer_field = getattr(resource, self.reviewer_field_id.name, False)
+            if not reviewer_field or not reviewer_field._name == "res.users":
+                raise ValidationError(_("There are no res.users in the selected field"))
+        return reviewer_field

--- a/base_tier_validation/views/tier_definition_view.xml
+++ b/base_tier_validation/views/tier_definition_view.xml
@@ -13,6 +13,7 @@
                 <field name="review_type"/>
                 <field name="reviewer_id"/>
                 <field name="reviewer_group_id"/>
+                <field name="reviewer_field_id" />
                 <field name="sequence"/>
                 <field name="company_id" groups="base.group_multi_company"/>
                 <field name="active"/>
@@ -49,6 +50,11 @@
                                    attrs="{'invisible': [('review_type', '!=', 'individual')]}"/>
                             <field name="reviewer_group_id"
                                    attrs="{'invisible': [('review_type', '!=', 'group')]}"/>
+                            <field name="reviewer_field_id"
+                                attrs="{'invisible': [('review_type', '!=', 'field')]}"
+                                options="{'no_create': True}"
+                            />
+                            <field name="valid_reviewer_field_ids" invisible="1" />
                         </group>
                         <group name="right">
                             <field name="company_id"


### PR DESCRIPTION
Add a review type based on a res.users field in the tier definition.
Backport of https://github.com/OCA/server-ux/pull/371
cc @LoisRForgeFlow