### PR TITLE
[14.0][IMP] base_tier_validation: add new review type

### DIFF
--- a/base_tier_validation/models/tier_definition.py
+++ b/base_tier_validation/models/tier_definition.py
@@ -34,12 +34,22 @@ class TierDefinition(models.Model):
         default="individual",
         selection=[
             ("individual", "Specific user"),
-            ("group", "Any user in a specific group."),
+            ("group", "Any user in a specific group"),
+            ("field", "Field in related record"),
         ],
     )
     reviewer_id = fields.Many2one(comodel_name="res.users", string="Reviewer")
     reviewer_group_id = fields.Many2one(
         comodel_name="res.groups", string="Reviewer group"
+    )
+    reviewer_field_id = fields.Many2one(
+        comodel_name="ir.model.fields",
+        string="Reviewer field",
+        domain="[('id', 'in', valid_reviewer_field_ids)]",
+    )
+    valid_reviewer_field_ids = fields.One2many(
+        comodel_name="ir.model.fields",
+        compute="_compute_domain_reviewer_field",
     )
     definition_type = fields.Selection(
         string="Definition", selection=[("domain", "Domain")], default="domain"
@@ -68,3 +78,10 @@ class TierDefinition(models.Model):
     def onchange_review_type(self):
         self.reviewer_id = None
         self.reviewer_group_id = None
+
+    @api.depends("review_type", "model_id")
+    def _compute_domain_reviewer_field(self):
+        for rec in self:
+            rec.valid_reviewer_field_ids = self.env["ir.model.fields"].search(
+                [("model", "=", rec.model), ("relation", "=", "res.users")]
+            )

--- a/base_tier_validation/models/tier_review.py
+++ b/base_tier_validation/models/tier_review.py
@@ -2,6 +2,7 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 from odoo import _, api, fields, models
+from odoo.exceptions import ValidationError
 
 
 class TierReview(models.Model):
@@ -28,6 +29,9 @@ class TierReview(models.Model):
     reviewer_id = fields.Many2one(related="definition_id.reviewer_id", readonly=True)
     reviewer_group_id = fields.Many2one(
         related="definition_id.reviewer_group_id", readonly=True
+    )
+    reviewer_field_id = fields.Many2one(
+        related="definition_id.reviewer_field_id", readonly=True
     )
     reviewer_ids = fields.Many2many(
         string="Reviewers",
@@ -94,4 +98,12 @@ class TierReview(models.Model):
             rec.todo_by = todo_by
 
     def _get_reviewers(self):
-        return self.reviewer_id + self.reviewer_group_id.users
+        if self.reviewer_id or self.reviewer_group_id.users:
+            return self.reviewer_id + self.reviewer_group_id.users
+        reviewer_field = self.env["res.users"]
+        if self.reviewer_field_id:
+            resource = self.env[self.model].browse(self.res_id)
+            reviewer_field = getattr(resource, self.reviewer_field_id.name, False)
+            if not reviewer_field or not reviewer_field._name == "res.users":
+                raise ValidationError(_("There are no res.users in the selected field"))
+        return reviewer_field

--- a/base_tier_validation/tests/test_tier_validation.py
+++ b/base_tier_validation/tests/test_tier_validation.py
@@ -413,6 +413,29 @@ class TierTierValidation(CommonTierValidation):
         )
         self.assertEquals(len(records), 0)
 
+    def test_18_test_review_by_res_users_field(self):
+        selected_field = self.env["ir.model.fields"].search(
+            [("model", "=", self.test_model._name), ("name", "=", "user_id")]
+        )
+        test_record = self.test_model.create(
+            {"test_field": 2.5, "user_id": self.test_user_2.id}
+        )
+
+        definition = self.env["tier.definition"].create(
+            {
+                "model_id": self.tester_model.id,
+                "review_type": "field",
+                "reviewer_field_id": selected_field.id,
+                "definition_domain": "[('test_field', '>', 1.0)]",
+                "approve_sequence": True,
+            }
+        )
+
+        reviews = test_record.request_validation()
+        review = reviews.filtered(lambda r: r.definition_id == definition)
+        self.assertTrue(review)
+        self.assertEqual(review.reviewer_ids, self.test_user_2)
+
 
 @tagged("at_install")
 class TierTierValidationView(CommonTierValidation):

--- a/base_tier_validation/views/tier_definition_view.xml
+++ b/base_tier_validation/views/tier_definition_view.xml
@@ -12,6 +12,7 @@
                 <field name="review_type" />
                 <field name="reviewer_id" />
                 <field name="reviewer_group_id" />
+                <field name="reviewer_field_id" />
                 <field name="sequence" />
                 <field name="company_id" groups="base.group_multi_company" />
                 <field name="active" />
@@ -55,6 +56,12 @@
                                 name="reviewer_group_id"
                                 attrs="{'invisible': [('review_type', '!=', 'group')]}"
                             />
+                            <field
+                                name="reviewer_field_id"
+                                attrs="{'invisible': [('review_type', '!=', 'field')]}"
+                                options="{'no_create': True}"
+                            />
+                            <field name="valid_reviewer_field_ids" invisible="1" />
                         </group>
                         <group name="right">
                             <field


### PR DESCRIPTION
Add a review type based on a res.users field in the tier definition.
Forward port of https://github.com/OCA/server-ux/pull/371
cc @LoisRForgeFlow

