### PR TITLE
[FIX] base_tier_validation: get definition by sequence

### DIFF
--- a/base_tier_validation/models/tier_validation.py
+++ b/base_tier_validation/models/tier_validation.py
@@ -372,7 +372,7 @@ class TierValidation(models.AbstractModel):
             if getattr(rec, self._state_field) in self._state_from:
                 if rec.need_validation:
                     tier_definitions = td_obj.search(
-                        [("model", "=", self._name)], order="sequence desc"
+                        [("model", "=", self._name)], order="sequence"
                     )
                     sequence = 0
                     for td in tier_definitions:


### PR DESCRIPTION
Create 2 définition with A: sequence 10, B: sequence 20
On document ask validation
The order is reverse:
1 - B
2 - A