### PR TITLE
[13.0][IMP] mass_editing: feature to disable tracking.

### DIFF
--- a/mass_editing/wizard/mass_editing_wizard.py
+++ b/mass_editing/wizard/mass_editing_wizard.py
@@ -16,6 +16,12 @@ class MassEditingWizard(models.TransientModel):
         help="Thick if you want to use the custom domain (+ domain of the "
         "mass edition) instead of select all items manually.",
     )
+    tracking_disable = fields.Boolean(
+        string="Disable tracking",
+        help="Thick if you want to disable tracking (mail thread feature).\n"
+        "That may improve performance but you won't have any tracking "
+        "activities (to know what has been updated, when and by who).",
+    )
 
     @api.model
     def _prepare_fields(self, line, field, field_info):
@@ -182,7 +188,7 @@ class MassEditingWizard(models.TransientModel):
                             m2m_list.append((4, m2m_id))
                         values.update({split_key: m2m_list})
             if values:
-                items.write(values)
+                items.with_context(tracking_disable=self.tracking_disable).write(values)
 
     def read(self, fields, load="_classic_read"):
         """ Without this call, dynamic fields build by fields_view_get()

--- a/mass_editing/wizard/view_mass_editing_wizard.xml
+++ b/mass_editing/wizard/view_mass_editing_wizard.xml
@@ -17,6 +17,7 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
                 <group>
                     <group>
                         <field name="use_active_domain" />
+                        <field name="tracking_disable" />
                     </group>
                     <group />
                 </group>


### PR DESCRIPTION
Add possibility to disable the tracking (mail.thread system) during the mass editing. This could be helpful when updating a huge amount of records (like pricelist items; supplier-info) because the full tracking system slow down the entire update