### PR TITLE
[12.0][FIX] base_tier_validation : Model name not translated in reviews widget

### DIFF
--- a/base_tier_validation/models/res_users.py
+++ b/base_tier_validation/models/res_users.py
@@ -33,7 +33,7 @@ class Users(models.Model):
                 if len(records):
                     record = self.env[model]
                     user_reviews[model] = {
-                        "name": record._description,
+                        "name": self.env['ir.model']._get(record._name).name,
                         "model": model,
                         "icon": modules.module.get_module_icon(record._original_module),
                         "pending_count": len(records),


### PR DESCRIPTION
Very small change in order to fix #216 

The technical solution has been taken from https://github.com/odoo/odoo/pull/33957