### PR TITLE
[14.0][FIX] base_tier_validation condition

### DIFF
--- a/base_tier_validation/models/tier_validation.py
+++ b/base_tier_validation/models/tier_validation.py
@@ -209,6 +209,7 @@ class TierValidation(models.AbstractModel):
             if (
                 rec.review_ids
                 and getattr(rec, self._state_field) in self._state_from
+                and vals.get(self._state_field)
                 and not vals.get(self._state_field)
                 in (self._state_to + [self._cancel_state])
                 and not rec._check_allow_write_under_validation(vals)


### PR DESCRIPTION
Check vals state should be state (not None)