### PR TITLE
[14.0][IMP] base_tier_validation, approve by sequence with option to bypass for same reviewer

### DIFF
--- a/base_tier_validation/models/tier_definition.py
+++ b/base_tier_validation/models/tier_definition.py
@@ -73,6 +73,9 @@ class TierDefinition(models.Model):
         default=False,
         help="Approval order by the specified sequence number",
     )
+    approve_sequence_bypass = fields.Boolean(
+        help="Bypassed (auto validated), if previous tier was validated by same reviewer",
+    )
 
     @api.onchange("review_type")
     def onchange_review_type(self):

--- a/base_tier_validation/models/tier_review.py
+++ b/base_tier_validation/models/tier_review.py
@@ -55,6 +55,9 @@ class TierReview(models.Model):
     approve_sequence = fields.Boolean(
         related="definition_id.approve_sequence", readonly=True
     )
+    approve_sequence_bypass = fields.Boolean(
+        related="definition_id.approve_sequence_bypass", readonly=True
+    )
 
     @api.depends("definition_id.approve_sequence")
     def _compute_can_review(self):

--- a/base_tier_validation/models/tier_validation.py
+++ b/base_tier_validation/models/tier_validation.py
@@ -357,7 +357,9 @@ class TierValidation(models.AbstractModel):
     def validate_tier(self):
         self.ensure_one()
         sequences = self._get_sequences_to_approve(self.env.user)
-        reviews = self.review_ids.filtered(lambda l: l.sequence in sequences)
+        reviews = self.review_ids.filtered(
+            lambda l: l.sequence in sequences or l.approve_sequence_bypass
+        )
         if self.has_comment:
             return self._add_comment("validate", reviews)
         self._validate_tier(reviews)

--- a/base_tier_validation/views/tier_definition_view.xml
+++ b/base_tier_validation/views/tier_definition_view.xml
@@ -71,6 +71,16 @@
                             />
                             <field name="sequence" />
                             <field name="approve_sequence" />
+                            <label for="approve_sequence_bypass" invisible="1" />
+                            <div
+                                name="approve_sequence_bypass_div"
+                                class="o_row"
+                                attrs="{'invisible': [('approve_sequence', '=', False)]}"
+                            >
+                                <field name="approve_sequence_bypass" />
+                                <span
+                                >Bypassed, if previous tier was validated by same reviewer</span>
+                            </div>
                         </group>
                     </group>
                     <notebook>


### PR DESCRIPTION
Old behaviour with approve by sequence

#. Tier 1 to be approved by Mr. A
#. Tier 2 to be approved by Mr. A
#. Tier 3 to be approved by Mr. A

Mr. A will have to approve 3 times.

But with option approve_sequence_bypass = True in Tier 2 and Tier 3

Mr.A will only approve 1 time, then tier 2 and tier 3 will auto approve immediately.

