### PR TITLE
[14.0][IMP] base_tier_validation: Include inactive records in activities

### DIFF
--- a/base_tier_validation/models/res_users.py
+++ b/base_tier_validation/models/res_users.py
@@ -25,6 +25,7 @@ class Users(models.Model):
                 records = (
                     self.env[model]
                     .with_user(self.env.user)
+                    .with_context(active_test=False)
                     .search([("id", "in", reviews.mapped("res_id"))])
                     .filtered(lambda x: not x.rejected and x.can_review)
                 )

--- a/base_tier_validation/static/src/js/systray.js
+++ b/base_tier_validation/static/src/js/systray.js
@@ -134,7 +134,7 @@ odoo.define("tier_validation.systray", function (require) {
                 $(event.currentTarget).data(),
                 $(event.target).data()
             );
-            var context = {};
+            var context = {active_test: false};
             this.do_action({
                 type: "ir.actions.act_window",
                 name: data.model_name,

--- a/base_tier_validation/static/src/js/systray.js
+++ b/base_tier_validation/static/src/js/systray.js
@@ -134,7 +134,7 @@ odoo.define("tier_validation.systray", function (require) {
                 $(event.currentTarget).data(),
                 $(event.target).data()
             );
-            var context = {active_test: false};
+            var context = {from_review_systray: true, active_test: false};
             this.do_action({
                 type: "ir.actions.act_window",
                 name: data.model_name,


### PR DESCRIPTION
If record validations are based on a domain with active = False,
then the activities are not visible.