### PR TITLE
[14.0] [MIG] mass_operation_abstract port pr 12/13.0 to 14.0

### DIFF
--- a/mass_operation_abstract/README.rst
+++ b/mass_operation_abstract/README.rst
@@ -36,8 +36,6 @@ operations on any models.
 Known issues / Roadmap
 ======================
 
-* Propose this module in the OCA. (server-tools repository)
-
 * refactor ``mass_editing`` and ``mass_sorting`` OCA modules to depend on
   this module.
 

--- a/mass_operation_abstract/models/mass_operation_mixin.py
+++ b/mass_operation_abstract/models/mass_operation_mixin.py
@@ -67,9 +67,11 @@ class MassOperationMixin(models.AbstractModel):
         for mixin in self:
             if not mixin.ref_ir_act_window_id:
                 mixin.ref_ir_act_window_id = action_obj.create(mixin._prepare_action())
+        return True
 
     def disable_mass_operation(self):
         self.mapped("ref_ir_act_window_id").unlink()
+        return True
 
     # Overload Section
     def unlink(self):

--- a/mass_operation_abstract/models/mass_operation_mixin.py
+++ b/mass_operation_abstract/models/mass_operation_mixin.py
@@ -45,7 +45,13 @@ class MassOperationMixin(models.AbstractModel):
         copy=False,
     )
 
-    groups_id = fields.Many2one(comodel_name="res.groups", string="Allowed Groups")
+    group_ids = fields.Many2many(
+        comodel_name="res.groups",
+        relation="mass_group_rel",
+        column1="mass_id",
+        column2="group_id",
+        string="Allowed Groups",
+    )
 
     domain = fields.Char(string="Domain", required=True, default="[]")
 
@@ -82,7 +88,7 @@ class MassOperationMixin(models.AbstractModel):
             "name": self.action_name,
             "type": "ir.actions.act_window",
             "res_model": self._wizard_model_name,
-            "groups_id": [(6, 0, self.groups_id.ids)],
+            "groups_id": [(6, 0, self.group_ids.ids)],
             "context": """{
                 'mass_operation_mixin_id' : %d,
                 'mass_operation_mixin_name' : '%s',

--- a/mass_operation_abstract/models/mass_operation_mixin.py
+++ b/mass_operation_abstract/models/mass_operation_mixin.py
@@ -15,7 +15,7 @@ class MassOperationMixin(models.AbstractModel):
 
     # To Overwrite Section (Optional)
     def _prepare_action_name(self):
-        return _("Mass Operation (%s)" % (self.name))
+        return _("Mass Operation (%s)") % self.name
 
     def _get_model_domain(self):
         return [("transient", "=", False)]

--- a/mass_operation_abstract/readme/ROADMAP.rst
+++ b/mass_operation_abstract/readme/ROADMAP.rst
@@ -1,5 +1,3 @@
-* Propose this module in the OCA. (server-tools repository)
-
 * refactor ``mass_editing`` and ``mass_sorting`` OCA modules to depend on
   this module.
 

--- a/mass_operation_abstract/static/description/index.html
+++ b/mass_operation_abstract/static/description/index.html
@@ -3,7 +3,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<meta name="generator" content="Docutils 0.15.1: http://docutils.sourceforge.net/" />
+<meta name="generator" content="Docutils: http://docutils.sourceforge.net/" />
 <title>Mass Operation Abstract</title>
 <style type="text/css">
 
@@ -387,7 +387,6 @@ operations on any models.</p>
 <div class="section" id="known-issues-roadmap">
 <h1><a class="toc-backref" href="#id1">Known issues / Roadmap</a></h1>
 <ul class="simple">
-<li>Propose this module in the OCA. (server-tools repository)</li>
 <li>refactor <tt class="docutils literal">mass_editing</tt> and <tt class="docutils literal">mass_sorting</tt> OCA modules to depend on
 this module.</li>
 <li>Develop new modules like:</li>

--- a/mass_operation_abstract/views/view_mass_operation_mixin.xml
+++ b/mass_operation_abstract/views/view_mass_operation_mixin.xml
@@ -11,7 +11,7 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
             <search>
                 <field name="name" />
                 <field name="model_id" />
-                <field name="groups_id" />
+                <field name="group_ids" />
             </search>
         </field>
     </record>
@@ -21,7 +21,7 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
             <tree decoration-muted="(ref_ir_act_window_id == False)">
                 <field name="name" />
                 <field name="model_id" />
-                <field name="groups_id" />
+                <field name="group_ids" />
                 <field name="ref_ir_act_window_id" invisible="1" />
             </tree>
         </field>
@@ -77,10 +77,6 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
                                 name="domain"
                                 attrs="{'readonly': [('ref_ir_act_window_id', '!=', False)]}"
                             />
-                            <field
-                                name="groups_id"
-                                attrs="{'readonly': [('ref_ir_act_window_id', '!=', False)]}"
-                            />
                         </group>
                         <group>
                             <field name="message" />
@@ -96,6 +92,13 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
                                     attrs="{'invisible':[('ref_ir_act_window_id', '=', False)]}"
                                 />
                             </group>
+                        </page>
+                        <page string="Security">
+                            <field
+                                name="group_ids"
+                                nolabel="1"
+                                attrs="{'readonly': [('ref_ir_act_window_id', '!=', False)]}"
+                            />
                         </page>
                     </notebook>
                 </sheet>

--- a/mass_operation_abstract/wizard/mass_operation_wizard_mixin.py
+++ b/mass_operation_abstract/wizard/mass_operation_wizard_mixin.py
@@ -49,22 +49,17 @@ class MassOperationWizardMixin(models.AbstractModel):
 
         if len(active_ids) == len(remaining_items):
             operation_description_info = _(
-                "The treatment will be processed on the {} selected"
-                " elements.".format(len(active_ids))
-            )
+                "The treatment will be processed on the %d selected elements."
+            ) % len(active_ids)
         elif len(remaining_items):
             operation_description_warning = _(
-                "You have selected {} items that can not be processed."
-                " Only {} items will be processed.".format(
-                    len(active_ids) - len(remaining_items), len(remaining_items)
-                )
-            )
+                "You have selected %d items that can not be processed."
+                " Only %d items will be processed."
+            ) % (len(active_ids) - len(remaining_items), len(remaining_items))
         else:
             operation_description_danger = _(
-                "None of the {} items you have selected can be processed.".format(
-                    len(active_ids)
-                )
-            )
+                "None of the %d items you have selected can be processed."
+            ) % len(active_ids)
 
         res.update(
             {


### PR DESCRIPTION
PR ported:
* [PR#211 [12.0] Backport/forward port mass editing improvements from 13.0/10.0](https://github.com/OCA/server-ux/pull/211)
* [PR#223 [FIX] mass_operation_abstract : return True to allow call from xml-rpc
](https://github.com/OCA/server-ux/pull/223)
* [PR#406 [13.0][FIX] mass_operation_abstract: change translations variables formatting](https://github.com/OCA/server-ux/pull/406)