### PR TITLE
[14.0][IMP] base_tier_validation: Change assertEquals to assertEqual in tests.

### DIFF
--- a/base_tier_validation/tests/test_tier_validation.py
+++ b/base_tier_validation/tests/test_tier_validation.py
@@ -404,14 +404,14 @@ class TierTierValidation(CommonTierValidation):
         records = self.env["tier.validation.tester"].search(
             [("reviewer_ids", "=", False)]
         )
-        self.assertEquals(len(records), 1)
+        self.assertEqual(len(records), 1)
         self.test_record.with_user(self.test_user_2.id).request_validation()
         record = self.test_record.with_user(self.test_user_1.id)
         record.invalidate_cache()
         records = self.env["tier.validation.tester"].search(
             [("reviewer_ids", "=", False)]
         )
-        self.assertEquals(len(records), 0)
+        self.assertEqual(len(records), 0)
 
     def test_18_test_review_by_res_users_field(self):
         selected_field = self.env["ir.model.fields"].search(


### PR DESCRIPTION
Change `assertEquals` to `assertEqual` in tests.

Please @joao-p-marques and  @CarlosRoca13 can you review it?

@Tecnativa TT33774