### PR TITLE
[14.0][ADD] base_tier_validation_bypass

### DIFF
--- a/base_tier_validation_bypass/__init__.py
+++ b/base_tier_validation_bypass/__init__.py
@@ -1,0 +1,4 @@
+# Copyright 2022 Ecosoft Co., Ltd. (http://ecosoft.co.th)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from . import models
+from . import wizard

--- a/base_tier_validation_bypass/__manifest__.py
+++ b/base_tier_validation_bypass/__manifest__.py
@@ -1,0 +1,23 @@
+# Copyright 2022 Ecosoft Co., Ltd. (http://ecosoft.co.th)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+{
+    "name": "Base Tier Validation Bypass",
+    "summary": "All authorized user to set bypass tier on any document",
+    "version": "14.0.1.0.0",
+    "category": "Tools",
+    "website": "https://github.com/OCA/server-ux",
+    "author": "Ecosoft,Odoo Community Association (OCA)",
+    "license": "AGPL-3",
+    "depends": ["base_tier_validation_forward"],
+    "data": [
+        "security/security.xml",
+        "data/mail_data.xml",
+        "wizard/forward_wizard_view.xml",
+        "templates/tier_validation_templates.xml",
+    ],
+    "development_status": "Alpha",
+    "maintainers": ["kittiu"],
+    "application": False,
+    "installable": True,
+    "qweb": ["static/src/xml/tier_review_template.xml"],
+}

--- a/base_tier_validation_bypass/data/mail_data.xml
+++ b/base_tier_validation_bypass/data/mail_data.xml
@@ -1,0 +1,12 @@
+<odoo noupdate="1">
+    <record
+        id="mt_tier_validation_bypassed"
+        model="mail.message.subtype"
+        forcecreate="1"
+    >
+        <field name="name">Tier Validation Bypass Notification</field>
+        <field name="default" eval="True" />
+        <field name="internal" eval="True" />
+        <field name="hidden" eval="True" />
+    </record>
+</odoo>

--- a/base_tier_validation_bypass/models/__init__.py
+++ b/base_tier_validation_bypass/models/__init__.py
@@ -1,0 +1,3 @@
+# Copyright 2020 Ecosoft Co., Ltd. (http://ecosoft.co.th)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from . import tier_validation

--- a/base_tier_validation_bypass/models/tier_validation.py
+++ b/base_tier_validation_bypass/models/tier_validation.py
@@ -1,0 +1,74 @@
+# Copyright 2017-19 ForgeFlow S.L. (https://www.forgeflow.com)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+
+from odoo import _, fields, models
+from odoo.exceptions import UserError
+
+
+class TierValidation(models.AbstractModel):
+    _inherit = "tier.validation"
+
+    def _add_comment(self, validate_reject, reviews):
+        self.env.ref("base_tier_validation.view_comment_wizard")
+        res = super()._add_comment(validate_reject, reviews)
+        if self.env.context.get("forward_bypass_only"):
+            res["context"]["default_forward_reviewer_id"] = self.env.user.id
+        return res
+
+    def _get_sequences_to_approve(self, user):
+        if self.env.context.get("forward_bypass_only"):
+            # Bypass only the next review in sequence
+            all_reviews = self.review_ids.filtered(lambda r: r.status == "pending")
+            if len(all_reviews) == 1:
+                raise UserError(_("Last review cannot be bypassed"))
+            approve_sequences = all_reviews.filtered("approve_sequence").mapped(
+                "sequence"
+            )
+            sequences = [min(approve_sequences)] if approve_sequences else []
+            return sequences
+        return super()._get_sequences_to_approve(user)
+
+    def forward_tier(self):
+        res = super().forward_tier()
+        if self.env.context.get("forward_bypass_only"):
+            # Change wizard view
+            wizard = self.env.ref("base_tier_validation_bypass.view_bypass_wizard")
+            res.update(
+                {
+                    "name": _("Bypass"),
+                    "views": [(wizard.id, "form")],
+                    "view_id": wizard.id,
+                }
+            )
+        return res
+
+    def _forward_tier(self, tiers=False):
+        if self.env.context.get("forward_bypass_only"):
+            self.ensure_one()
+            if not tiers:
+                raise UserError(_("There is no next review in sequence to bypass"))
+            user_reviews = tiers.filtered(lambda r: r.status != "approved")
+            user_reviews.write(
+                {
+                    "status": "forwarded",
+                    "done_by": self.env.user.id,
+                    "reviewed_date": fields.Datetime.now(),
+                }
+            )
+            for review in user_reviews:
+                rec = self.env[review.model].browse(review.res_id)
+                rec._notify_bypassed_reviews()
+            return
+        super()._forward_tier(tiers=tiers)
+
+    def _get_bypassed_notification_subtype(self):
+        return "base_tier_validation_bypass.mt_tier_validation_bypassed"
+
+    def _notify_bypassed_reviews(self):
+        post = "message_post"
+        if hasattr(self, post):
+            getattr(self, post)(
+                subtype_xmlid=self._get_bypassed_notification_subtype(),
+                body=_("A review was bypassed by %s.") % (self.env.user.name),
+            )

--- a/base_tier_validation_bypass/models/tier_validation.py
+++ b/base_tier_validation_bypass/models/tier_validation.py
@@ -9,13 +9,6 @@ from odoo.exceptions import UserError
 class TierValidation(models.AbstractModel):
     _inherit = "tier.validation"
 
-    def _add_comment(self, validate_reject, reviews):
-        self.env.ref("base_tier_validation.view_comment_wizard")
-        res = super()._add_comment(validate_reject, reviews)
-        if self.env.context.get("forward_bypass_only"):
-            res["context"]["default_forward_reviewer_id"] = self.env.user.id
-        return res
-
     def _get_sequences_to_approve(self, user):
         if self.env.context.get("forward_bypass_only"):
             # Bypass only the next review in sequence

--- a/base_tier_validation_bypass/readme/CONFIGURE.rst
+++ b/base_tier_validation_bypass/readme/CONFIGURE.rst
@@ -1,0 +1,1 @@
+Set "Authorized to bypass tier review" for a user to see the "Bypass" button.

--- a/base_tier_validation_bypass/readme/CONTRIBUTORS.rst
+++ b/base_tier_validation_bypass/readme/CONTRIBUTORS.rst
@@ -1,0 +1,1 @@
+* Kitti U. <kittiu@ecosoft.co.th>

--- a/base_tier_validation_bypass/readme/DESCRIPTION.rst
+++ b/base_tier_validation_bypass/readme/DESCRIPTION.rst
@@ -1,0 +1,1 @@
+This module allow an authorized user to bypass any document. Bypass is different than Forward in the way that, there is no person to forward to. It just by pass the next approving tier (with the exception of last tier).

--- a/base_tier_validation_bypass/security/security.xml
+++ b/base_tier_validation_bypass/security/security.xml
@@ -1,0 +1,6 @@
+<odoo>
+    <record id="group_can_bypass_tier_reivew" model="res.groups">
+        <field name="name">Authorized to bypass tier review</field>
+        <field name="category_id" ref="base.module_category_hidden" />
+    </record>
+</odoo>

--- a/base_tier_validation_bypass/templates/tier_validation_templates.xml
+++ b/base_tier_validation_bypass/templates/tier_validation_templates.xml
@@ -10,7 +10,7 @@
                 type="object"
                 class="oe_inline oe_button btn-info"
                 icon="fa-arrow-circle-up"
-                context="{'forward_bypass_only': True}"
+                context="{'forward_bypass_only': True, 'default_forward_reviewer_id': uid}"
                 groups="base_tier_validation_bypass.group_can_bypass_tier_reivew"
                 confirm="You are about to bypass a document, are you sure to continue?"
             />

--- a/base_tier_validation_bypass/templates/tier_validation_templates.xml
+++ b/base_tier_validation_bypass/templates/tier_validation_templates.xml
@@ -1,0 +1,19 @@
+<odoo>
+    <template
+        id="tier_validation_label_forward"
+        inherit_id="base_tier_validation_forward.tier_validation_label_forward"
+    >
+        <xpath expr="//button[@name='forward_tier']" position="after">
+            <button
+                name="forward_tier"
+                string="Bypass"
+                type="object"
+                class="oe_inline oe_button btn-info"
+                icon="fa-arrow-circle-up"
+                context="{'forward_bypass_only': True}"
+                groups="base_tier_validation_bypass.group_can_bypass_tier_reivew"
+                confirm="You are about to bypass a document, are you sure to continue?"
+            />
+        </xpath>
+    </template>
+</odoo>

--- a/base_tier_validation_bypass/wizard/__init__.py
+++ b/base_tier_validation_bypass/wizard/__init__.py
@@ -1,0 +1,3 @@
+# Copyright 2022 Ecosoft Co., Ltd. (http://ecosoft.co.th)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from . import forward_wizard

--- a/base_tier_validation_bypass/wizard/forward_wizard.py
+++ b/base_tier_validation_bypass/wizard/forward_wizard.py
@@ -1,0 +1,20 @@
+# Copyright 2022 Ecosoft Co., Ltd. (http://ecosoft.co.th)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from odoo import _, models
+
+
+class ValidationForwardWizard(models.TransientModel):
+    _inherit = "tier.validation.forward.wizard"
+
+    def add_forward(self):
+        if self.env.context.get("forward_bypass_only"):
+            rec = self.env[self.res_model].browse(self.res_id)
+            prev_comment = self.env["comment.wizard"].browse(
+                self._context.get("comment_id")
+            )
+            prev_comment.write({"comment": _("Bypass: %s") % self.forward_description})
+            prev_comment.add_comment()
+            rec.invalidate_cache()
+            rec.review_ids._compute_can_review()
+            return
+        super().add_forward()

--- a/base_tier_validation_bypass/wizard/forward_wizard_view.xml
+++ b/base_tier_validation_bypass/wizard/forward_wizard_view.xml
@@ -1,0 +1,38 @@
+<!-- Copyright 2022 Ecosoft Co., Ltd. (http://ecosoft.co.th)
+     License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl). -->
+<odoo>
+
+    <record id="view_bypass_wizard" model="ir.ui.view">
+        <field name="name">Bypass Wizard</field>
+        <field name="model">tier.validation.forward.wizard</field>
+        <field name="type">form</field>
+        <field name="arch" type="xml">
+            <form string="Bypass">
+                <group>
+                    <group>
+                        <field name="forward_reviewer_id" invisible="1" />
+                        <field
+                            name="forward_description"
+                            string="Bypass Description"
+                            required="1"
+                        />
+                    </group>
+                    <group>
+                        <field name="has_comment" invisible="1" />
+                        <field name="approve_sequence" invisible="1" />
+                    </group>
+                </group>
+                <footer>
+                    <button
+                        name="add_forward"
+                        string="Bypass"
+                        type="object"
+                        class="oe_highlight"
+                    />
+                    <button special="cancel" string="Cancel" class="oe_link" />
+                </footer>
+            </form>
+        </field>
+    </record>
+
+</odoo>

--- a/setup/base_tier_validation_bypass/odoo/addons/base_tier_validation_bypass
+++ b/setup/base_tier_validation_bypass/odoo/addons/base_tier_validation_bypass
@@ -1,0 +1,1 @@
+../../../../base_tier_validation_bypass

--- a/setup/base_tier_validation_bypass/setup.py
+++ b/setup/base_tier_validation_bypass/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
This module allow an authorized user to bypass any document. Bypass is different than Forward in the way that, there is no person to forward to. It just by pass the next approving tier (with the exception of last tier).

![bypass](https://user-images.githubusercontent.com/1973598/152384207-25630ec1-e557-4bc9-8613-65eaa9b53c2c.gif)
