### PR TITLE
[14.0][FIX] base_tier_validation_server_action:  rejected with server action error

### DIFF
--- a/base_tier_validation_server_action/models/__init__.py
+++ b/base_tier_validation_server_action/models/__init__.py
@@ -2,3 +2,4 @@
 
 from . import tier_definition
 from . import tier_review
+from . import tier_validation

--- a/base_tier_validation_server_action/models/tier_review.py
+++ b/base_tier_validation_server_action/models/tier_review.py
@@ -9,13 +9,9 @@ class TierReview(models.Model):
 
     def write(self, vals):
         res = super().write(vals)
-        if vals.get("status") in ["approved", "rejected"]:
+        if vals.get("status") == "approved":
             for rec in self:
-                server_action = False
-                if rec.status == "approved":
-                    server_action = rec.definition_id.server_action_id
-                if rec.status == "rejected":
-                    server_action = rec.definition_id.rejected_server_action_id
+                server_action = rec.definition_id.server_action_id
                 server_action_tier = self.env.context.get("server_action_tier")
                 # Don't allow reentrant server action as it will lead to
                 # recursive behaviour

--- a/base_tier_validation_server_action/models/tier_validation.py
+++ b/base_tier_validation_server_action/models/tier_validation.py
@@ -1,0 +1,28 @@
+# Copyright 2022 Ecosoft (http://ecosoft.co.th)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import models
+
+
+class TierValidation(models.AbstractModel):
+    _inherit = "tier.validation"
+
+    def reject_tier(self):
+        self.ensure_one()
+        res = super().reject_tier()
+        review = self.review_ids[-1]
+        server_action = review.definition_id.rejected_server_action_id
+        server_action_tier = self.env.context.get("server_action_tier")
+        # Don't allow reentrant server action as it will lead to
+        # recursive behaviour
+        if (
+            not self.has_comment
+            and server_action
+            and (not server_action_tier or server_action_tier != server_action.id)
+        ):
+            server_action.with_context(
+                server_action_tier=server_action.id,
+                active_model=review.model,
+                active_id=review.res_id,
+            ).sudo().run()
+        return res

--- a/base_tier_validation_server_action/wizard/__init__.py
+++ b/base_tier_validation_server_action/wizard/__init__.py
@@ -1,4 +1,3 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
-from . import models
-from . import wizard
+from . import comment_wizard

--- a/base_tier_validation_server_action/wizard/comment_wizard.py
+++ b/base_tier_validation_server_action/wizard/comment_wizard.py
@@ -6,26 +6,22 @@ from odoo import models
 class CommentWizard(models.TransientModel):
     _inherit = "comment.wizard"
 
-    def _get_server_action(self, review):
-        """ get server action validate or reject """
-        validate_reject = self._context.get("default_validate_reject")
-        if validate_reject == "validate":
-            return review.definition_id.server_action_id
-        return review.definition_id.rejected_server_action_id
-
     def add_comment(self):
+        """ For case reject only """
         res = super().add_comment()
-        review = self.review_ids[-1]
-        server_action = self._get_server_action(review)
-        server_action_tier = self.env.context.get("server_action_tier")
-        # Don't allow reentrant server action as it will lead to
-        # recursive behaviour
-        if server_action and (
-            not server_action_tier or server_action_tier != server_action.id
-        ):
-            server_action.with_context(
-                server_action_tier=server_action.id,
-                active_model=review.model,
-                active_id=review.res_id,
-            ).sudo().run()
+        validate_reject = self._context.get("default_validate_reject")
+        if validate_reject == "reject":
+            review = self.review_ids[-1]
+            reject_server_action = review.definition_id.rejected_server_action_id
+            server_action_tier = self.env.context.get("server_action_tier")
+            # Don't allow reentrant server action as it will lead to
+            # recursive behaviour
+            if reject_server_action and (
+                not server_action_tier or server_action_tier != reject_server_action.id
+            ):
+                reject_server_action.with_context(
+                    server_action_tier=reject_server_action.id,
+                    active_model=review.model,
+                    active_id=review.res_id,
+                ).sudo().run()
         return res

--- a/base_tier_validation_server_action/wizard/comment_wizard.py
+++ b/base_tier_validation_server_action/wizard/comment_wizard.py
@@ -6,10 +6,19 @@ from odoo import models
 class CommentWizard(models.TransientModel):
     _inherit = "comment.wizard"
 
+    def _get_server_action(self, review):
+        """ get server action validate or reject """
+        validate_reject = self._context.get("default_validate_reject")
+        return (
+            validate_reject == "validate"
+            and review.definition_id.server_action_id
+            or review.definition_id.rejected_server_action_id
+        )
+
     def add_comment(self):
         res = super().add_comment()
         review = self.review_ids[-1]
-        server_action = review.definition_id.rejected_server_action_id
+        server_action = self._get_server_action(review)
         server_action_tier = self.env.context.get("server_action_tier")
         # Don't allow reentrant server action as it will lead to
         # recursive behaviour

--- a/base_tier_validation_server_action/wizard/comment_wizard.py
+++ b/base_tier_validation_server_action/wizard/comment_wizard.py
@@ -1,0 +1,24 @@
+# Copyright 2022 Ecosoft Co., Ltd. (http://ecosoft.co.th)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from odoo import models
+
+
+class CommentWizard(models.TransientModel):
+    _inherit = "comment.wizard"
+
+    def add_comment(self):
+        res = super().add_comment()
+        review = self.review_ids[-1]
+        server_action = review.definition_id.rejected_server_action_id
+        server_action_tier = self.env.context.get("server_action_tier")
+        # Don't allow reentrant server action as it will lead to
+        # recursive behaviour
+        if server_action and (
+            not server_action_tier or server_action_tier != server_action.id
+        ):
+            server_action.with_context(
+                server_action_tier=server_action.id,
+                active_model=review.model,
+                active_id=review.res_id,
+            ).sudo().run()
+        return res

--- a/base_tier_validation_server_action/wizard/comment_wizard.py
+++ b/base_tier_validation_server_action/wizard/comment_wizard.py
@@ -9,11 +9,9 @@ class CommentWizard(models.TransientModel):
     def _get_server_action(self, review):
         """ get server action validate or reject """
         validate_reject = self._context.get("default_validate_reject")
-        return (
-            validate_reject == "validate"
-            and review.definition_id.server_action_id
-            or review.definition_id.rejected_server_action_id
-        )
+        if validate_reject == "validate":
+            return review.definition_id.server_action_id
+        return review.definition_id.rejected_server_action_id
 
     def add_comment(self):
         res = super().add_comment()


### PR DESCRIPTION
[BUG]
you can not rejected document when you use tier validation server action with state cancel
because it remove **tier.review** when state cancel https://github.com/OCA/server-ux/blob/14.0/base_tier_validation/models/tier_validation.py#L243

Step to error:

1. Create tier and Post Reject Action = change state to cancel 
2. Reject document and it will error

[FIX]
- Reject first and run server
- cherry-pick PR https://github.com/OCA/server-ux/pull/434 because it will conflict file.

@kittiu @rousseldenis 