### PR TITLE
[14.0][FIX] base_tier_validation: error on reviews after uninstalling Tier Validation support

### DIFF
--- a/base_tier_validation/models/res_users.py
+++ b/base_tier_validation/models/res_users.py
@@ -20,11 +20,12 @@ class Users(models.Model):
         review_groups = self.env["tier.review"].read_group(domain, ["model"], ["model"])
         for review_group in review_groups:
             model = review_group["model"]
+            Model = self.env[model]
             reviews = self.env["tier.review"].search(review_group.get("__domain"))
-            if reviews:
+            # Skip Models not having Tier Validation enabled (example: was unistalled)
+            if reviews and hasattr(Model, "can_review"):
                 records = (
-                    self.env[model]
-                    .with_user(self.env.user)
+                    Model.with_user(self.env.user)
                     .with_context(active_test=False)
                     .search([("id", "in", reviews.mapped("res_id"))])
                     .filtered(lambda x: not x.rejected and x.can_review)


### PR DESCRIPTION
Supersedes #320 (cleaner fix here)

I came across this issue again.
You install a module adding Tier validation support to a Model, Partners in my case.
You do some tests where reviews are created.
You then remove the module from your system.
From there on, you get traceback errors in ` review_user_count()` while accessing `rejected` and `can_review`field in theat Model, that does not support them anymore.