### PR TITLE
[13.0][FIX] base_user_locale: make new fields readable for user

### DIFF
--- a/base_user_locale/models/res_users.py
+++ b/base_user_locale/models/res_users.py
@@ -38,6 +38,23 @@ class ResUsers(models.Model):
         help="See Settings > Translations > Languages for details",
     )
 
+    def __init__(self, pool, cr):
+        """ Override of __init__ to add access rights.
+            Access rights are disabled by default, but allowed
+            on some specific fields defined in self.SELF_{READ/WRITE}ABLE_FIELDS.
+        """
+        base_user_locale_readable_fields = [
+            "date_format",
+            "time_format",
+            "week_start",
+            "decimal_point",
+            "thousands_sep",
+        ]
+        super(ResUsers, self).__init__(pool, cr)
+        type(self).SELF_READABLE_FIELDS = (
+            type(self).SELF_READABLE_FIELDS + base_user_locale_readable_fields
+        )
+
     def preference_save(self):
         super().preference_save()
         # Do a "full" reload instead of just a context_reload to apply locale


### PR DESCRIPTION
If the new fields are not marked as readable for the user, the user will not be able to access 'My Profile' menu due to missing access rights. This happens when standard 'HR' module is installed.

STEPS TO REPRODUCE IN DEMO DB WITH base_user_locale INSTALLED:

1. Install hr module.
2. Log in with demo user.
3. Access 'My profile'.

The access error is only triggered due to the new fields in base_user_locale.

![image](https://user-images.githubusercontent.com/71635103/154908489-48d28d23-d5b3-44c2-a757-ebd8a4f6c501.png)

![image](https://user-images.githubusercontent.com/71635103/154908516-1651d54a-22b1-4d47-b1a6-0eef56d28622.png)
