### PR TITLE
[14.0] [FIX] external_dependency python-stdnum

### DIFF
--- a/sequence_check_digit/__manifest__.py
+++ b/sequence_check_digit/__manifest__.py
@@ -13,5 +13,5 @@
     "summary": "Adds a check digit on sequences",
     "depends": ["base"],
     "data": ["views/sequence_views.xml"],
-    "external_dependencies": {"python": ["stdnum"]},
+    "external_dependencies": {"python": ["python-stdnum"]},
 }


### PR DESCRIPTION
Fix external dependency from `stdnum` to `python-stdnum`

Package `stdnum` do not exists on PyPi, so change it to `python-stdnum`

File requirements.txt is ok