### PR TITLE
[FIX] [14.0] Removed external dependencies already defined in Odoo base

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 # generated from manifests external_dependencies
 pdf2image
-python-stdnum
 pyzbar

--- a/sequence_check_digit/__manifest__.py
+++ b/sequence_check_digit/__manifest__.py
@@ -13,5 +13,4 @@
     "summary": "Adds a check digit on sequences",
     "depends": ["base"],
     "data": ["views/sequence_views.xml"],
-    "external_dependencies": {"python": ["stdnum"]},
 }


### PR DESCRIPTION
Removed external dependencies already defined in Odoo base
https://github.com/odoo/odoo/blob/ae6f414ba41eee4e14235a1e82fd5ebd237dd97f/requirements.txt#L48

MT-282 @moduon