### PR TITLE
[14.0][FIX+IMP] base_tier_validation: Don't mess searches with NewId + non …

### DIFF
--- a/base_tier_validation/models/tier_validation.py
+++ b/base_tier_validation/models/tier_validation.py
@@ -7,7 +7,6 @@ from lxml import etree
 
 from odoo import _, api, fields, models
 from odoo.exceptions import ValidationError
-from odoo.osv import expression
 
 
 class TierValidation(models.AbstractModel):
@@ -180,10 +179,11 @@ class TierValidation(models.AbstractModel):
             )
 
     def evaluate_tier(self, tier):
-        domain = []
         if tier.definition_domain:
             domain = literal_eval(tier.definition_domain)
-        return self.search(expression.AND([[("id", "=", self.id)], domain]))
+            return self.filtered_domain(domain)
+        else:
+            return self
 
     @api.model
     def _get_under_validation_exceptions(self):


### PR DESCRIPTION
…saved data

You can't search for a NewId in a domain, and doing a search requires
to flush cache contents to DB for being effective, so this disregards
the correct use of this on the fly computed field.

Fortunately, we have a tool at ORM level for applying domains on cached
content and without worrying about NewId, which is filtered_domain, so
let's apply it.

Forward port of #462.

cc @pedrobaeza 