### PR TITLE
[13.0][IMP] base_tier_validation: Allow sequential tier reviews

### DIFF
--- a/base_tier_validation/models/tier_review.py
+++ b/base_tier_validation/models/tier_review.py
@@ -37,6 +37,7 @@ class TierReview(models.Model):
         store=True,
     )
     sequence = fields.Integer(string="Tier")
+    definition_sequence = fields.Integer(related="definition_id.sequence", store=True)
     todo_by = fields.Char(compute="_compute_todo_by", store=True)
     done_by = fields.Many2one(comodel_name="res.users")
     requested_by = fields.Many2one(comodel_name="res.users")

--- a/base_tier_validation/models/tier_validation.py
+++ b/base_tier_validation/models/tier_validation.py
@@ -159,10 +159,10 @@ class TierValidation(models.AbstractModel):
 
     def _compute_validated_rejected(self):
         for rec in self:
-            rec.validated = not self.need_validation and self._calc_reviews_validated(
+            rec.validated = not rec.need_validation and rec._calc_reviews_validated(
                 rec.review_ids
             )
-            rec.rejected = not self.need_validation and self._calc_reviews_rejected(
+            rec.rejected = not rec.need_validation and rec._calc_reviews_rejected(
                 rec.review_ids
             )
 

--- a/base_tier_validation/readme/CONFIGURE.rst
+++ b/base_tier_validation/readme/CONFIGURE.rst
@@ -9,3 +9,11 @@ To configure this module, you need to:
 * If check *Notify Reviewers on Creation*, all possible reviewers will be notified by email when this definition is triggered.
 * If check *Comment*, reviewers can comment after click Validate or Reject.
 * If check *Approve by sequence*, reviewers is forced to review by specified sequence.
+* If you want to introduce a workflow where there are multiple sequential
+  tiers of validations, instead of all validations being triggered at once,
+  use the field *validation_max_sequence* in your definition. This field is
+  available in all models that support the tier validation. For example,
+  trigger the validation of the Supply Chain Manager (tier definition with
+  sequence 20) only when the Supply Chain User has approved (tier definition
+  with sequence 10). In this case you would set your Tier Definition for
+  Supply Chain Manager to be applied when *validation_max_sequence = 10*.

--- a/base_tier_validation/tests/common.py
+++ b/base_tier_validation/tests/common.py
@@ -57,6 +57,9 @@ class CommonTierValidation(common.SavepointCase):
         cls.test_user_2 = cls.env["res.users"].create(
             {"name": "Mike", "login": "test2"}
         )
+        cls.test_user_3 = cls.env["res.users"].create(
+            {"name": "Judith", "login": "test3", "groups_id": [(6, 0, group_ids)]}
+        )
 
         # Create tier definitions:
         cls.tier_def_obj = cls.env["tier.definition"]


### PR DESCRIPTION
It is possible that after one validation has been accepted, and before proceeding
with the transition of the status the conditions of the object have changed,
requiring an additional validation.
This change allows the engine to support this scenario.

cc @LoisRForgeFlow @judithaforgeflow @jaumebforgeflow