### PR TITLE
[FIX] mass_operation_abstract (mass_editing, ...) : Prevent message if mass operation is realized on archived items

### DIFF
--- a/mass_operation_abstract/wizard/mass_operation_wizard_mixin.py
+++ b/mass_operation_abstract/wizard/mass_operation_wizard_mixin.py
@@ -114,4 +114,4 @@ class MassOperationWizardMixin(models.AbstractModel):
             )
         else:
             domain = [("id", "in", active_ids)]
-        return SrcModel.search(domain)
+        return SrcModel.with_context(active_test=False).search(domain)


### PR DESCRIPTION
**Step to reproduce**

- select a user, and disable it.
- in the tree view, select it and click on "mass edit" action

A first error is displayed : 
![image](https://user-images.githubusercontent.com/3407482/161056358-fe97311f-f559-4f86-80ec-fa5d4965a7a3.png)

When clicking on "Apply" button, a second message is displayed.

![image](https://user-images.githubusercontent.com/3407482/161056498-9e5a1640-1bac-4e44-b60a-dd6c8c21af50.png)

This trivial patch fixes the problem

GRAP#258

CC : @quentinDupont 