### PR TITLE
[14.0][ENH] base_cancel_confirm, allow disable cancel confirm

### DIFF
--- a/base_cancel_confirm/readme/CONFIGURE.rst
+++ b/base_cancel_confirm/readme/CONFIGURE.rst
@@ -1,0 +1,8 @@
+By default, the cancel confirm will be disabled (to ensure no side effect on other module unit test)
+
+To enable cancel confirm wizard, please add System Parameter (ir.config_parameter) for each extended module.
+
+For example,
+
+* sale_cancel_confirm, add `sale.order.cancel_confirm_disable = False`
+* purchase_cancel_confirm, add `purchase.order.cancel_confirm_disable = False`

--- a/base_cancel_confirm/tests/test_cancel_confirm.py
+++ b/base_cancel_confirm/tests/test_cancel_confirm.py
@@ -20,7 +20,9 @@ class TestCancelConfirm(common.SavepointCase):
         cls.tester_model = cls.env["ir.model"].search(
             [("model", "=", "cancel.confirm.tester")]
         )
-
+        cls.env["ir.config_parameter"].create(
+            {"key": "cancel.confirm.tester.cancel_confirm_disable", "value": "False"}
+        )
         # Access record:
         cls.env["ir.model.access"].create(
             {


### PR DESCRIPTION
By default, the cancel confirm will be disabled (to ensure no side effect on other module unit test)

To enable cancel confirm wizard, please add System Parameter (ir.config_parameter) for each extended module.

For example,

* sale_cancel_confirm, add `sale.order.cancel_confirm_disable = False`
* purchase_cancel_confirm, add `purchase.order.cancel_confirm_disable = False`
