### PR TITLE
[14.0][FIX] date_range: fix TZ

### DIFF
--- a/date_range/static/src/js/date_range.js
+++ b/date_range/static/src/js/date_range.js
@@ -56,8 +56,8 @@ odoo.define("date_range.CustomFilterItem", function (require) {
                         const default_range = this.date_ranges[
                             operator.date_range_type
                         ][0];
-                        const d_start = moment(`${default_range.date_start} 00:00:00`);
-                        const d_end = moment(`${default_range.date_end} 23:59:59`);
+                        const d_start = moment(`${default_range.date_start} 00:00:00Z`);
+                        const d_end = moment(`${default_range.date_end} 23:59:59Z`);
                         condition.value = [d_start, d_end];
                     } else {
                         super._setDefaultValue(...arguments);
@@ -73,8 +73,8 @@ odoo.define("date_range.CustomFilterItem", function (require) {
                         const eid = parseInt(ev.target.value);
                         const ranges = this.date_ranges[operator.date_range_type];
                         const range = ranges.find((x) => x.id == eid);
-                        const d_start = moment(`${range.date_start} 00:00:00`);
-                        const d_end = moment(`${range.date_end} 23:59:59`);
+                        const d_start = moment(`${range.date_start} 00:00:00Z`);
+                        const d_end = moment(`${range.date_end} 23:59:59Z`);
                         condition.value = [d_start, d_end];
                     } else {
                         super._onValueInput(...arguments);


### PR DESCRIPTION
tz is added by odoo (in js) at some point so no need to handle it here.

Without this patch, with a tz set to Europe/Paris, a range starting at 01/01/2022, is then converted to in this module 01/01/2022 00:00 UTC+1 (= 31/12/2021 23:00) then (in some odoo js) 31/12/2021 22:00.
