### PR TITLE
[14.0][FIX] Reset fieldx_id when one of it dependency field change

### DIFF
--- a/base_export_manager/models/ir_exports_line.py
+++ b/base_export_manager/models/ir_exports_line.py
@@ -10,6 +10,21 @@ class IrExportsLine(models.Model):
     _inherit = "ir.exports.line"
     _order = "sequence,id"
 
+    @api.depends("field1_id")
+    def _compute_field2_id(self):
+        for rec in self:
+            rec.field2_id = False
+
+    @api.depends("field2_id", "field1_id")
+    def _compute_field3_id(self):
+        for rec in self:
+            rec.field3_id = False
+
+    @api.depends("field3_id", "field2_id", "field1_id")
+    def _compute_field4_id(self):
+        for rec in self:
+            rec.field4_id = False
+
     name = fields.Char(
         store=True,
         compute="_compute_name",
@@ -20,13 +35,28 @@ class IrExportsLine(models.Model):
         "ir.model.fields", "First field", domain="[('model_id', '=', model1_id)]"
     )
     field2_id = fields.Many2one(
-        "ir.model.fields", "Second field", domain="[('model_id', '=', model2_id)]"
+        "ir.model.fields",
+        "Second field",
+        domain="[('model_id', '=', model2_id)]",
+        compute="_compute_field2_id",
+        store=True,
+        readonly=False,
     )
     field3_id = fields.Many2one(
-        "ir.model.fields", "Third field", domain="[('model_id', '=', model3_id)]"
+        "ir.model.fields",
+        "Third field",
+        domain="[('model_id', '=', model3_id)]",
+        compute="_compute_field3_id",
+        store=True,
+        readonly=False,
     )
     field4_id = fields.Many2one(
-        "ir.model.fields", "Fourth field", domain="[('model_id', '=', model4_id)]"
+        "ir.model.fields",
+        "Fourth field",
+        domain="[('model_id', '=', model4_id)]",
+        compute="_compute_field4_id",
+        store=True,
+        readonly=False,
     )
     model1_id = fields.Many2one(
         "ir.model",


### PR DESCRIPTION
How to reproduce the issue : 

Install the module base_export_manager.
Create an `ir.exports` for res.partner model, create a line with field1 = `country_id` and field2 = `code`.
Save the form
Edit the form
Change field1 and choose `active` instead. Save => There is an error because the name is inconsistent

Instead of raising an error, I believe it is more logic to reset the subfields if a dependency field changes. 

I did not use onchange because it is kind of deprecated in favor of compute fields.
Indeed, if a fieldx_id changes, all subfields should be reset anyway because they can't make sense anymore.