### PR TITLE
[FIX] mass_editing: Removed non-existing column from migration query.

### DIFF
--- a/mass_editing/migrations/14.0.1.0.0/pre-migrate.py
+++ b/mass_editing/migrations/14.0.1.0.0/pre-migrate.py
@@ -59,7 +59,7 @@ def migrate_mass_editing(env):
             'mass_edit',
             me.model_id,
             mo.model,
-            me.domain
+            NULL
         FROM mass_editing me
         LEFT JOIN ir_model mo ON (me.model_id = mo.id)
         """


### PR DESCRIPTION
The current migration script of module `mass_editing` uses a query that expects there to be a column `domain` in table `mass_editing`. I have not found this field in Odoo 13.0 or 14.0, so I removed it from the query.