### PR TITLE
[14.0][FIX] base_search_custom_field_filter: Resolve the error when the expression has related fields (dot notation).

### DIFF
--- a/base_search_custom_field_filter/models/base.py
+++ b/base_search_custom_field_filter/models/base.py
@@ -1,5 +1,6 @@
 # Copyright 2020 Tecnativa - Carlos Dauden
 # Copyright 2020 Tecnativa - Pedro M. Baeza
+# Copyright 2022 Tecnativa - Víctor Martínez
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 from lxml import etree
@@ -58,7 +59,7 @@ class Base(models.AbstractModel):
         )
         for custom_filter in custom_filters:
             field = custom_filter._get_related_field()
-            field_name = "ir_ui_custom_filter_%s" % custom_filter.id
+            field_name = custom_filter.expression
             res["fields"][field_name] = field.get_description(self.env)
             # force this for avoiding to appear on the rest of the UI
             res["fields"][field_name]["selectable"] = False


### PR DESCRIPTION
**Steps to reproduce the error**:
- Install `contacts` addon
- Go to Settings > Technical > User Interface > Custom Field Filters and create a new record with the following data: 
- Model: Contact
- Name: Country
- Expression: state_id.country_id
- Go to Contacts

Before this change there was an error (field does not exist).

Please @pedrobaeza can you review it?

@Tecnativa TT38645