### PR TITLE
[13.0][FIX] announcement: log read just once

### DIFF
--- a/announcement/models/res_users.py
+++ b/announcement/models/res_users.py
@@ -52,5 +52,8 @@ class ResUsers(models.Model):
         """Used as a controller for the widget"""
         announcement = self.env["announcement"].browse(int(announcement_id))
         self.env.user.unread_announcement_ids -= announcement
-        self.env.user.read_announcement_ids += announcement
-        self.env["announcement.log"].create({"announcement_id": announcement.id})
+        # Log only the first time. Users with the announcement in multiple windows would
+        # log multiple reads. We're only interested in the first one.
+        if announcement not in self.env.user.read_announcement_ids:
+            self.env.user.read_announcement_ids += announcement
+            self.env["announcement.log"].create({"announcement_id": announcement.id})


### PR DESCRIPTION
If a user has an announcement open in multiple windows, the read will be logged multiple times. The relevant one is only the first one.

cc @Tecntiva TT38705

please review @victoralmau @pedrobaeza 