### PR TITLE
[IMP] document_quick_access_folder_auto_classification: Add Python-OpenCV as backup check

### DIFF
--- a/document_quick_access_folder_auto_classification/__manifest__.py
+++ b/document_quick_access_folder_auto_classification/__manifest__.py
@@ -11,7 +11,7 @@
     "website": "https://github.com/OCA/server-ux",
     "depends": ["document_quick_access", "edi_storage"],
     "external_dependencies": {
-        "deb": ["libzbar0", "poppler-utils"],
+        "deb": ["libzbar0", "poppler-utils", "libgl1"],
         "python": ["pyzbar", "pdf2image"],
     },
     "data": [

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,1 +1,3 @@
 odoo_test_helper
+opencv-python
+numpy


### PR DESCRIPTION
In some cases ZBar might not find the QR, OpenCV might be better. However, we keep it as it is. We might consider the change on 16 :thinking: 