### PR TITLE
[13.0][IMP] announcement: configurable full width

### DIFF
--- a/announcement/README.rst
+++ b/announcement/README.rst
@@ -58,6 +58,12 @@ When your user has such permissions, this is the way to create an announcement:
 #. If the announcement doesn't make sense once a date is passed, you can set a due date.
    From that date, the announcement won't be shown to anyone.
 
+There's a soft compatibility with OCA's `web_dialog_size` module. If the instance has
+the module installed, you'll have the dialog resize controls by default in the
+announcements. Additionally, you can show the announcement dialogs expanded to the
+screen full width by default setting the system parameter key `announcement.full_size`
+with to any value. Remove the parameter record to disable this behavior.
+
 Usage
 =====
 

--- a/announcement/models/__init__.py
+++ b/announcement/models/__init__.py
@@ -1,2 +1,3 @@
 from . import announcement
+from . import ir_config_parameter
 from . import res_users

--- a/announcement/models/ir_config_parameter.py
+++ b/announcement/models/ir_config_parameter.py
@@ -1,0 +1,11 @@
+# Copyright 2022 Tecnativa - David
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from odoo import api, models
+
+
+class IrConfigParameter(models.Model):
+    _inherit = "ir.config_parameter"
+
+    @api.model
+    def announcement_full_size(self):
+        return self.sudo().get_param("announcement.full_size")

--- a/announcement/readme/CONFIGURE.rst
+++ b/announcement/readme/CONFIGURE.rst
@@ -19,3 +19,9 @@ When your user has such permissions, this is the way to create an announcement:
    announcement won't show up until that date.
 #. If the announcement doesn't make sense once a date is passed, you can set a due date.
    From that date, the announcement won't be shown to anyone.
+
+There's a soft compatibility with OCA's `web_dialog_size` module. If the instance has
+the module installed, you'll have the dialog resize controls by default in the
+announcements. Additionally, you can show the announcement dialogs expanded to the
+screen full width by default setting the system parameter key `announcement.full_size`
+with to any value. Remove the parameter record to disable this behavior.

--- a/announcement/static/description/index.html
+++ b/announcement/static/description/index.html
@@ -3,7 +3,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<meta name="generator" content="Docutils 0.15.1: http://docutils.sourceforge.net/" />
+<meta name="generator" content="Docutils: http://docutils.sourceforge.net/" />
 <title>Announcement</title>
 <style type="text/css">
 
@@ -410,6 +410,11 @@ announcement won’t show up until that date.</li>
 <li>If the announcement doesn’t make sense once a date is passed, you can set a due date.
 From that date, the announcement won’t be shown to anyone.</li>
 </ol>
+<p>There’s a soft compatibility with OCA’s <cite>web_dialog_size</cite> module. If the instance has
+the module installed, you’ll have the dialog resize controls by default in the
+announcements. Additionally, you can show the announcement dialogs expanded to the
+screen full width by default setting the system parameter key <cite>announcement.full_size</cite>
+with to any value. Remove the parameter record to disable this behavior.</p>
 </div>
 <div class="section" id="usage">
 <h1><a class="toc-backref" href="#id2">Usage</a></h1>

--- a/announcement/static/src/js/announcement_dialog.js
+++ b/announcement/static/src/js/announcement_dialog.js
@@ -2,6 +2,7 @@ odoo.define("announcement.AnnouncementDialog", function(require) {
     "use strict";
 
     const core = require("web.core");
+    const rpc = require("web.rpc");
     const Dialog = require("web.Dialog");
 
     const QWeb = core.qweb;
@@ -39,7 +40,16 @@ odoo.define("announcement.AnnouncementDialog", function(require) {
                     this.$modal
                         .find(".dialog_button_restore")
                         .on("click", this.proxy("_restore"));
-                    this._extending();
+                    rpc.query({
+                        model: "ir.config_parameter",
+                        method: "announcement_full_size",
+                    }).then(config_full_size => {
+                        if (config_full_size) {
+                            this._extending();
+                            return;
+                        }
+                        this._restore();
+                    });
                 }
                 this.$footer = this.$modal.find(".modal-footer");
                 this.set_buttons(this.buttons);


### PR DESCRIPTION
There's a soft compatibility with OCA's `web_dialog_size` module. If the instance has the module installed, you'll have the dialog resize controls by default in the announcements. Additionally, you can show the announcement dialogs expanded to the screen full width by default setting the system parameter key `announcement.full_size` with to any value. Remove the parameter record to disable this behavior.

cc @Tecnativa TT39634

please review @pedrobaeza @CarlosRoca13 