### PR TITLE
[12.0][FIX] base_tier_validation: port from #273

### DIFF
--- a/base_tier_validation/static/src/js/systray.js
+++ b/base_tier_validation/static/src/js/systray.js
@@ -123,12 +123,7 @@ odoo.define('tier_validation.systray', function (require) {
                 res_model: data.res_model,
                 views: [[false, 'list'], [false, 'form']],
                 search_view_id: [false],
-                domain: [
-                    ["review_ids.reviewer_ids", "=", session.uid],
-                    ["review_ids.status", "=", "pending"],
-                    ["review_ids.can_review", "=", true],
-                    ["rejected", "=", false],
-                ],
+                domain: [["can_review", "=", true]],
                 context: context,
             });
         },


### PR DESCRIPTION
Port from #273 

@kittiu Apparently this modification had already been made but for some reason in this other PR it returned to what it was
https://github.com/oca/server-ux/commit/8126a10bf288b5144cbc8903459d93921f9c30c1#diff-3e06a347716d25487820eafd239b0c3839ad41c3dca7f0efe62880ecb085fe13L126

cc @rvalyi @douglascstd @netosjb @felipemotter 