### PR TITLE
[12.0][FIX] base_tier_validation: Ignore active_test coming from upstream methods

### DIFF
--- a/base_tier_validation/models/tier_validation.py
+++ b/base_tier_validation/models/tier_validation.py
@@ -142,6 +142,11 @@ class TierValidation(models.AbstractModel):
 
     @api.multi
     def _compute_need_validation(self):
+        # Ignore active_test coming from upstream methods
+        if 'active_test' in self._context:
+            context = dict(self._context)
+            del context['active_test']
+            self = self.with_context(context)
         for rec in self:
             tiers = self.env[
                 'tier.definition'].search([('model', '=', self._name)])


### PR DESCRIPTION
The use case is when filtering account invoice, active_test = False is set in the context down-streaming the context to the search inside evaluate tier.

Not happening on v14. Need to be check for v13

CC @ForgeFlow 