### PR TITLE
[16.0][IMP] server_action_mass_edit: Do not re-use demo and admin users to avoid incompatibilities with data from those users.

### DIFF
--- a/server_action_mass_edit/tests/test_mass_editing.py
+++ b/server_action_mass_edit/tests/test_mass_editing.py
@@ -6,7 +6,7 @@
 from ast import literal_eval
 
 from odoo.exceptions import ValidationError
-from odoo.tests import Form, common
+from odoo.tests import Form, common, new_test_user
 
 from odoo.addons.base.models.ir_actions import IrActionsServer
 
@@ -36,9 +36,16 @@ class TestMassEditing(common.TransactionCase):
         self.mass_editing_partner_title = self.env.ref(
             "server_action_mass_edit.mass_editing_partner_title"
         )
-
-        self.users = self.env["res.users"].search([])
-        self.user = self.env.ref("base.user_demo")
+        user_admin = self.env.ref("base.user_admin")
+        user_demo = self.env.ref("base.user_demo")
+        self.users = self.env["res.users"].search(
+            [("id", "not in", (user_admin.id, user_demo.id))]
+        )
+        self.user = new_test_user(
+            self.env,
+            login="test-mass_editing-user",
+            groups="base.group_system",
+        )
         self.partner_title = self._create_partner_title()
 
     def _create_partner_title(self):


### PR DESCRIPTION
FWP from 15.0: https://github.com/OCA/server-ux/pull/560

Do not re-use demo and admin users to avoid incompatibilities with data from those users.

If module `mass_mailing_partner` was installed the tests showed the error https://github.com/OCA/social/blob/15.0/mass_mailing_partner/models/res_partner.py#L41-L47 related to admin user.

Please @pedrobaeza can you review it?

@Tecnativa