### PR TITLE
[14.0][IMP] base_tier_validation : multi companies context

### DIFF
--- a/base_tier_validation/models/__init__.py
+++ b/base_tier_validation/models/__init__.py
@@ -5,3 +5,4 @@ from . import tier_review
 from . import tier_validation
 from . import res_users
 from . import res_config_settings
+from . import ir_rule

--- a/base_tier_validation/models/ir_rule.py
+++ b/base_tier_validation/models/ir_rule.py
@@ -1,0 +1,16 @@
+# Copyright (C) 2023 Akretion (<http://www.akretion.com>).
+# @author Kévin Roche <kevin.roche@akretion.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import api, models
+
+
+class IrRule(models.Model):
+    _inherit = "ir.rule"
+
+    @api.model
+    def _eval_context(self):
+        ctx = super()._eval_context()
+        if self._context.get("from_review_systray"):
+            ctx["company_ids"] = self.env.user.company_ids.ids
+        return ctx

--- a/base_tier_validation/models/res_users.py
+++ b/base_tier_validation/models/res_users.py
@@ -11,6 +11,7 @@ class Users(models.Model):
 
     @api.model
     def review_user_count(self):
+        self = self.with_context(show_all_companies=True)
         user_reviews = {}
         domain = [
             ("status", "=", "pending"),


### PR DESCRIPTION
In a multi companies context, a validator needs to be in a company to see the records to validate. This PR allows to see all the records waiting validation in all the user companies. 