### PR TITLE
[14.0][IMP] base_tier_validation: skip_validation_check

### DIFF
--- a/base_tier_validation/models/tier_validation.py
+++ b/base_tier_validation/models/tier_validation.py
@@ -274,6 +274,7 @@ class TierValidation(models.AbstractModel):
                 rec.review_ids
                 and rec._check_tier_state_transition(vals)
                 and not rec._check_allow_write_under_validation(vals)
+                and not rec._context.get("skip_validation_check")
             ):
                 raise ValidationError(_("The operation is under validation."))
         if vals.get(new_self._state_field) in (


### PR DESCRIPTION
Some modules have compatibility issues with this one. E.g. delivery_auto_refresh.
_get_under_validation_exceptions() does not cover cases when you dont want to exclude field from a check in general, but only for certain cases, like specific methods calls. Or when multiple fields are changed, but validation check should be skipped.
I suggest to add context  check to avoid "The operation is under validation." raise. 
Im open to any alternative solutions. 
Related:
https://github.com/OCA/server-ux/issues/473
https://github.com/OCA/server-ux/pull/605
https://github.com/OCA/server-ux/pull/607#issuecomment-1461595114