### PR TITLE
[FIX][14.0] base_export_manager: manage

### DIFF
--- a/base_export_manager/models/ir_exports_line.py
+++ b/base_export_manager/models/ir_exports_line.py
@@ -138,6 +138,10 @@ class IrExportsLine(models.Model):
                     one.with_context(skip_check=True)[one.field_n(num, True)] = False
                     continue
                 field_name = parts[num - 1]
+                # Odoo make difference between bank_ids/.id and bank_ids/id, the
+                # former refer to xml id the second the postgresql id column
+                # here we want to find the id field is user request for `.id`
+                field_name = field_name.replace(".id", "id")
                 model = one.model_n(num)
                 # You could get to failing constraint while populating the
                 # fields, so we skip the uniqueness check and manually check

--- a/base_export_manager/tests/test_ir_exports.py
+++ b/base_export_manager/tests/test_ir_exports.py
@@ -17,10 +17,12 @@ class TestIrExportsCase(TransactionCase):
             "name": "Test éxport",
             "resource": "ir.exports",
             "export_fields": [
+                [0, 0, {"name": ".id"}],
                 [0, 0, {"name": "export_fields"}],
                 [0, 0, {"name": "export_fields/create_uid"}],
                 [0, 0, {"name": "export_fields/create_date"}],
                 [0, 0, {"name": "export_fields/field1_id"}],
+                [0, 0, {"name": "export_fields/field1_id/.id"}],
             ],
         }
         virt_record = self.env["ir.exports"].new(data)


### PR DESCRIPTION
while exporting data, (could be before installing this module), if user request for postgresql id, we can get some entries likes ,  in ir.exports.line.

We should be able to handle such existing lines