### PR TITLE
[16.0][FIX] date_range: Remove a test requirement from install dependencies

### DIFF
--- a/date_range/__manifest__.py
+++ b/date_range/__manifest__.py
@@ -29,7 +29,4 @@
     },
     "development_status": "Mature",
     "maintainers": ["lmignon"],
-    "external_dependencies": {
-        "python": ["odoo_test_helper"],
-    },
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
 # generated from manifests external_dependencies
-odoo_test_helper

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,0 +1,1 @@
+odoo_test_helper


### PR DESCRIPTION
odoo_test_helper is only required for testing, should not be added as a dependency

@baimont