### PR TITLE
[FIX] base_tier_validation: Use domain for filtering values

### DIFF
--- a/base_tier_validation/models/tier_validation.py
+++ b/base_tier_validation/models/tier_validation.py
@@ -237,21 +237,13 @@ class TierValidation(models.AbstractModel):
         ) in (self._state_to + [self._cancel_state])
 
     def write(self, vals):
-        new_self = self
-        if (
-            "from_review_systray" in self.env.context
-            and "active_test" in self.env.context
-        ):
-            context = self.env.context.copy()
-            context.pop("active_test")
-            new_self = self.with_context(context)
-        for rec in new_self:
+        for rec in self:
             if rec._check_state_conditions(vals):
                 if rec.need_validation:
                     # try to validate operation
                     reviews = rec.request_validation()
                     rec._validate_tier(reviews)
-                    if not new_self._calc_reviews_validated(reviews):
+                    if not self._calc_reviews_validated(reviews):
                         pending_reviews = reviews.filtered(
                             lambda r: r.status == "pending"
                         ).mapped("name")
@@ -277,11 +269,9 @@ class TierValidation(models.AbstractModel):
                 and not rec._context.get("skip_validation_check")
             ):
                 raise ValidationError(_("The operation is under validation."))
-        if vals.get(new_self._state_field) in (
-            new_self._state_from + [new_self._cancel_state]
-        ):
-            new_self.mapped("review_ids").unlink()
-        return super(TierValidation, new_self).write(vals)
+        if vals.get(self._state_field) in (self._state_from + [self._cancel_state]):
+            self.mapped("review_ids").unlink()
+        return super(TierValidation, self).write(vals)
 
     def _check_state_conditions(self, vals):
         self.ensure_one()

--- a/base_tier_validation/models/tier_validation.py
+++ b/base_tier_validation/models/tier_validation.py
@@ -88,6 +88,7 @@ class TierValidation(models.AbstractModel):
                     ("review_ids.status", "=", "pending"),
                     ("review_ids.can_review", "=", True),
                     ("rejected", "=", False),
+                    ("active", "in", [True, False]),
                 ]
             )
             .filtered("can_review")

--- a/base_tier_validation/static/src/js/systray.js
+++ b/base_tier_validation/static/src/js/systray.js
@@ -134,7 +134,7 @@ odoo.define("tier_validation.systray", function (require) {
                 $(event.currentTarget).data(),
                 $(event.target).data()
             );
-            var context = {active_test: false};
+            var context = {};
             this.do_action({
                 type: "ir.actions.act_window",
                 name: data.model_name,

--- a/base_tier_validation/static/src/js/systray.js
+++ b/base_tier_validation/static/src/js/systray.js
@@ -134,7 +134,7 @@ odoo.define("tier_validation.systray", function (require) {
                 $(event.currentTarget).data(),
                 $(event.target).data()
             );
-            var context = {from_review_systray: true, active_test: false};
+            var context = {active_test: false};
             this.do_action({
                 type: "ir.actions.act_window",
                 name: data.model_name,

--- a/base_tier_validation/static/src/js/systray.js
+++ b/base_tier_validation/static/src/js/systray.js
@@ -144,7 +144,10 @@ odoo.define("tier_validation.systray", function (require) {
                     [false, "form"],
                 ],
                 search_view_id: [false],
-                domain: [["can_review", "=", true]],
+                domain: [
+                    ["can_review", "=", true],
+                    ["active", "in", [true, false]],
+                ],
                 context: context,
             });
         },


### PR DESCRIPTION
Using active_test might arise lots of problems when executing functions. For example, I found the issue when validating Stock request orders, as it was trying to use archived routes. It was a problem, because I had a solution when coming from the widget and another one when using the standard menu.

The right approach is to show them using domain.

@rousseldenis @kittiu @LoisRForgeFlow 