### PR TITLE
[15.0][FIX] base_tier_validation: edit domain can_review

### DIFF
--- a/base_tier_validation/models/tier_validation.py
+++ b/base_tier_validation/models/tier_validation.py
@@ -81,19 +81,15 @@ class TierValidation(models.AbstractModel):
 
     @api.model
     def _search_can_review(self, operator, value):
-        res_ids = (
-            self.search(
-                [
-                    ("review_ids.reviewer_ids", "=", self.env.user.id),
-                    ("review_ids.status", "=", "pending"),
-                    ("review_ids.can_review", "=", True),
-                    ("rejected", "=", False),
-                    ("active", "in", [True, False]),
-                ]
-            )
-            .filtered("can_review")
-            .ids
-        )
+        domain = [
+            ("review_ids.reviewer_ids", "=", self.env.user.id),
+            ("review_ids.status", "=", "pending"),
+            ("review_ids.can_review", "=", True),
+            ("rejected", "=", False),
+        ]
+        if hasattr(self, "active"):
+            domain.append(("active", "in", [True, False]))
+        res_ids = self.search(domain).filtered("can_review").ids
         return [("id", "in", res_ids)]
 
     @api.depends("review_ids")

--- a/base_tier_validation/static/src/js/systray.js
+++ b/base_tier_validation/static/src/js/systray.js
@@ -144,10 +144,7 @@ odoo.define("tier_validation.systray", function (require) {
                     [false, "form"],
                 ],
                 search_view_id: [false],
-                domain: [
-                    ["can_review", "=", true],
-                    ["active", "in", [true, false]],
-                ],
+                domain: [["can_review", "=", true]],
                 context: context,
             });
         },


### PR DESCRIPTION
I found the issue when validating the model without an active field such as Expense. So, I edit `search_can_review` function and I change the domain in `_onReviewFilterClick` to the old code.

NOTE: I don't know how to check if the field exists in .js file (like .py file). You can suggest it to me.