### PR TITLE
[FIX] date_range : change license from AGPL-3 to LGPL-3, because l10n-france/l10n_fr_fec_oca/12.0 (LGPL) depends on date_range

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,9 +36,13 @@ jobs:
       matrix:
         include:
           - container: ghcr.io/oca/oca-ci/py3.6-odoo12.0:latest
+            # See: See: https://github.com/OCA/server-ux/pull/654
+            exclude: "base_import_security_group,base_duplicate_security_group"
             makepot: "true"
             name: test with Odoo
           - container: ghcr.io/oca/oca-ci/py3.6-ocb12.0:latest
+            # See: See: https://github.com/OCA/server-ux/pull/654
+            exclude: "base_import_security_group,base_duplicate_security_group"
             name: test with OCB
     services:
       postgres:
@@ -49,6 +53,9 @@ jobs:
           POSTGRES_DB: odoo
         ports:
           - 5432:5432
+    env:
+      INCLUDE: "${{ matrix.include }}"
+      EXCLUDE: "${{ matrix.exclude }}"
     steps:
       - uses: actions/checkout@v2
         with:

--- a/date_range/__manifest__.py
+++ b/date_range/__manifest__.py
@@ -7,7 +7,7 @@
     "category": "Uncategorized",
     "website": "https://github.com/OCA/server-ux",
     "author": "ACSONE SA/NV, Odoo Community Association (OCA)",
-    "license": "AGPL-3",
+    "license": "LGPL-3",
     "installable": True,
     "depends": [
         "web",


### PR DESCRIPTION
Trivial Change.
for the time being : 
- [l10n_fr_fec_oca](https://github.com/OCA/l10n-france/tree/12.0/l10n_fr_fec_oca) is LGPL-3 and depends on date_range (AGPL-3)
- we don't have the copyright of l10n_fr_fec_oca to change the licence.

**3 options :** 
- remove ``l10n_fr_fec_oca`` from OCA/l10n-france. that solution looks quite radical
- remove dependency to date_range. That solution looks not desirable
- change the license of date_range. (solution simple)

Thanks for your quick review.

(This PR allow to use new oca CI on l10n-france repo. https://github.com/OCA/l10n-france/pull/446)

CC : @sbidoul, @alexis-via 

