### PR TITLE
[15.0][FIX] base_import_security_group: fix test test_error

### DIFF
--- a/base_import_security_group/static/src/js/tour_import.js
+++ b/base_import_security_group/static/src/js/tour_import.js
@@ -10,10 +10,12 @@ odoo.define("base_import_security_group.tour", function (require) {
             url: "/web",
         },
         [
-            tour.stepUtils.showAppsMenuItem(),
+            {
+                trigger: ".o_navbar_apps_menu > button.dropdown-toggle",
+            },
             {
                 id: "settings_menu_click",
-                trigger: '.o_app[data-menu-xmlid="base.menu_administration"]',
+                trigger: '[data-menu-xmlid="base.menu_administration"]',
             },
             {
                 id: "settings_menu_users_and_companies",
@@ -40,10 +42,12 @@ odoo.define("base_import_security_group.tour", function (require) {
             url: "/web",
         },
         [
-            tour.stepUtils.showAppsMenuItem(),
+            {
+                trigger: ".o_navbar_apps_menu > button.dropdown-toggle",
+            },
             {
                 id: "settings_menu_click",
-                trigger: '.o_app[data-menu-xmlid="base.menu_administration"]',
+                trigger: '[data-menu-xmlid="base.menu_administration"]',
             },
             {
                 id: "settings_menu_users_and_companies",


### PR DESCRIPTION
When the web_responsive module is installed, the tests fail when looking for "Settings" in the menu, because you have to access the menu first to get that option. Adding the extra step to display the menu is the right option so that the tests don't fail whether the web_responsive module is installed or not.

Example of the menu without web_responsive:

![image](https://github.com/OCA/server-ux/assets/118818446/4afba1da-bf80-4291-b51a-430d1bc221b5)

Example of the menu with web_responsive:

![image](https://github.com/OCA/server-ux/assets/118818446/1acfc1dd-7519-4767-bd04-ab7c43fa5abe)

Error:

![image](https://github.com/OCA/server-ux/assets/118818446/06d67d07-dc51-456d-8e7b-9e42b166826d)

cc @Tecnativa TT42822

@chienandalu @CarlosRoca13 please review

