### PR TITLE
[13.0][ADD]base_archive_date & web_archive_date

### DIFF
--- a/base_archive_date/__init__.py
+++ b/base_archive_date/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/base_archive_date/__manifest__.py
+++ b/base_archive_date/__manifest__.py
@@ -1,0 +1,17 @@
+# Copyright 2023 ForgeFlow S.L. (https://www.forgeflow.com)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+{
+    "name": "Base Archive Date",
+    "summary": """
+        Adds an archive timestamp and user doing the archiving to all models.
+    """,
+    "version": "13.0.1.0.0",
+    "category": "Usability",
+    "license": "AGPL-3",
+    "website": "https://github.com/OCA/server-ux",
+    "author": "ForgeFlow, Odoo Community Association (OCA)",
+    "depends": ["base"],
+    "maintainers": ["GuillemCForgeFlow"],
+    "installable": True,
+    "application": False,
+}

--- a/base_archive_date/models/__init__.py
+++ b/base_archive_date/models/__init__.py
@@ -1,0 +1,1 @@
+from . import base

--- a/base_archive_date/models/base.py
+++ b/base_archive_date/models/base.py
@@ -1,0 +1,74 @@
+# Copyright 2023 ForgeFlow S.L. (https://www.forgeflow.com)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+from odoo import api, fields, models
+
+LOG_ARCHIVE_DATE = "archive_date"
+LOG_ARCHIVE_UID = "archive_uid"
+
+
+class Base(models.AbstractModel):
+    """
+    The base model is inherited by all models.
+
+    Whenever a record has the active field, we save the latest date in which the record
+    has been archived, False otherwise. We also save which user did the archiving.
+    """
+
+    _inherit = "base"
+
+    @api.model
+    def _get_now_date(self):
+        """
+        :return: datetime.datetime: actual time formated in the way Odoo saves dates
+        for base fields, such as write_date or create_date
+        """
+        now = fields.Datetime.context_timestamp(self, fields.Datetime.now())
+        return now.replace(tzinfo=None)
+
+    @api.model
+    def _add_magic_fields(self):
+        result = super(Base, self)._add_magic_fields()
+        if self._log_access and "active" in self._fields:
+            self._add_field(
+                LOG_ARCHIVE_DATE,
+                fields.Datetime(
+                    string="Last Archived on", automatic=True, readonly=True
+                ),
+            )
+            self._add_field(
+                LOG_ARCHIVE_UID,
+                fields.Many2one(
+                    comodel_name="res.users",
+                    string="Last Archived by",
+                    automatic=True,
+                    readonly=True,
+                ),
+            )
+        return result
+
+    @api.model_create_multi
+    @api.returns("self", lambda value: value.id)
+    def create(self, vals_list):
+        if self._log_access:
+            for vals in vals_list:
+                if "active" in vals:
+                    archive_date = (
+                        False if vals.get("active", False) else self._get_now_date()
+                    )
+                    archive_uid = self.env.user.id if archive_date else False
+                    vals.update(
+                        {LOG_ARCHIVE_DATE: archive_date, LOG_ARCHIVE_UID: archive_uid}
+                    )
+        return super(Base, self).create(vals_list)
+
+    def write(self, vals):
+        if (
+            self._log_access
+            and LOG_ARCHIVE_DATE not in vals
+            and "active" in vals
+            and not vals.get("active", True)
+        ):
+            now = self._get_now_date()
+            user_id = self.env.user.id
+            vals.update({LOG_ARCHIVE_DATE: now, LOG_ARCHIVE_UID: user_id})
+        return super(Base, self).write(vals)

--- a/base_archive_date/readme/CONTRIBUTORS.rst
+++ b/base_archive_date/readme/CONTRIBUTORS.rst
@@ -1,0 +1,3 @@
+* `ForgeFlow S.L. <https://www.forgeflow.com>`_:
+
+  * Guillem Casassas <guillem.casassas@forgeflow.com>

--- a/base_archive_date/readme/DESCRIPTION.rst
+++ b/base_archive_date/readme/DESCRIPTION.rst
@@ -1,0 +1,3 @@
+This module adds an archive timestamp and the user who did the archiving to all models having the `active` field.
+
+Whenever a record is archived, the latest archived date is timestamped on the record.

--- a/base_archive_date/readme/USAGE.rst
+++ b/base_archive_date/readme/USAGE.rst
@@ -1,0 +1,2 @@
+#. Archive a record and the timestamp of the moment that the record has been archived is
+saved on the record on the `archive_date` technical field, also the user doing the archiving is saved under the `archive_uid` field.

--- a/base_archive_date/tests/__init__.py
+++ b/base_archive_date/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_base_archive_date

--- a/base_archive_date/tests/test_base_archive_date.py
+++ b/base_archive_date/tests/test_base_archive_date.py
@@ -1,0 +1,33 @@
+# Copyright 2023 ForgeFlow S.L. (https://www.forgeflow.com)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import fields
+from odoo.tests.common import SavepointCase
+
+
+class TestBaseArchiveDate(SavepointCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
+
+        # Models
+        cls.partner_model = cls.env["res.partner"]
+
+        # Instances
+        cls.partner = cls.partner_model.create({"name": "Test Partner"})
+
+    def test_01_archive_partner_timestamp(self):
+        """
+        Check that the technical field exists and check for the timestamp once the
+        partner is archived.
+        """
+        self.assertTrue(self.partner.active)
+        self.assertTrue("archive_date" in self.partner._fields)
+        self.partner.toggle_active()
+        now = fields.Datetime.context_timestamp(
+            self.partner, fields.Datetime.now()
+        ).replace(tzinfo=None)
+        self.assertEqual(
+            self.partner.archive_date, now, "Archive Date should be equal to now."
+        )

--- a/setup/base_archive_date/odoo/addons/base_archive_date
+++ b/setup/base_archive_date/odoo/addons/base_archive_date
@@ -1,0 +1,1 @@
+../../../../base_archive_date

--- a/setup/base_archive_date/setup.py
+++ b/setup/base_archive_date/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)

--- a/setup/web_archive_date/odoo/addons/web_archive_date
+++ b/setup/web_archive_date/odoo/addons/web_archive_date
@@ -1,0 +1,1 @@
+../../../../web_archive_date

--- a/setup/web_archive_date/setup.py
+++ b/setup/web_archive_date/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)

--- a/web_archive_date/__init__.py
+++ b/web_archive_date/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/web_archive_date/__manifest__.py
+++ b/web_archive_date/__manifest__.py
@@ -1,0 +1,19 @@
+# Copyright 2023 ForgeFlow S.L. (https://www.forgeflow.com)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+{
+    "name": "Web Archive Date",
+    "summary": """
+        Reflects the Latest Archived Date and Latest Archived by on the record metadata.
+    """,
+    "version": "13.0.1.0.0",
+    "category": "Usability",
+    "license": "AGPL-3",
+    "website": "https://github.com/OCA/server-ux",
+    "author": "ForgeFlow, Odoo Community Association (OCA)",
+    "depends": ["web", "base_archive_date"],
+    "maintainers": ["GuillemCForgeFlow"],
+    "qweb": ["static/src/xml/debug.xml"],
+    "installable": True,
+    "application": False,
+    "auto_install": True,
+}

--- a/web_archive_date/models/__init__.py
+++ b/web_archive_date/models/__init__.py
@@ -1,0 +1,1 @@
+from . import base

--- a/web_archive_date/models/base.py
+++ b/web_archive_date/models/base.py
@@ -1,0 +1,23 @@
+# Copyright 2023 ForgeFlow S.L. (https://www.forgeflow.com)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+from odoo import models
+
+from odoo.addons.base_archive_date.models.base import LOG_ARCHIVE_DATE, LOG_ARCHIVE_UID
+
+
+class Base(models.AbstractModel):
+    _inherit = "base"
+
+    def get_metadata(self):
+        def merge_lists_of_dicts(original, new, key):
+            merged_dict = {}
+            for item in original:
+                merged_dict[item[key]] = item
+            for item in new:
+                merged_dict.setdefault(item[key], {}).update(item)
+            merged_list = list(merged_dict.values())
+            return merged_list
+
+        result = super(Base, self).get_metadata()
+        archive_dict = self.read([LOG_ARCHIVE_DATE, LOG_ARCHIVE_UID])
+        return merge_lists_of_dicts(result, archive_dict, "id")

--- a/web_archive_date/readme/CONTRIBUTORS.rst
+++ b/web_archive_date/readme/CONTRIBUTORS.rst
@@ -1,0 +1,3 @@
+* `ForgeFlow S.L. <https://www.forgeflow.com>`_:
+
+  * Guillem Casassas <guillem.casassas@forgeflow.com>

--- a/web_archive_date/readme/DESCRIPTION.rst
+++ b/web_archive_date/readme/DESCRIPTION.rst
@@ -1,0 +1,3 @@
+Glue module between `web` and `base_archive_date`.
+
+This module adds the `Latest Archived Date:` and `Latest Archived by:` as fields showing in the metadata of a record. Just like the `Latest Modification Date:` (write_date) or the `Created by:` (create_uid).

--- a/web_archive_date/readme/ROADMAP.rst
+++ b/web_archive_date/readme/ROADMAP.rst
@@ -1,0 +1,3 @@
+Format of `archive_date` is not the same as `write_date` shown in the metadata. Values are formatted in javascript. Can't inherit the method and adapt the value there.
+
+TO BE DONE: Check how to format the value in the QWeb view somehow.

--- a/web_archive_date/readme/USAGE.rst
+++ b/web_archive_date/readme/USAGE.rst
@@ -1,0 +1,6 @@
+#. Install the module, archive a record and show on the Metdata of the record and you'll
+be able to see the `Latest Archived Date` `Latest Archived by` there.
+#. To check the Metadata:
+* Activate the Developer Mode.
+* Click on the `bug`, once the markdown appears, click on the View Metadata button.
+* You can check the `Latest Archived Date` and `Latest Archived by` value once the record has been archived previously.

--- a/web_archive_date/static/src/xml/debug.xml
+++ b/web_archive_date/static/src/xml/debug.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!-- # Copyright 2023 ForgeFlow S.L. (https://www.forgeflow.com)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html). -->
+<template id="template" xml:space="preserve">
+    <t t-extend="WebClient.DebugViewLog">
+        <t t-jquery="tr:last" t-operation='after'>
+            <tr t-if="perm.archive_date">
+                <th>Latest Archived Date:</th>
+                <td><t t-esc="perm.archive_date" /></td>
+            </tr>
+            <tr t-if="perm.archive_uid">
+                <th>Latest Archived by:</th>
+                <td><t t-esc="perm.archive_uid[1]" /></td>
+            </tr>
+        </t>
+    </t>
+</template>

--- a/web_archive_date/tests/__init__.py
+++ b/web_archive_date/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_web_archive_date

--- a/web_archive_date/tests/test_web_archive_date.py
+++ b/web_archive_date/tests/test_web_archive_date.py
@@ -1,0 +1,40 @@
+# Copyright 2023 ForgeFlow S.L. (https://www.forgeflow.com)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo.addons.base_archive_date.tests.test_base_archive_date import (
+    TestBaseArchiveDate,
+)
+
+
+class TestWebArchiveDate(TestBaseArchiveDate):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
+
+    def test_01_check_metadata_shown(self):
+        """
+        Check that the method getting the metadata on a record, once it is archived.
+        """
+        self.partner.toggle_active()
+        metadata = self.partner.get_metadata()
+        self.assertEqual(len(metadata), 1, "List should only contain one value.")
+        value = metadata[0]
+        self.assertTrue(value)
+        self.assertTrue(
+            "id" in value.keys() and self.partner.id == value.get("id"),
+            "Partner ID should be the value of the key ID in the dictionary.",
+        )
+        self.assertTrue(
+            "archive_date" in value.keys() and "archive_uid" in value.keys()
+        )
+        self.assertEqual(
+            value.get("archive_date"),
+            self.partner.archive_date,
+            "Value shown in the metadata view should be equal to the one set in the partner.",
+        )
+        self.assertEqual(
+            value.get("archive_uid")[0],
+            self.partner.archive_uid.id,
+            "User ID shown used in the metadata should be the same as the archive_uid value.",
+        )


### PR DESCRIPTION
Adds an archived timestamp and user archiving whenever a record is archived.

Two modules:

- Base module to set the archived date and user archiving the record.
- Glue module between first module and web to display the values on the _View Metadata_ section.

cc @ForgeFlow