### PR TITLE
[14.0][WIP] base_tier_validation: Change FakeModelLoader to setup_test_model()

### DIFF
--- a/base_tier_validation/tests/__init__.py
+++ b/base_tier_validation/tests/__init__.py
@@ -1,4 +1,3 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
-from . import common
 from . import test_tier_validation

--- a/base_tier_validation/tests/test_tier_validation.py
+++ b/base_tier_validation/tests/test_tier_validation.py
@@ -481,9 +481,6 @@ class TierTierValidation(CommonTierValidation):
         self.assertTrue(review)
         self.assertEqual(review.reviewer_ids, self.test_user_2)
 
-
-@tagged("at_install")
-class TierTierValidationView(CommonTierValidation):
     def test_view_manual(self):
         # We need to add a view in order to ensure that an automatic view with all
         # fields is not created

--- a/base_tier_validation_formula/tests/test_tier_validation.py
+++ b/base_tier_validation_formula/tests/test_tier_validation.py
@@ -1,73 +1,19 @@
 # Copyright 2018 ForgeFlow S.L.
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
 
-from odoo_test_helper import FakeModelLoader
-
 from odoo.exceptions import UserError
-from odoo.tests import common
+from odoo.tests import new_test_user
 from odoo.tests.common import tagged
+
+from odoo.addons.base_tier_validation.tests.common import CommonTierValidation
 
 
 @tagged("post_install", "-at_install")
-class TierTierValidation(common.SavepointCase):
+class TierTierValidation(CommonTierValidation):
     @classmethod
     def setUpClass(cls):
-        super(TierTierValidation, cls).setUpClass()
-
-        cls.loader = FakeModelLoader(cls.env, cls.__module__)
-        cls.loader.backup_registry()
-        from odoo.addons.base_tier_validation.tests.tier_validation_tester import (
-            TierValidationTester,
-        )
-
-        cls.loader.update_registry((TierValidationTester,))
-        cls.test_model = cls.env[TierValidationTester._name]
-
-        cls.tester_model = cls.env["ir.model"].search(
-            [("model", "=", "tier.validation.tester")]
-        )
-
-        # Access record:
-        cls.env["ir.model.access"].create(
-            {
-                "name": "access.tester",
-                "model_id": cls.tester_model.id,
-                "perm_read": 1,
-                "perm_write": 1,
-                "perm_create": 1,
-                "perm_unlink": 1,
-            }
-        )
-
-        # Create users:
-        group_ids = cls.env.ref("base.group_system").ids
-        cls.test_user_1 = cls.env["res.users"].create(
-            {"name": "John", "login": "test1", "groups_id": [(6, 0, group_ids)]}
-        )
-        cls.test_user_2 = cls.env["res.users"].create(
-            {"name": "Mike", "login": "test2"}
-        )
-        cls.test_user_3 = cls.env["res.users"].create(
-            {"name": "Mary", "login": "test3"}
-        )
-
-        # Create tier definitions:
-        cls.tier_def_obj = cls.env["tier.definition"]
-        cls.tier_def_obj.create(
-            {
-                "model_id": cls.tester_model.id,
-                "review_type": "individual",
-                "reviewer_id": cls.test_user_1.id,
-                "definition_domain": "[('test_field', '>', 1.0)]",
-            }
-        )
-
-        cls.test_record = cls.test_model.create({"test_field": 2.5})
-
-    @classmethod
-    def tearDownClass(cls):
-        cls.loader.restore_registry()
-        super(TierTierValidation, cls).tearDownClass()
+        super().setUpClass()
+        cls.test_user_3 = new_test_user(cls.env, name="Mary", login="test3")
 
     def test_01_reviewer_from_python_expression(self):
         tier_definition = self.tier_def_obj.create(

--- a/base_tier_validation_forward/tests/test_tier_validation.py
+++ b/base_tier_validation_forward/tests/test_tier_validation.py
@@ -1,72 +1,18 @@
 # Copyright 2018 ForgeFlow S.L.
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
 
-from odoo_test_helper import FakeModelLoader
-
 from odoo.tests import Form
-from odoo.tests.common import SavepointCase, tagged
+from odoo.tests.common import new_test_user, tagged
+
+from odoo.addons.base_tier_validation.tests.common import CommonTierValidation
 
 
 @tagged("post_install", "-at_install")
-class TierTierValidation(SavepointCase):
+class TierTierValidation(CommonTierValidation):
     @classmethod
     def setUpClass(cls):
-        super(TierTierValidation, cls).setUpClass()
-
-        cls.loader = FakeModelLoader(cls.env, cls.__module__)
-        cls.loader.backup_registry()
-        from odoo.addons.base_tier_validation.tests.tier_validation_tester import (
-            TierValidationTester,
-        )
-
-        cls.loader.update_registry((TierValidationTester,))
-        cls.test_model = cls.env[TierValidationTester._name]
-
-        cls.tester_model = cls.env["ir.model"].search(
-            [("model", "=", "tier.validation.tester")]
-        )
-
-        # Access record:
-        cls.env["ir.model.access"].create(
-            {
-                "name": "access.tester",
-                "model_id": cls.tester_model.id,
-                "perm_read": 1,
-                "perm_write": 1,
-                "perm_create": 1,
-                "perm_unlink": 1,
-            }
-        )
-
-        # Create users:
-        group_ids = cls.env.ref("base.group_system").ids
-        cls.test_user_1 = cls.env["res.users"].create(
-            {"name": "John", "login": "test1", "groups_id": [(6, 0, group_ids)]}
-        )
-        cls.test_user_2 = cls.env["res.users"].create(
-            {"name": "Mike", "login": "test2"}
-        )
-        cls.test_user_3 = cls.env["res.users"].create(
-            {"name": "Mary", "login": "test3"}
-        )
-
-        # Create tier definitions:
-        cls.tier_def_obj = cls.env["tier.definition"]
-        cls.tier_def_obj.create(
-            {
-                "model_id": cls.tester_model.id,
-                "review_type": "individual",
-                "reviewer_id": cls.test_user_1.id,
-                "definition_domain": "[('test_field', '>', 1.0)]",
-            }
-        )
-
-        cls.test_record = cls.test_model.create({"test_field": 2.5})
-
-    @classmethod
-    def tearDownClass(cls):
-        cls.loader.restore_registry()
-        super(TierTierValidation, cls).tearDownClass()
+        super().setUpClass()
+        cls.test_user_3 = new_test_user(cls.env, name="Mary", login="test3")
 
     def test_01_forward_tier(self):
         # Create new test record

--- a/base_tier_validation_server_action/tests/test_tier_validation.py
+++ b/base_tier_validation_server_action/tests/test_tier_validation.py
@@ -1,27 +1,27 @@
 # Copyright 2020 Ecosoft (http://ecosoft.co.th)
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
-from odoo_test_helper import FakeModelLoader
 
-from odoo.tests import common
+from odoo.tests import common, new_test_user
 from odoo.tests.common import tagged
+
+from odoo.addons.base_tier_validation.tests.common import (
+    setup_test_model,
+    teardown_test_model,
+)
+
+from .tier_validation_tester import TierValidationTester
 
 
 @tagged("post_install", "-at_install")
 class TierTierValidation(common.SavepointCase):
     @classmethod
     def setUpClass(cls):
-        super(TierTierValidation, cls).setUpClass()
-
-        cls.loader = FakeModelLoader(cls.env, cls.__module__)
-        cls.loader.backup_registry()
-        from .tier_validation_tester import TierValidationTester
-
-        cls.loader.update_registry((TierValidationTester,))
+        super().setUpClass()
+        setup_test_model(cls.env, [TierValidationTester])
         cls.test_model = cls.env[TierValidationTester._name]
         cls.tester_model = cls.env["ir.model"].search(
             [("model", "=", "tier.validation.tester")]
         )
-
         # Access record:
         cls.env["ir.model.access"].create(
             {
@@ -33,20 +33,21 @@ class TierTierValidation(common.SavepointCase):
                 "perm_unlink": 1,
             }
         )
-
         # Create users:
         cls.group_system = cls.env.ref("base.group_system")
-        group_ids = cls.group_system.ids
-        cls.test_user_1 = cls.env["res.users"].create(
-            {"name": "John", "login": "test1", "groups_id": [(6, 0, group_ids)]}
+        cls.test_user_1 = new_test_user(
+            cls.env,
+            name="John",
+            login="test1",
+            groups="base.group_system",
         )
-        cls.test_user_2 = cls.env["res.users"].create(
-            {"name": "Mike", "login": "test2"}
+        cls.test_user_2 = new_test_user(cls.env, name="Mike", login="test2")
+        cls.test_user_3 = new_test_user(
+            cls.env,
+            name="John Wick",
+            login="test3",
+            groups="base.group_system",
         )
-        cls.test_user_3 = cls.env["res.users"].create(
-            {"name": "John Wick", "login": "test3", "groups_id": [(6, 0, group_ids)]}
-        )
-
         # Create tier definitions:
         cls.tier_def_obj = cls.env["tier.definition"]
         cls.tier_def_obj.create(
@@ -58,13 +59,12 @@ class TierTierValidation(common.SavepointCase):
                 "sequence": 30,
             }
         )
-
         cls.test_record = cls.test_model.create({"test_field": 2.5})
 
     @classmethod
     def tearDownClass(cls):
-        cls.loader.restore_registry()
-        super(TierTierValidation, cls).tearDownClass()
+        teardown_test_model(cls.env, [TierValidationTester])
+        return super().tearDownClass()
 
     def test_1_auto_validation(self):
         # Create new test record

--- a/base_tier_validation_waiting/tests/test_tier_validation.py
+++ b/base_tier_validation_waiting/tests/test_tier_validation.py
@@ -1,64 +1,16 @@
 # Copyright (c) 2022 brain-tec AG (https://braintec.com)
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
 
-from odoo_test_helper import FakeModelLoader
+from odoo.tests.common import tagged
 
-from odoo.tests.common import SavepointCase, tagged
+from odoo.addons.base_tier_validation.tests.common import CommonTierValidation
 
 
 @tagged("post_install", "-at_install")
-class TierTierValidation(SavepointCase):
+class TierTierValidation(CommonTierValidation):
     @classmethod
     def setUpClass(cls):
-        super(TierTierValidation, cls).setUpClass()
-
-        cls.loader = FakeModelLoader(cls.env, cls.__module__)
-        cls.loader.backup_registry()
-        from odoo.addons.base_tier_validation.tests.tier_validation_tester import (
-            TierValidationTester,
-        )
-
-        cls.loader.update_registry((TierValidationTester,))
-        cls.test_model = cls.env[TierValidationTester._name]
-
-        cls.tester_model = cls.env["ir.model"].search(
-            [("model", "=", "tier.validation.tester")]
-        )
-
-        # Access record:
-        cls.env["ir.model.access"].create(
-            {
-                "name": "access.tester",
-                "model_id": cls.tester_model.id,
-                "perm_read": 1,
-                "perm_write": 1,
-                "perm_create": 1,
-                "perm_unlink": 1,
-            }
-        )
-
-        # Create users:
-        group_ids = cls.env.ref("base.group_system").ids
-        cls.test_user_1 = cls.env["res.users"].create(
-            {"name": "John", "login": "test1", "groups_id": [(6, 0, group_ids)]}
-        )
-        cls.test_user_2 = cls.env["res.users"].create(
-            {"name": "Mike", "login": "test2"}
-        )
-
-        # Create tier definitions:
-        cls.tier_def_obj = cls.env["tier.definition"]
-        cls.tier_def_obj.create(
-            {
-                "model_id": cls.tester_model.id,
-                "review_type": "individual",
-                "reviewer_id": cls.test_user_1.id,
-                "definition_domain": "[('test_field', '>', 1.0)]",
-                "approve_sequence": True,
-                "sequence": 20,
-                "name": "Test definition 1 - user 1",
-            }
-        )
+        super().setUpClass()
         cls.tier_def_obj.create(
             {
                 "model_id": cls.tester_model.id,
@@ -70,13 +22,6 @@ class TierTierValidation(SavepointCase):
                 "name": "Test definition 2 -  user 2",
             }
         )
-
-        cls.test_record = cls.test_model.create({"test_field": 2.5})
-
-    @classmethod
-    def tearDownClass(cls):
-        cls.loader.restore_registry()
-        super(TierTierValidation, cls).tearDownClass()
 
     def test_01_waiting_tier(self):
         # Create new test record


### PR DESCRIPTION
Change `FakeModelLoader` to `setup_test_model()` (similar to tests of `account_move_tier_validation`: https://github.com/OCA/account-invoicing/blob/14.0/account_move_tier_validation/tests/test_tier_validation.py#L17)

@Tecnativa TT43351