### PR TITLE
[15.0][IMP] announcement: add general_anouncement option to announcement

### DIFF
--- a/announcement/views/announcement_views.xml
+++ b/announcement/views/announcement_views.xml
@@ -67,6 +67,9 @@
                         </h1>
                     </div>
                     <group>
+                        <field name="is_general_announcement" />
+                    </group>
+                    <group>
                         <field name="active" invisible="1" />
                         <group name="announcement_validity">
                             <field name="notification_date" string="Announce at" />
@@ -115,7 +118,10 @@
                 </button>
             </xpath>
             <group name="announcement_validity" position="before">
-                <group name="announcement_scope">
+                <group
+                    name="announcement_scope"
+                    attrs="{'invisible': [('is_general_announcement', '=', True)]}"
+                >
                     <field name="announcement_type" />
                     <field
                         name="specific_user_ids"


### PR DESCRIPTION
A new field "is_general_announcement" is added which when checked sends the announcement to users belonging to the "Internal User" group.

cc @Tecnativa TT42581

@chienandalu @victoralmau please review :)