### PR TITLE
[14.0][IMP] base_tier_validation : add write possibility for reviewers

### DIFF
--- a/base_tier_validation/i18n/fr.po
+++ b/base_tier_validation/i18n/fr.po
@@ -6,15 +6,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 14.0\n"
 "Report-Msgid-Bugs-To: \n"
-"PO-Revision-Date: 2021-05-14 19:47+0000\n"
-"Last-Translator: Yves Le Doeuff <yld@alliasys.fr>\n"
-"Language-Team: none\n"
+"POT-Creation-Date: 2023-06-30 16:12+0000\n"
+"PO-Revision-Date: 2023-06-30 18:14+0200\n"
+"Last-Translator: \n"
+"Language-Team: \n"
 "Language: fr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
-"Plural-Forms: nplurals=2; plural=n > 1;\n"
-"X-Generator: Weblate 4.3.2\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"X-Generator: Poedit 3.3.2\n"
 
 #. module: base_tier_validation
 #. openerp-web
@@ -126,6 +127,11 @@ msgid "All"
 msgstr "Tout"
 
 #. module: base_tier_validation
+#: model:ir.model.fields,field_description:base_tier_validation.field_tier_definition__allow_write_for_reviewer
+msgid "Allow Write For Reviewers"
+msgstr "Modification par les Vérificateurs"
+
+#. module: base_tier_validation
 #: model:ir.model.fields.selection,name:base_tier_validation.selection__tier_definition__review_type__group
 msgid "Any user in a specific group"
 msgstr ""
@@ -214,7 +220,7 @@ msgstr "Société"
 #. module: base_tier_validation
 #: model:ir.model,name:base_tier_validation.model_res_config_settings
 msgid "Config Settings"
-msgstr ""
+msgstr "Paramètres de config"
 
 #. module: base_tier_validation
 #: model:ir.model.fields,field_description:base_tier_validation.field_comment_wizard__create_uid
@@ -258,7 +264,7 @@ msgstr ""
 #: model:ir.model.fields,field_description:base_tier_validation.field_tier_review__display_name
 #: model:ir.model.fields,field_description:base_tier_validation.field_tier_validation__display_name
 msgid "Display Name"
-msgstr ""
+msgstr "Nom affiché"
 
 #. module: base_tier_validation
 #: model:ir.model.fields.selection,name:base_tier_validation.selection__tier_definition__definition_type__domain
@@ -323,7 +329,7 @@ msgstr ""
 #: model:ir.model.fields,field_description:base_tier_validation.field_tier_review____last_update
 #: model:ir.model.fields,field_description:base_tier_validation.field_tier_validation____last_update
 msgid "Last Modified on"
-msgstr ""
+msgstr "Dernière modification le"
 
 #. module: base_tier_validation
 #: model:ir.model.fields,field_description:base_tier_validation.field_comment_wizard__write_uid
@@ -532,7 +538,6 @@ msgstr "Vérifications"
 #. openerp-web
 #: code:addons/base_tier_validation/static/src/xml/tier_review_template.xml:0
 #: model:ir.model.fields,field_description:base_tier_validation.field_tier_definition__sequence
-#: model:ir.model.fields,field_description:base_tier_validation.field_tier_review__sequence
 #, python-format
 msgid "Sequence"
 msgstr ""
@@ -578,9 +583,15 @@ msgstr ""
 #: code:addons/base_tier_validation/models/tier_validation.py:0
 #, python-format
 msgid ""
-"This action needs to be validated for at least one record. Reviews pending:\n"
+"This action needs to be validated for at least one record. Reviews "
+"pending:\n"
 " - %s \n"
 "Please request a validation."
+msgstr ""
+
+#. module: base_tier_validation
+#: model:ir.model.fields,field_description:base_tier_validation.field_tier_review__sequence
+msgid "Tier"
 msgstr ""
 
 #. module: base_tier_validation
@@ -723,6 +734,3 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:base_tier_validation.tier_definition_view_form
 msgid "e.g. Tier Validation for..."
 msgstr "ie Validation par un tiers pour..."
-
-#~ msgid "Any user in a specific group."
-#~ msgstr "Tout utilisateur d'un groupe spécifique."

--- a/base_tier_validation/models/tier_definition.py
+++ b/base_tier_validation/models/tier_definition.py
@@ -38,6 +38,10 @@ class TierDefinition(models.Model):
             ("field", "Field in related record"),
         ],
     )
+    allow_write_for_reviewer = fields.Boolean(
+        string="Allow Write For Reviewers",
+        default=False,
+    )
     reviewer_id = fields.Many2one(comodel_name="res.users", string="Reviewer")
     reviewer_group_id = fields.Many2one(
         comodel_name="res.groups", string="Reviewer group"

--- a/base_tier_validation/models/tier_validation.py
+++ b/base_tier_validation/models/tier_validation.py
@@ -215,7 +215,13 @@ class TierValidation(models.AbstractModel):
 
     def _check_allow_write_under_validation(self, vals):
         """Allow to add exceptions for fields that are allowed to be written
-        even when the record is under validation."""
+        or for reviewers for all fields, even when the record is under
+        validation."""
+        if (
+            all(self.review_ids.mapped("definition_id.allow_write_for_reviewer"))
+            and self.env.user in self.reviewer_ids
+        ):
+            return True
         exceptions = self._get_under_validation_exceptions()
         for val in vals:
             if val not in exceptions:

--- a/base_tier_validation/tests/test_tier_validation.py
+++ b/base_tier_validation/tests/test_tier_validation.py
@@ -481,6 +481,17 @@ class TierTierValidation(CommonTierValidation):
         self.assertTrue(review)
         self.assertEqual(review.reviewer_ids, self.test_user_2)
 
+    def test_19_allow_write_for_reviewers(self):
+        reviews = self.test_record.with_user(self.test_user_2.id).request_validation()
+        record = self.test_record.with_user(self.test_user_1.id)
+        record.invalidate_cache()
+        with self.assertRaises(ValidationError):
+            record.with_user(self.test_user_1.id).write({"test_field": 0.3})
+        reviews.definition_id.with_user(self.test_user_1.id).write(
+            {"allow_write_for_reviewer": True}
+        )
+        record.with_user(self.test_user_1.id).write({"test_field": 0.3})
+
 
 @tagged("at_install")
 class TierTierValidationView(CommonTierValidation):

--- a/base_tier_validation/views/tier_definition_view.xml
+++ b/base_tier_validation/views/tier_definition_view.xml
@@ -48,6 +48,7 @@
                             <field name="model_id" options="{'no_create': True}" />
                             <field name="model" invisible="1" />
                             <field name="review_type" />
+                            <field name="allow_write_for_reviewer" />
                             <field
                                 name="reviewer_id"
                                 attrs="{'invisible': [('review_type', '!=', 'individual')]}"


### PR DESCRIPTION
Add write option for reviewers on the tier definition, allowing to directly change some values before validation. 
Option is false by default in order to keep the previous behavior. 