### PR TITLE
[13.0][FIX]web_archive_date: ensure new archive fields in model

### DIFF
--- a/web_archive_date/models/base.py
+++ b/web_archive_date/models/base.py
@@ -19,5 +19,8 @@ class Base(models.AbstractModel):
             return merged_list
 
         result = super(Base, self).get_metadata()
-        archive_dict = self.read([LOG_ARCHIVE_DATE, LOG_ARCHIVE_UID])
-        return merge_lists_of_dicts(result, archive_dict, "id")
+        fields_list = list(self._fields)
+        if LOG_ARCHIVE_DATE in fields_list and LOG_ARCHIVE_UID in fields_list:
+            archive_dict = self.read([LOG_ARCHIVE_DATE, LOG_ARCHIVE_UID])
+            return merge_lists_of_dicts(result, archive_dict, "id")
+        return result

--- a/web_archive_date/tests/test_web_archive_date.py
+++ b/web_archive_date/tests/test_web_archive_date.py
@@ -12,6 +12,12 @@ class TestWebArchiveDate(TestBaseArchiveDate):
         super().setUpClass()
         cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
 
+        # Models
+        cls.company_model = cls.env["res.company"]
+
+        # Instances
+        cls.company = cls.company_model.create({"name": "Test Company"})
+
     def test_01_check_metadata_shown(self):
         """
         Check that the method getting the metadata on a record, once it is archived.
@@ -37,4 +43,23 @@ class TestWebArchiveDate(TestBaseArchiveDate):
             value.get("archive_uid")[0],
             self.partner.archive_uid.id,
             "User ID shown used in the metadata should be the same as the archive_uid value.",
+        )
+
+    def test_02_check_metadata_shown_on_model_not_having_active_field(self):
+        """
+        Check that the method getting the metadata on a record, if the record doesn't
+        have the active field.
+        """
+        c_fields_list = list(self.company._fields)
+        self.assertFalse("active" in c_fields_list)
+        metadata = self.company.get_metadata()
+        self.assertEqual(len(metadata), 1, "List should only contain one value.")
+        value = metadata[0]
+        self.assertFalse(
+            "archive_date" in value.keys(),
+            "The Archive Date should not be listed for a model not having the active field.",
+        )
+        self.assertFalse(
+            "archive_uid" in value.keys(),
+            "The Archive by should not be listed for a model not having the active field.",
         )


### PR DESCRIPTION
Fixing for those models not having the newly added fields in the `base_archive_date` module, where it will fail when reading.

cc @ForgeFlow