### PR TITLE
[14.0][FIX] mass_editing ambigous sql column

### DIFF
--- a/mass_editing/migrations/14.0.1.0.0/pre-migrate.py
+++ b/mass_editing/migrations/14.0.1.0.0/pre-migrate.py
@@ -56,10 +56,10 @@ def migrate_mass_editing(env):
         )
         SELECT
             me.id,
-            create_uid,
-            create_date,
-            write_uid,
-            write_date,
+            me.create_uid,
+            me.create_date,
+            me.write_uid,
+            me.write_date,
             COALESCE(me.action_name, me.name),
             'ir.actions.server',
             'ir_actions_server',


### PR DESCRIPTION
This PR solves this bug in migration (translated from italian):
_psycopg2.ProgrammingError: <ERROR: reference to column "create_uid" is ambiguos>
LINE 20: create_uid,_