### PR TITLE
[16.0][ADD] base_tier_validation: compute validation flag dynamically

### DIFF
--- a/base_tier_validation/models/tier_definition.py
+++ b/base_tier_validation/models/tier_definition.py
@@ -85,3 +85,32 @@ class TierDefinition(models.Model):
             rec.valid_reviewer_field_ids = self.env["ir.model.fields"].search(
                 [("model", "=", rec.model), ("relation", "=", "res.users")]
             )
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        result = super().create(vals_list)
+        result._update_registry()
+        return result
+
+    def write(self, vals):
+        result = super().write(vals)
+        if "definition_domain" in vals:
+            self._update_registry()
+        return result
+
+    def unlink(self):
+        models = set(self.mapped("model"))
+        result = super().unlink()
+        self._update_registry(models)
+        return result
+
+    def _update_registry(self, models=None):
+        """Update dependencies of validation flag"""
+        for model in models or set(self.mapped("model")):
+            depends = self.env[model]._compute_need_validation._depends
+            if not callable(depends):
+                continue
+            self.pool.field_depends[
+                self.env[model]._fields["need_validation"]
+            ] = depends(self.env[model])
+            self.pool.registry_invalidated = True

--- a/base_tier_validation/models/tier_validation.py
+++ b/base_tier_validation/models/tier_validation.py
@@ -553,7 +553,7 @@ class TierValidation(models.AbstractModel):
                         all_models[model] = res["models"][model]
                 new_node = etree.fromstring(new_arch)
                 node.append(new_node)
-            for node in doc.xpath("//field[@name]"):
+            for node in doc.xpath("//field[@name][not(ancestor::field)]"):
                 modifiers = json.loads(
                     node.attrib.get("modifiers", '{"readonly": false}')
                 )

--- a/base_tier_validation/models/tier_validation.py
+++ b/base_tier_validation/models/tier_validation.py
@@ -201,7 +201,13 @@ class TierValidation(models.AbstractModel):
             return []
         tiers = self.env["tier.definition"].search([("model", "=", self._name)])
         tier_domains = sum(
-            (literal_eval(tier.definition_domain or "[]") for tier in tiers),
+            # we can't browse because this is called during updates too
+            (
+                literal_eval(
+                    tier.read(["definition_domain"])[0]["definition_domain"] or "[]"
+                )
+                for tier in tiers
+            ),
             [],
         )
         return list(

--- a/base_tier_validation/tests/test_tier_validation.py
+++ b/base_tier_validation/tests/test_tier_validation.py
@@ -436,6 +436,22 @@ class TierTierValidation(CommonTierValidation):
         self.assertTrue(review)
         self.assertEqual(review.reviewer_ids, self.test_user_2)
 
+    def test_19_update_registry(self):
+        """Test that changes to the tier definition reloads the registry"""
+        tier = self.env["tier.definition"].search(
+            [
+                ("model_id", "=", self.tester_model.id),
+            ]
+        )
+        field = self.env[self.test_model._name]._fields["need_validation"]
+        self.assertIn("test_field", self.env.registry.field_depends[field])
+        tier.write({"definition_domain": "[]"})
+        self.assertNotIn("test_field", self.env.registry.field_depends[field])
+        tier.unlink()
+        self.assertNotIn("test_field", self.env.registry.field_depends[field])
+        self.assertTrue(self.env.registry.registry_invalidated)
+        self.env.registry.registry_invalidated = False
+
 
 @tagged("at_install")
 class TierTierValidationView(CommonTierValidation):


### PR DESCRIPTION
with this the validation button shows immediately on a form and not only after save

@astirpe finally I find time to work on this again. I'm a bit at a loss as to why this doesn't work for you, it does [on runboat](https://github.com/OCA/account-invoicing/pull/1507) though, even with just domain `[('move_type', '=', 'in_invoice')]`:

![image](https://github.com/OCA/server-ux/assets/2563186/1ec735e9-ddb7-489a-9ecd-e62654502c8b)

![image](https://github.com/OCA/server-ux/assets/2563186/ba8d07fe-291b-4c7f-9c7e-973c07405b82)
