### PR TITLE
[15.0][IMP] announcement: Prevent False specific_user_ids from when not appropriate

### DIFF
--- a/announcement/models/announcement.py
+++ b/announcement/models/announcement.py
@@ -103,7 +103,6 @@ class Announcement(models.Model):
                 announcement.announcement_type = "user_group"
                 announcement.user_group_ids = self.env.ref("base.group_user")
             else:
-                announcement.specific_user_ids = False
                 announcement.user_group_ids = False
 
     @api.depends("announcement_log_ids")


### PR DESCRIPTION
Prevent False `specific_user_ids` from when not appropriate.

Example use case:
- We create an announcement with the `create()` method and specify the users (`specific_user_ids`).
- The users are not defined.

Please @pedrobaeza and @pilarvargas-tecnativa can you review it?

@Tecnativa TT43046