### PR TITLE
[16.0][FIX] unit test in sale_order_revision fails

### DIFF
--- a/base_revision/tests/test_base_revision.py
+++ b/base_revision/tests/test_base_revision.py
@@ -26,8 +26,13 @@ class TestBaseRevision(common.TransactionCase):
         cls.loader.restore_registry()
         return super(TestBaseRevision, cls).tearDownClass()
 
-    def _create_tester(self):
-        return self.revision_model.create({"name": "TEST0001"})
+    def _create_tester(self, vals_list=None):
+        if not vals_list:
+            vals_list = [{}]
+        for vals in vals_list:
+            if "name" not in vals:
+                vals["name"] = "TEST0001"
+        return self.revision_model.create(vals_list)
 
     @staticmethod
     def _revision_tester(tester):
@@ -92,9 +97,7 @@ class TestBaseRevision(common.TransactionCase):
     def test_create_multiple(self):
         """Check copy process"""
         # Create a tester
-        tester_2 = self.revision_model.create(
-            [{"name": "TEST0001"}, {"name": "TEST0002"}]
-        )
+        tester_2 = self._create_tester([{"name": "TEST0001"}, {"name": "TEST0002"}])
         # Check the 'Order Reference' of the tester
         for tester in tester_2:
             self.assertEqual(tester.name, tester.unrevisioned_name)


### PR DESCRIPTION
Unfortunately this https://github.com/OCA/server-ux/pull/672 breaks one unit test in sale_order_revision.
