### PR TITLE
[14.0][FIX] base_tier_validation: multiple comment with approve_sequence_bypass

### DIFF
--- a/base_tier_validation/models/tier_validation.py
+++ b/base_tier_validation/models/tier_validation.py
@@ -353,7 +353,10 @@ class TierValidation(models.AbstractModel):
             lambda l: l.sequence in sequences or l.approve_sequence_bypass
         )
         if self.has_comment:
-            return self._add_comment("validate", reviews)
+            user_reviews = reviews.filtered(
+                lambda r: r.status == "pending" and (self.env.user in r.reviewer_ids)
+            )
+            return self._add_comment("validate", user_reviews)
         self._validate_tier(reviews)
         self._update_counter()
 


### PR DESCRIPTION
    [FIX] base_tier_validation: multiple comment with approve_sequence_bypass

    - when option approve_sequence_bypass is enable and comments option with
    sequence, the user add a comment and all level approbation add this
    comment.
    This code add comment only for appropriate tier validation