### PR TITLE
[15.0][FIX] base_export_manager: Avoid access error when using export profile

### DIFF
--- a/base_export_manager/models/ir_exports.py
+++ b/base_export_manager/models/ir_exports.py
@@ -16,6 +16,7 @@ class IrExports(models.Model):
         store=True,
         inverse="_inverse_model_id",
         compute="_compute_model_id",
+        compute_sudo=True,
         domain=[("transient", "=", False)],
         help="Database model to export.",
     )

--- a/base_export_manager/models/ir_exports_line.py
+++ b/base_export_manager/models/ir_exports_line.py
@@ -13,6 +13,7 @@ class IrExportsLine(models.Model):
     name = fields.Char(
         store=True,
         compute="_compute_name",
+        compute_sudo=True,
         inverse="_inverse_name",
         help="Field's technical name.",
     )
@@ -33,13 +34,16 @@ class IrExportsLine(models.Model):
         "First model",
         readonly=True,
         related="export_id.model_id",
+        related_sudo=True,
     )
     model2_id = fields.Many2one(
-        "ir.model", "Second model", compute="_compute_model2_id"
+        "ir.model", "Second model", compute="_compute_model2_id", compute_sudo=True
     )
-    model3_id = fields.Many2one("ir.model", "Third model", compute="_compute_model3_id")
+    model3_id = fields.Many2one(
+        "ir.model", "Third model", compute="_compute_model3_id", compute_sudo=True
+    )
     model4_id = fields.Many2one(
-        "ir.model", "Fourth model", compute="_compute_model4_id"
+        "ir.model", "Fourth model", compute="_compute_model4_id", compute_sudo=True
     )
     sequence = fields.Integer()
     label = fields.Char(compute="_compute_label")


### PR DESCRIPTION
Steps to reproduce:

- Create an export profile in any model.
- Login with a user without setting permissions.
- Go to export popup on that model.
- Try to select the saved export profile.

You'll get an access error.

Using sudo for computed/related stuff linked to ir.model,  we avoid the problem.

@Tecnativa TT44721