### PR TITLE
[16.0][FIX] Fix model read permissions for request_validation

### DIFF
--- a/base_tier_validation/__manifest__.py
+++ b/base_tier_validation/__manifest__.py
@@ -3,7 +3,7 @@
 {
     "name": "Base Tier Validation",
     "summary": "Implement a validation process based on tiers.",
-    "version": "16.0.1.0.5",
+    "version": "16.0.1.0.6",
     "development_status": "Mature",
     "maintainers": ["LoisRForgeFlow"],
     "category": "Tools",

--- a/base_tier_validation/models/tier_validation.py
+++ b/base_tier_validation/models/tier_validation.py
@@ -411,7 +411,7 @@ class TierValidation(models.AbstractModel):
         for rec in self:
             if rec._check_state_from_condition():
                 if rec.need_validation:
-                    tier_definitions = td_obj.search(
+                    tier_definitions = td_obj.sudo().search(
                         [("model", "=", self._name)], order="sequence desc"
                     )
                     sequence = 0


### PR DESCRIPTION
This PR fixes the model read permissions for the `request_validation()` method in the `tier_validation` module. After the changes introduced by [#69120](https://github.com/odoo/odoo/pull/69120) in [Odoo 15.0](https://github.com/OCA/maintainer-tools/wiki/Migration-to-version-15.0) the method most users interact with requires elevated permissions. These changes make it so any user can request validation (a typical user flow).

![16 0-request-validation-user-error](https://github.com/OCA/server-ux/assets/22648657/3d6fd7b7-03e7-4623-942c-d8efc5f6c966)
