### PR TITLE
[16.0][ADD] base_tier_validation: allow comments being optional

### DIFF
--- a/base_tier_validation/models/tier_definition.py
+++ b/base_tier_validation/models/tier_definition.py
@@ -68,6 +68,12 @@ class TierDefinition(models.Model):
         "this definition is triggered.",
     )
     has_comment = fields.Boolean(string="Comment", default=False)
+    comment_required_validate = fields.Boolean(
+        string="Comment required for validation", default=True
+    )
+    comment_required_reject = fields.Boolean(
+        string="Comment required for rejection", default=True
+    )
     approve_sequence = fields.Boolean(
         string="Approve by sequence",
         default=False,

--- a/base_tier_validation/models/tier_review.py
+++ b/base_tier_validation/models/tier_review.py
@@ -50,6 +50,12 @@ class TierReview(models.Model):
         string="Validation Formated Date", compute="_compute_reviewed_formated_date"
     )
     has_comment = fields.Boolean(related="definition_id.has_comment", readonly=True)
+    comment_required_validate = fields.Boolean(
+        related="definition_id.comment_required_validate", readonly=True
+    )
+    comment_required_reject = fields.Boolean(
+        related="definition_id.comment_required_reject", readonly=True
+    )
     comment = fields.Char(string="Comments")
     can_review = fields.Boolean(
         compute="_compute_can_review",

--- a/base_tier_validation/tests/test_tier_validation.py
+++ b/base_tier_validation/tests/test_tier_validation.py
@@ -160,6 +160,7 @@ class TierTierValidation(CommonTierValidation):
         wizard = Form(self.env["comment.wizard"].with_context(**ctx))
         wizard.comment = "Test Comment"
         wiz = wizard.save()
+        self.assertTrue(wiz.comment_required)
         wiz.add_comment()
         self.assertTrue(test_record.review_ids.mapped("comment"))
         # Check notify
@@ -183,6 +184,7 @@ class TierTierValidation(CommonTierValidation):
                 "reviewer_id": self.test_user_1.id,
                 "definition_domain": "[('test_field', '>', 1.0)]",
                 "has_comment": True,
+                "comment_required_reject": False,
             }
         )
         # Request validation
@@ -195,6 +197,7 @@ class TierTierValidation(CommonTierValidation):
         wizard = Form(self.env["comment.wizard"].with_context(**ctx))
         wizard.comment = "Test Comment"
         wiz = wizard.save()
+        self.assertFalse(wiz.comment_required)
         wiz.add_comment()
         self.assertTrue(test_record.review_ids.mapped("comment"))
         # Check notify

--- a/base_tier_validation/views/tier_definition_view.xml
+++ b/base_tier_validation/views/tier_definition_view.xml
@@ -100,6 +100,14 @@
                                 <group name="notify">
                                     <field name="notify_on_create" />
                                     <field name="has_comment" />
+                                    <field
+                                        name="comment_required_validate"
+                                        attrs="{'invisible': [('has_comment', '=', False)]}"
+                                    />
+                                    <field
+                                        name="comment_required_reject"
+                                        attrs="{'invisible': [('has_comment', '=', False)]}"
+                                    />
                                 </group>
                             </group>
                         </page>

--- a/base_tier_validation/wizard/comment_wizard_view.xml
+++ b/base_tier_validation/wizard/comment_wizard_view.xml
@@ -9,7 +9,13 @@
         <field name="arch" type="xml">
             <form string="Comment">
                 <group>
-                    <field colspan="2" name="comment" nolabel="1" />
+                    <field name="comment_required" invisible="True" />
+                    <field
+                        colspan="2"
+                        name="comment"
+                        nolabel="1"
+                        attrs="{'required': [('comment_required', '=', True)]}"
+                    />
                 </group>
                 <footer>
                     <button


### PR DESCRIPTION
this allows comments to be configured to be optional depending on the record being validated/rejected (the defaults are chosen such that existing definitions won't behave differently after the update)