### PR TITLE
[15.0][FIX] date_range: Allow select date_ranges on custom filters

### DIFF
--- a/date_range/static/src/js/date_range.esm.js
+++ b/date_range/static/src/js/date_range.esm.js
@@ -1,76 +1,77 @@
 /** @odoo-module **/
-import {patch} from "web.utils";
+import {patch} from "@web/core/utils/patch";
 import {_lt} from "@web/core/l10n/translation";
 import {session} from "@web/session";
 import {FIELD_OPERATORS, FIELD_TYPES} from "web.searchUtils";
 import CustomFilterItem from "web.CustomFilterItem";
 
-patch(
-    CustomFilterItem.prototype,
-    "date_range/static/src/js/date_range.esm.js",
-    (T) =>
-        class extends T {
-            constructor() {
-                super(...arguments);
-                this._computeDateRangeOperators();
-            }
+patch(CustomFilterItem.prototype, "date_range.CustomFilterItem", {
+    /**
+     * Ideally we'd want this in setup, but CustomFilterItem does its initialization
+     * in the constructor, which can't be patched.
+     *
+     * Doing it here works just as well.
+     *
+     * @override
+     */
+    async willStart() {
+        this._super(...arguments);
+        this._computeDateRangeOperators();
+    },
 
-            async _computeDateRangeOperators() {
-                this.OPERATORS = Object.assign({}, FIELD_OPERATORS);
-                this.OPERATORS.date = [...FIELD_OPERATORS.date];
-                this.OPERATORS.datetime = [...FIELD_OPERATORS.datetime];
-                this.date_ranges = {};
-                const result = await this.rpc({
-                    model: "date.range",
-                    method: "search_read",
-                    fields: ["name", "type_id", "date_start", "date_end"],
-                    context: session.user_context,
-                });
-                result.forEach((range) => {
-                    const range_type = range.type_id[0];
-                    if (this.date_ranges[range_type] === undefined) {
-                        const r = {
-                            symbol: "between",
-                            description: `${_lt("in")} ${range.type_id[1]}`,
-                            date_range: true,
-                            date_range_type: range_type,
-                        };
-                        this.OPERATORS.date.push(r);
-                        this.OPERATORS.datetime.push(r);
-                        this.date_ranges[range_type] = [];
-                    }
-                    this.date_ranges[range_type].push(range);
-                });
+    async _computeDateRangeOperators() {
+        this.OPERATORS = Object.assign({}, FIELD_OPERATORS);
+        this.OPERATORS.date = [...FIELD_OPERATORS.date];
+        this.OPERATORS.datetime = [...FIELD_OPERATORS.datetime];
+        this.date_ranges = {};
+        const result = await this.rpc({
+            model: "date.range",
+            method: "search_read",
+            fields: ["name", "type_id", "date_start", "date_end"],
+            context: session.user_context,
+        });
+        result.forEach((range) => {
+            const range_type = range.type_id[0];
+            if (this.date_ranges[range_type] === undefined) {
+                const r = {
+                    symbol: "between",
+                    description: `${_lt("in")} ${range.type_id[1]}`,
+                    date_range: true,
+                    date_range_type: range_type,
+                };
+                this.OPERATORS.date.push(r);
+                this.OPERATORS.datetime.push(r);
+                this.date_ranges[range_type] = [];
             }
+            this.date_ranges[range_type].push(range);
+        });
+    },
 
-            _setDefaultValue(condition) {
-                const type = this.fields[condition.field].type;
-                const operator = this.OPERATORS[FIELD_TYPES[type]][condition.operator];
-                if (operator.date_range) {
-                    const default_range = this.date_ranges[operator.date_range_type][0];
-                    const d_start = moment(`${default_range.date_start} 00:00:00Z`);
-                    const d_end = moment(`${default_range.date_end} 23:59:59Z`);
-                    condition.value = [d_start, d_end];
-                } else {
-                    super._setDefaultValue(...arguments);
-                }
-            }
-
-            _onValueInputChange(condition, ev) {
-                const type = this.fields[condition.field].type;
-                const operator = this.OPERATORS[FIELD_TYPES[type]][condition.operator];
-                if (operator.date_range) {
-                    const eid = parseInt(ev.target.value);
-                    const ranges = this.date_ranges[operator.date_range_type];
-                    const range = ranges.find((x) => x.id == eid);
-                    const d_start = moment(`${range.date_start} 00:00:00Z`);
-                    const d_end = moment(`${range.date_end} 23:59:59Z`);
-                    condition.value = [d_start, d_end];
-                } else {
-                    super._onValueInputChange(...arguments);
-                }
-            }
+    _setDefaultValue(condition) {
+        const type = this.fields[condition.field].type;
+        const operator = this.OPERATORS[FIELD_TYPES[type]][condition.operator];
+        if (operator.date_range) {
+            const default_range = this.date_ranges[operator.date_range_type][0];
+            const d_start = moment(`${default_range.date_start} 00:00:00`);
+            const d_end = moment(`${default_range.date_end} 23:59:59`);
+            condition.value = [d_start, d_end];
+        } else {
+            this._super(...arguments);
         }
-);
+    },
 
-export default CustomFilterItem;
+    onValueChange(condition, ev) {
+        const type = this.fields[condition.field].type;
+        const operator = this.OPERATORS[FIELD_TYPES[type]][condition.operator];
+        if (operator.date_range) {
+            const eid = parseInt(ev.target.value);
+            const ranges = this.date_ranges[operator.date_range_type];
+            const range = ranges.find((x) => x.id == eid);
+            const d_start = moment.utc(`${range.date_start} 00:00:00`);
+            const d_end = moment.utc(`${range.date_end} 23:59:59`);
+            condition.value = [d_start, d_end];
+        } else {
+            this._super(...arguments);
+        }
+    },
+});

--- a/date_range/static/src/xml/date_range.xml
+++ b/date_range/static/src/xml/date_range.xml
@@ -8,7 +8,7 @@
                 t-if="(fieldType === 'date' || fieldType === 'datetime') &amp;&amp; selectedOperator.date_range"
             >
                 <span class="o_generator_menu_value">
-                    <select class="o_input" t-on-change="_onValueInput(condition)">
+                    <select class="o_input" t-on-change="onValueChange(condition)">
                         <option
                             t-foreach="date_ranges[selectedOperator.date_range_type]"
                             t-as="option"


### PR DESCRIPTION
This commit solves the problems reported on Issue https://github.com/OCA/server-ux/issues/597

cc @Tecnativa TT43442

ping @pedrobaeza @sergio-teruel 

I tried to set the description provided on the date_range but it needs to overwrite the onApply method with not a simply way to do it. As the description shows the range you are filtering by, I don't think this is a very important feature to keep.