### PR TITLE
[16.0][FIX] date_range: Avoid redefinition of this.OPERATORS as a new object

### DIFF
--- a/date_range/static/src/js/date_range.esm.js
+++ b/date_range/static/src/js/date_range.esm.js
@@ -1,6 +1,6 @@
 /** @odoo-module **/
-import {FIELD_OPERATORS, FIELD_TYPES} from "web.searchUtils";
 import {CustomFilterItem} from "@web/search/filter_menu/custom_filter_item";
+import {FIELD_TYPES} from "web.searchUtils";
 import {_lt} from "@web/core/l10n/translation";
 import {patch} from "@web/core/utils/patch";
 import {useService} from "@web/core/utils/hooks";
@@ -15,9 +15,6 @@ patch(CustomFilterItem.prototype, "date_range.CustomFilterItem", {
     },
 
     async _computeDateRangeOperators() {
-        this.OPERATORS = Object.assign({}, FIELD_OPERATORS);
-        this.OPERATORS.date = [...FIELD_OPERATORS.date];
-        this.OPERATORS.datetime = [...FIELD_OPERATORS.datetime];
         this.date_ranges = {};
         const result = await this.orm.searchRead(
             "date.range",


### PR DESCRIPTION
This causes problems with inheritance of this.OPERATORS from other addons when new operators are added.

As commented in issue #722, this causes problems with the web_advanced_search addon, [which adds a new relational operator to this.OPERATORS](https://github.com/OCA/web/blob/16.0/web_advanced_search/static/src/search/filter_menu/custom_filter_item.esm.js#L16)

This fix is intended to not create a new JS object, with a new reference, and different than the one Odoo creates in web.searchUtils as FIELD_OPERATORS, and already defined as this.OPERATORS by super CustomFilterItem.

I don't know if reassigning this.OPERATORS.date from FIELD_OPERATORS.date and datetime is still necessary because they are already defined in this.OPERATORS from super

Fixes #722