### PR TITLE
[FIX] date_range: prevent filters to be added multiple times

### DIFF
--- a/date_range/static/src/js/date_range.esm.js
+++ b/date_range/static/src/js/date_range.esm.js
@@ -30,14 +30,16 @@ patch(CustomFilterItem.prototype, "date_range.CustomFilterItem", {
                     date_range: true,
                     date_range_type: range_type,
                 };
-                var dateExistingOption = this.OPERATORS.date.find(function(option) {
+                var dateExistingOption = this.OPERATORS.date.find(function (option) {
                     return option.date_range_type === r.date_range_type;
                 });
                 if (!dateExistingOption) {
                     this.OPERATORS.date.push(r);
                 }
 
-                var datetimeExistingOption = this.OPERATORS.datetime.find(function(option) {
+                var datetimeExistingOption = this.OPERATORS.datetime.find(function (
+                    option
+                ) {
                     return option.date_range_type === r.date_range_type;
                 });
                 if (!datetimeExistingOption) {

--- a/date_range/static/src/js/date_range.esm.js
+++ b/date_range/static/src/js/date_range.esm.js
@@ -30,8 +30,19 @@ patch(CustomFilterItem.prototype, "date_range.CustomFilterItem", {
                     date_range: true,
                     date_range_type: range_type,
                 };
-                this.OPERATORS.date.push(r);
-                this.OPERATORS.datetime.push(r);
+                var dateExistingOption = this.OPERATORS.date.find(function(option) {
+                    return option.date_range_type === r.date_range_type;
+                });
+                if (!dateExistingOption) {
+                    this.OPERATORS.date.push(r);
+                }
+
+                var datetimeExistingOption = this.OPERATORS.datetime.find(function(option) {
+                    return option.date_range_type === r.date_range_type;
+                });
+                if (!datetimeExistingOption) {
+                    this.OPERATORS.datetime.push(r);
+                }
                 this.date_ranges[range_type] = [];
             }
             this.date_ranges[range_type].push(range);


### PR DESCRIPTION
Module date_range automatically adds, to all date and datetime filtering options, a new item for each Date Range Type defined into the system.
Under some circumstances, when the method responsible for it is invoked, it works on a data structure ( `OPERATORS.date` / `OPERATORS.datetime` ) which wasn't preventively cleaned-up. If that happens, because this method is invoked each time the user clicks on the **Filters** button, the result is to have multiple times the same Date Range Type options.

https://github.com/OCA/server-ux/assets/8192093/3de50aa1-8813-4a1c-8142-c66862342754

This PR aims at making the module more robust to this kind of situations by adding a prior check when adding a Date Range Type option to filters.