### PR TITLE
[15.0][IMP]base_tier_validation: only post notifications to reciepients

### DIFF
--- a/base_tier_validation/models/tier_validation.py
+++ b/base_tier_validation/models/tier_validation.py
@@ -441,13 +441,14 @@ class TierValidation(models.AbstractModel):
                     lambda r: r.definition_id.notify_on_create and r.res_id == rec.id
                 ).mapped("reviewer_ids")
                 # Subscribe reviewers and notify
-                getattr(rec, subscribe)(
-                    partner_ids=users_to_notify.mapped("partner_id").ids
-                )
-                getattr(rec, post)(
-                    subtype_xmlid=self._get_requested_notification_subtype(),
-                    body=rec._notify_requested_review_body(),
-                )
+                if users_to_notify:
+                    getattr(rec, subscribe)(
+                        partner_ids=users_to_notify.mapped("partner_id").ids
+                    )
+                    getattr(rec, post)(
+                        subtype_xmlid=self._get_requested_notification_subtype(),
+                        body=rec._notify_requested_review_body(),
+                    )
 
     def request_validation(self):
         td_obj = self.env["tier.definition"]


### PR DESCRIPTION
Before this PR there where double tier review notifications when used in combination with tier_validation_waiting.

![image](https://github.com/OCA/server-ux/assets/11499387/4940146b-04d9-41e2-bcf6-045227cee32f)

One of the messages has no recepients:
![image](https://github.com/OCA/server-ux/assets/11499387/527d643b-5fa0-46d4-8508-77b836a52731)

After this PR:
Only one notification gets posted.
(The one adressed to the requested reviewer)
![image](https://github.com/OCA/server-ux/assets/11499387/33d10880-e5c4-4299-9ccb-4efb1fc121ec)
