### PR TITLE
[15.0][FIX] base_substate: track template on substate

### DIFF
--- a/base_substate/tests/sale_test.py
+++ b/base_substate/tests/sale_test.py
@@ -6,8 +6,8 @@ from .models_mixin import TestMixin
 
 
 class SaleTest(models.Model, TestMixin):
-    _inherit = "base.substate.mixin"
     _name = "base.substate.test.sale"
+    _inherit = ["base.substate.mixin", "mail.thread"]
     _description = "Base substate Test Model"
 
     name = fields.Char(required=True)


### PR DESCRIPTION
Move function `_track_template()` on base_substate_mixin to mail_thread
Currently, Email Template on Base Substate is not working.

Step to error:
1. Create base substate and add Email Template
2. Change substate to substate there is email template, it will not send email template.