### PR TITLE
[PERF] base_tier_validation: filter records with reviews before compute fields

### DIFF
--- a/base_tier_validation/models/tier_validation.py
+++ b/base_tier_validation/models/tier_validation.py
@@ -106,9 +106,9 @@ class TierValidation(models.AbstractModel):
     def _search_validated(self, operator, value):
         assert operator in ("=", "!="), "Invalid domain operator"
         assert value in (True, False), "Invalid domain value"
-        pos = self.search([(self._state_field, "in", self._state_from)]).filtered(
-            lambda r: r.validated
-        )
+        pos = self.search(
+            [(self._state_field, "in", self._state_from), ("review_ids", "!=", False)]
+        ).filtered(lambda r: r.validated)
         if value:
             return [("id", "in", pos.ids)]
         else:
@@ -118,9 +118,9 @@ class TierValidation(models.AbstractModel):
     def _search_rejected(self, operator, value):
         assert operator in ("=", "!="), "Invalid domain operator"
         assert value in (True, False), "Invalid domain value"
-        pos = self.search([(self._state_field, "in", self._state_from)]).filtered(
-            lambda r: r.rejected
-        )
+        pos = self.search(
+            [(self._state_field, "in", self._state_from), ("review_ids", "!=", False)]
+        ).filtered(lambda r: r.rejected)
         if value:
             return [("id", "in", pos.ids)]
         else:


### PR DESCRIPTION
Before this commit, in a database with many records candidates for applying reviews, fields with a `function search` defined were very slow because the search was performed over all records with these states. After this commit, first filter only records with `review_ids` set, which significantly enhancement performance by more than 10X!!!

Database with more than 10K Sale Orders on draft, sent(states defined for review). Less than 1K records has started a flow review

![image](https://github.com/OCA/server-ux/assets/7775116/ae355c0a-9af4-43bc-bdbd-4600be8a635e)


### Before change
**search_rejected**
![image](https://github.com/OCA/server-ux/assets/7775116/ad65d8df-9093-4804-b482-458b29444fad)

**search_validated**

![image](https://github.com/OCA/server-ux/assets/7775116/a876cc4b-b4b0-4a64-b991-cd5ad53f8877)


### After this commit
**search_rejected**
![image](https://github.com/OCA/server-ux/assets/7775116/e141f68f-b812-47af-b260-24ae624e5191)

**search_validated**
![image](https://github.com/OCA/server-ux/assets/7775116/dfda66e9-4568-48b5-82d9-f93118c19fdf)


fixed https://github.com/OCA/server-ux/issues/496

