### PR TITLE
[PERF] base_tier_validation: filter records with reviews before compu…

### DIFF
--- a/base_tier_validation/models/tier_validation.py
+++ b/base_tier_validation/models/tier_validation.py
@@ -116,9 +116,9 @@ class TierValidation(models.AbstractModel):
     def _search_validated(self, operator, value):
         assert operator in ("=", "!="), "Invalid domain operator"
         assert value in (True, False), "Invalid domain value"
-        pos = self.search([(self._state_field, "in", self._state_from)]).filtered(
-            lambda r: r.validated
-        )
+        pos = self.search(
+            [(self._state_field, "in", self._state_from), ("review_ids", "!=", False)]
+        ).filtered(lambda r: r.validated)
         if value:
             return [("id", "in", pos.ids)]
         else:
@@ -128,9 +128,9 @@ class TierValidation(models.AbstractModel):
     def _search_rejected(self, operator, value):
         assert operator in ("=", "!="), "Invalid domain operator"
         assert value in (True, False), "Invalid domain value"
-        pos = self.search([(self._state_field, "in", self._state_from)]).filtered(
-            lambda r: r.rejected
-        )
+        pos = self.search(
+            [(self._state_field, "in", self._state_from), ("review_ids", "!=", False)]
+        ).filtered(lambda r: r.rejected)
         if value:
             return [("id", "in", pos.ids)]
         else:


### PR DESCRIPTION
…te fields

Before this commit, in a database with many records candidates for applying reviews, fields with a defined search function were very slow because the search was performed over all records with these states. After this commit, first filter only records with review_ids set, which significantly reduces performance by more than 10X!!!

Fordward port of https://github.com/OCA/server-ux/pull/740