### PR TITLE
[15.0][FIX] base_search_custom_field_filter: Force name on custom filters

### DIFF
--- a/base_search_custom_field_filter/models/base.py
+++ b/base_search_custom_field_filter/models/base.py
@@ -61,6 +61,9 @@ class Base(models.AbstractModel):
             field = custom_filter._get_related_field()
             field_name = custom_filter.expression
             res["fields"][field_name] = field.get_description(self.env)
+            # Force name for avoiding error accesing to this field from pivot and graph
+            # (needed for owl framework)
+            res["fields"][field_name]["name"] = field_name
             # force this for avoiding to appear on the rest of the UI
             res["fields"][field_name]["selectable"] = False
             res["fields"][field_name]["sortable"] = False


### PR DESCRIPTION
Name is required to use the field for filters, but this one is not set on pivot and graph views, by doing this change we are making sure that this field is filled.

cc @Tecnativa TT45828

ping @carlosdauden @pedrobaeza  