### PR TITLE
[15.0][FIX]date_range: Fixed portal access denied

### DIFF
--- a/date_range/security/ir.model.access.csv
+++ b/date_range/security/ir.model.access.csv
@@ -1,6 +1,8 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 access_date_range_date_range,date_range.date_range,model_date_range,base.group_user,1,0,0,0
 access_date_range_date_range_type,date_range.date_range_type,model_date_range_type,base.group_user,1,0,0,0
+access_date_range_date_range_portal,date_range.date_range,model_date_range,base.group_portal,1,0,0,0
+access_date_range_date_range_type_portal,date_range.date_range_type,model_date_range_type,base.group_portal,1,0,0,0
 access_date_range_date_range_config,date_range.date_range.config,model_date_range,base.group_system,1,1,1,1
 access_date_range_date_range_type_config,date_range.date_range_type.config,model_date_range_type,base.group_system,1,1,1,1
 access_date_range_generator,access_date_range_generator,model_date_range_generator,base.group_system,1,1,1,1


### PR DESCRIPTION
The module "date_range" is not usable for portal users.
This fix adds the needed permissions to access the date_range for portal users. The added permissions are the same as a regular user.

Base Odoo module "portal" is required to login to the portal.
Another module which uses the date_range module is needed. For example the base Odoo module "project".

Current behavior:
The portal user accesses a project he got shared editable. When he tries to open the filter menu he gets an access denied error. 

Steps to reproduce:
1. Login as portal user
2. open a project that got shared "editable" (the portal user can edit/ write on that project)
3. Click on button "filter"
4. The access denied error appears

[Date_Range_Project_access_denied.webm](https://github.com/OCA/server-ux/assets/132348854/a62d6ad7-f121-45b5-a37e-d0ff5ad1ef09)