### PR TITLE
[14.0][IMP] base_tier_validation: filter tier definition for the current co…

### DIFF
--- a/base_tier_validation/models/tier_validation.py
+++ b/base_tier_validation/models/tier_validation.py
@@ -223,7 +223,12 @@ class TierValidation(models.AbstractModel):
             if isinstance(rec.id, models.NewId):
                 rec.need_validation = False
                 continue
-            tiers = self.env["tier.definition"].search([("model", "=", self._name)])
+            tiers = self.env["tier.definition"].search(
+                [
+                    ("model", "=", self._name),
+                    ("company_id", "in", [False] + self.env.company.ids),
+                ]
+            )
             valid_tiers = any([rec.evaluate_tier(tier) for tier in tiers])
             rec.need_validation = (
                 not rec.review_ids and valid_tiers and rec._check_state_from_condition()
@@ -482,7 +487,11 @@ class TierValidation(models.AbstractModel):
             if rec._check_state_from_condition():
                 if rec.need_validation:
                     tier_definitions = td_obj.search(
-                        [("model", "=", self._name)], order="sequence desc"
+                        [
+                            ("model", "=", self._name),
+                            ("company_id", "in", [False] + self.env.company.ids),
+                        ],
+                        order="sequence desc",
                     )
                     sequence = 0
                     for td in tier_definitions:


### PR DESCRIPTION
…mpany

In a multicompany environment as follows:
User Request. Selected Companies: C1, C2, Current Company C1 User Approver: Selected Companies: C1 Current Company C1 Before this commit, when a user requested validation with multicompany enabled (C1, C2), definitions of other companies could be applied. If the user approver had access to fewer companies (C1) and confirmed the document, then the remaining reviews (C2) were ignored in the pending state. These reviews were shown on the sidebar but could never be approved because the document had already been approved. After this commit, tier definitions are filtered only by the current company of the user request.

Forward port of https://github.com/OCA/server-ux/pull/754