### PR TITLE
[15.0][IMP] base_tier_validation: Add _prepare_tier_review_vals() methot to allow inheritance

### DIFF
--- a/base_tier_validation/models/tier_validation.py
+++ b/base_tier_validation/models/tier_validation.py
@@ -454,6 +454,15 @@ class TierValidation(models.AbstractModel):
                     body=rec._notify_requested_review_body(),
                 )
 
+    def _prepare_tier_review_vals(self, definition, sequence):
+        return {
+            "model": self._name,
+            "res_id": self.id,
+            "definition_id": definition.id,
+            "requested_by": self.env.uid,
+            "sequence": sequence,
+        }
+
     def request_validation(self):
         td_obj = self.env["tier.definition"]
         tr_obj = created_trs = self.env["tier.review"]
@@ -471,15 +480,8 @@ class TierValidation(models.AbstractModel):
                     for td in tier_definitions:
                         if rec.evaluate_tier(td):
                             sequence += 1
-                            created_trs += tr_obj.create(
-                                {
-                                    "model": self._name,
-                                    "res_id": rec.id,
-                                    "definition_id": td.id,
-                                    "sequence": sequence,
-                                    "requested_by": self.env.uid,
-                                }
-                            )
+                            vals = rec._prepare_tier_review_vals(td, sequence)
+                            created_trs += tr_obj.create(vals)
                     self._update_counter()
         self._notify_review_requested(created_trs)
         return created_trs

--- a/base_tier_validation/tests/common.py
+++ b/base_tier_validation/tests/common.py
@@ -9,7 +9,7 @@ from odoo.tests import common
 class CommonTierValidation(common.TransactionCase):
     @classmethod
     def setUpClass(cls):
-        super(CommonTierValidation, cls).setUpClass()
+        super().setUpClass()
         # Remove this variable in v16 and put instead:
         # from odoo.addons.base.tests.common import DISABLED_MAIL_CONTEXT
         DISABLED_MAIL_CONTEXT = {


### PR DESCRIPTION
FWP from 14.0: https://github.com/OCA/server-ux/pull/756

Add `_prepare_tier_review_vals()` methot to allow inheritance.

Please @pedrobaeza and @chienandalu can you review it?

@Tecnativa TT45804