### PR TITLE
[16.0][IMP] date_range: refactor calls to deprecated functions

### DIFF
--- a/date_range/tests/test_date_range_type.py
+++ b/date_range/tests/test_date_range_type.py
@@ -155,7 +155,7 @@ class DateRangeTypeTest(TransactionCase):
         )
         # Inject invalid value
         self.env.cr.execute("UPDATE date_range_type SET name_expr = 'invalid'")
-        dr_type.invalidate_cache()
+        dr_type.invalidate_model()
         with mute_logger("odoo.addons.date_range.models.date_range_type"):
             self.env["date.range.type"].autogenerate_ranges()
         self.assertFalse(dr_type.date_ranges_exist)


### PR DESCRIPTION
Apparantly we missed one.
This fixes:
![image](https://github.com/OCA/server-ux/assets/11499387/31c75786-3f0e-4cf9-9f35-2a60f7612b1a)

