### PR TITLE
[16.0][IMP] base_tier_validation: Add _prepare_tier_review_vals() methot to allow inheritance

### DIFF
--- a/base_tier_validation/tests/common.py
+++ b/base_tier_validation/tests/common.py
@@ -11,7 +11,7 @@ from odoo.addons.base.tests.common import DISABLED_MAIL_CONTEXT
 class CommonTierValidation(common.TransactionCase):
     @classmethod
     def setUpClass(cls):
-        super(CommonTierValidation, cls).setUpClass()
+        super().setUpClass()
         cls.env = cls.env(context=dict(cls.env.context, **DISABLED_MAIL_CONTEXT))
         cls.loader = FakeModelLoader(cls.env, cls.__module__)
         cls.loader.backup_registry()


### PR DESCRIPTION
FWP from 15.0: https://github.com/OCA/server-ux/pull/762

Add `_prepare_tier_review_vals()` methot to allow inheritance.

Please @pedrobaeza and @chienandalu can you review it?

@Tecnativa TT45804