### PR TITLE
[15.0][FIX] announcement: allow multicompany tags

### DIFF
--- a/announcement/models/announcement_tag.py
+++ b/announcement/models/announcement_tag.py
@@ -20,9 +20,7 @@ class AnnouncementTag(models.Model):
     company_id = fields.Many2one(
         comodel_name="res.company",
         string="Company",
-        required=True,
         index=True,
-        default=lambda self: self.env.company,
         help="Company related to this tag",
     )
 


### PR DESCRIPTION
Allow users to share tags across companies (the access rule is already prepared for it)

cc @Tecnativa TT46715

please review @pedrobaeza @pilarvargas-tecnativa 