### PR TITLE
[FIX] base_archive_security: skip check on empty recordset Also, allow to bypass through a special context key

### DIFF
--- a/base_archive_security/models/base.py
+++ b/base_archive_security/models/base.py
@@ -9,8 +9,14 @@ class Base(models.AbstractModel):
     _inherit = "base"
 
     def toggle_active(self):
-        # check if the user is in the group that can archive/unarchive the record
-        if not self.env.user.has_group("base_archive_security.group_can_archive"):
+        # skip check if special bypass context key exist in env
+        if self.env.context.get("bypass_archive_security"):
+            return super().toggle_active()
+        # skip check on empty recordset
+        # and check if the user is in the group that can archive/unarchive the record
+        if self and not self.env.user.has_group(
+            "base_archive_security.group_can_archive"
+        ):
             group = self.env.ref("base_archive_security.group_can_archive")
             raise AccessError(
                 _(


### PR DESCRIPTION
This error disappeared with the uninstallation of the module base_archive_security.

FIX : add condition to toggle_active method to check if user is public user or not.