### PR TITLE
[16.0][FIX] base_tier_validation: error on loading view from m2o field

### DIFF
--- a/base_tier_validation/models/tier_validation.py
+++ b/base_tier_validation/models/tier_validation.py
@@ -577,16 +577,21 @@ class TierValidation(models.AbstractModel):
                 new_node = etree.fromstring(new_arch)
                 for new_element in new_node:
                     node.addprevious(new_element)
+                for model in new_models:
+                    if model in all_models:
+                        all_models[model] = set(all_models[model])
+                        all_models[model] = all_models[model].union(new_models[model])
+                    else:
+                        all_models[model] = new_models[model]
                 # _add_tier_validation_reviews process
                 new_node = self._add_tier_validation_reviews(node, params)
                 new_arch, new_models = View.postprocess_and_fields(new_node, self._name)
                 for model in new_models:
                     if model in all_models:
-                        continue
-                    if model not in res["models"]:
-                        all_models[model] = new_models[model]
+                        all_models[model] = set(all_models[model])
+                        all_models[model] = all_models[model].union(new_models[model])
                     else:
-                        all_models[model] = res["models"][model]
+                        all_models[model] = new_models[model]
                 new_node = etree.fromstring(new_arch)
                 node.append(new_node)
             res["arch"] = etree.tostring(doc)


### PR DESCRIPTION
Fixes an issue when loading the form view of any model that inherits tier.validation from a m2o field (Create and Edit...). Computed fields must be loaded in before the OWL component renders the form view. 

Previous behavior: 
- Load the form view of a model that inherits tier.validation from a m2o field using "Create and Edit..." option
- Get `Missing field string information for the field '${fieldName}' from the '${resModel}' model` error from processArch()
- Caused by fields missing from "models" key returned by get_view()
- Previous code ignored fields needed if the model was already present in the "models" key

Changes:
- No longer ignores necessary fields if the model is already present in the "model" key

Possible future improvements:
- Reduce repeated code
- Add fields after adding the validation buttons node