### PR TITLE
[17.0][IMP] base_tier_validation: Merge module with base_tier_validation_waiting

### DIFF
--- a/base_tier_validation/README.rst
+++ b/base_tier_validation/README.rst
@@ -62,6 +62,10 @@ To configure this module, you need to:
 
 -  If check *Notify Reviewers on Creation*, all possible reviewers will
    be notified by email when this definition is triggered.
+-  If check *Notify reviewers on reaching pending* if you want to send a
+   notification when pending status is reached. This is usefull in a
+   approve by sequence scenario to only notify reviewers when it is
+   their turn in the sequence.
 -  If check *Comment*, reviewers can comment after click Validate or
    Reject.
 -  If check *Approve by sequence*, reviewers is forced to review by
@@ -95,6 +99,13 @@ improvement will be very valuable.
 
 Changelog
 =========
+
+17.0.1.0.0 (2024-01-10)
+-----------------------
+
+Migrated to Odoo 17. Merged module with tier_validation_waiting. To
+support sending messages in a validation sequence when it is their turn
+to validate.
 
 14.0.1.0.0 (2020-11-19)
 -----------------------
@@ -206,6 +217,7 @@ Credits
 Authors
 -------
 
+* brain-tec AG
 * ForgeFlow
 
 Contributors
@@ -219,6 +231,8 @@ Contributors
 -  Kitti U. <kittiu@ecosoft.co.th>
 -  Saran Lim. <saranl@ecosoft.co.th>
 -  Carlos Lopez <celm1990@gmail.com>
+-  Javier Colmeiro <javier.colmeiro@braintec.com>
+-  bosd
 
 Maintainers
 -----------

--- a/base_tier_validation/__manifest__.py
+++ b/base_tier_validation/__manifest__.py
@@ -8,7 +8,7 @@
     "maintainers": ["LoisRForgeFlow"],
     "category": "Tools",
     "website": "https://github.com/OCA/server-ux",
-    "author": "ForgeFlow, Odoo Community Association (OCA)",
+    "author": "brain-tec AG, ForgeFlow, Odoo Community Association (OCA)",
     "license": "AGPL-3",
     "application": False,
     "installable": True,

--- a/base_tier_validation/models/tier_definition.py
+++ b/base_tier_validation/models/tier_definition.py
@@ -67,6 +67,13 @@ class TierDefinition(models.Model):
         help="If set, all possible reviewers will be notified by email when "
         "this definition is triggered.",
     )
+    notify_on_pending = fields.Boolean(
+        string="Notify Reviewers on reaching Pending",
+        help="If set, all possible reviewers will be notified by email when "
+        "this status is reached."
+        "Usefull in an Approve by sequence scenario. "
+        "An notification request to review is sent out when it's their turn to review.",
+    )
     has_comment = fields.Boolean(string="Comment", default=False)
     approve_sequence = fields.Boolean(
         string="Approve by sequence",

--- a/base_tier_validation/models/tier_validation.py
+++ b/base_tier_validation/models/tier_validation.py
@@ -22,8 +22,6 @@ class TierValidation(models.AbstractModel):
     _state_to = ["confirmed"]
     _cancel_state = "cancel"
 
-    # TODO: step by step validation?
-
     review_ids = fields.One2many(
         comodel_name="tier.review",
         inverse_name="res_id",
@@ -47,6 +45,7 @@ class TierValidation(models.AbstractModel):
     validation_status = fields.Selection(
         selection=[
             ("no", "Without validation"),
+            ("waiting", "Waiting"),
             ("pending", "Pending"),
             ("rejected", "Rejected"),
             ("validated", "Validated"),
@@ -70,12 +69,15 @@ class TierValidation(models.AbstractModel):
     def _compute_has_comment(self):
         for rec in self:
             has_comment = rec.review_ids.filtered(
-                lambda r: r.status == "pending" and (self.env.user in r.reviewer_ids)
+                lambda r: r.status in ("waiting", "pending")
+                and (self.env.user in r.reviewer_ids)
             ).mapped("has_comment")
             rec.has_comment = True in has_comment
 
     def _get_sequences_to_approve(self, user):
-        all_reviews = self.review_ids.filtered(lambda r: r.status == "pending")
+        all_reviews = self.review_ids.filtered(
+            lambda r: r.status in ("waiting", "pending")
+        )
         my_reviews = all_reviews.filtered(lambda r: user in r.reviewer_ids)
         # Include all my_reviews with approve_sequence = False
         sequences = my_reviews.filtered(lambda r: not r.approve_sequence).mapped(
@@ -98,7 +100,7 @@ class TierValidation(models.AbstractModel):
     def _search_can_review(self, operator, value):
         domain = [
             ("review_ids.reviewer_ids", "=", self.env.user.id),
-            ("review_ids.status", "=", "pending"),
+            ("review_ids.status", "in", ["pending", "waiting"]),
             ("review_ids.can_review", "=", True),
             ("rejected", "=", False),
         ]
@@ -111,7 +113,7 @@ class TierValidation(models.AbstractModel):
     def _compute_reviewer_ids(self):
         for rec in self:
             rec.reviewer_ids = rec.review_ids.filtered(
-                lambda r: r.status == "pending"
+                lambda r: r.status in ("waiting", "pending")
             ).mapped("reviewer_ids")
 
     @api.model
@@ -145,7 +147,6 @@ class TierValidation(models.AbstractModel):
                 ("model", "=", self._name),
                 ("reviewer_ids", operator, value),
                 ("can_review", "=", True),
-                ("status", "=", "pending"),
             ]
         )
         return [("id", model_operator, list(set(reviews.mapped("res_id"))))]
@@ -192,6 +193,12 @@ class TierValidation(models.AbstractModel):
                 and any(item.review_ids.filtered(lambda x: x.status == "pending"))
             ):
                 item.validation_status = "pending"
+            elif (
+                not item.validated
+                and not item.rejected
+                and any(item.review_ids.filtered(lambda x: x.status == "waiting"))
+            ):
+                item.validation_status = "waiting"
             else:
                 item.validation_status = "no"
 
@@ -320,6 +327,20 @@ class TierValidation(models.AbstractModel):
     def _validate_tier(self, tiers=False):
         self.ensure_one()
         tier_reviews = tiers or self.review_ids
+        waiting_reviews = tier_reviews.filtered(
+            lambda r: r.status == "waiting"
+            or r.approve_sequence_bypass
+            and (self.env.user in r.reviewer_ids)
+        )
+        if waiting_reviews:
+            waiting_reviews.write(
+                {
+                    "status": "pending",
+                    "done_by": self.env.user.id,
+                    "reviewed_date": fields.Datetime.now(),
+                }
+            )
+
         user_reviews = tier_reviews.filtered(
             lambda r: r.status == "pending" and (self.env.user in r.reviewer_ids)
         )
@@ -427,7 +448,8 @@ class TierValidation(models.AbstractModel):
         self.ensure_one()
         tier_reviews = tiers or self.review_ids
         user_reviews = tier_reviews.filtered(
-            lambda r: r.status == "pending" and (self.env.user in r.reviewer_ids)
+            lambda r: r.status in ("waiting", "pending")
+            and (self.env.user in r.reviewer_ids)
         )
         user_reviews.write(
             {
@@ -440,10 +462,16 @@ class TierValidation(models.AbstractModel):
             rec = self.env[review.model].browse(review.res_id)
             rec._notify_rejected_review()
 
+    def _notify_created_review_body(self):
+        return _("A record to be reviewed has been created by %s.") % (
+            self.env.user.name
+        )
+
     def _notify_requested_review_body(self):
         return _("A review has been requested by %s.") % (self.env.user.name)
 
     def _notify_review_requested(self, tier_reviews):
+        """method to notify when tier validation is created"""
         subscribe = "message_subscribe"
         post = "message_post"
         if hasattr(self, post) and hasattr(self, subscribe):
@@ -459,7 +487,7 @@ class TierValidation(models.AbstractModel):
                     )
                     getattr(rec, post)(
                         subtype_xmlid=self._get_requested_notification_subtype(),
-                        body=rec._notify_requested_review_body(),
+                        body=rec._notify_created_review_body(),
                     )
 
     def _prepare_tier_review_vals(self, definition, sequence):
@@ -509,7 +537,9 @@ class TierValidation(models.AbstractModel):
         for rec in self:
             if getattr(rec, self._state_field) in self._state_from:
                 to_update_counter = (
-                    rec.mapped("review_ids").filtered(lambda a: a.status == "pending")
+                    rec.mapped("review_ids").filtered(
+                        lambda a: a.status in ("waiting", "pending")
+                    )
                     and True
                     or False
                 )
@@ -594,3 +624,22 @@ class TierValidation(models.AbstractModel):
             res["arch"] = etree.tostring(doc)
             res["models"] = frozendict(all_models)
         return res
+
+    def _notify_review_available(self, tier_reviews):
+        """method to notify when reaching pending"""
+        subscribe = "message_subscribe"
+        post = "message_post"
+        if hasattr(self, post) and hasattr(self, subscribe):
+            for rec in self.sudo():
+                users_to_notify = tier_reviews.filtered(
+                    lambda r, x=rec: r.definition_id.notify_on_pending
+                    and r.res_id == x.id
+                ).mapped("reviewer_ids")
+                # Subscribe reviewers and notify
+                getattr(rec, subscribe)(
+                    partner_ids=users_to_notify.mapped("partner_id").ids
+                )
+                getattr(rec, post)(
+                    subtype_xmlid=self._get_requested_notification_subtype(),
+                    body=rec._notify_requested_review_body(),
+                )

--- a/base_tier_validation/models/tier_validation.py
+++ b/base_tier_validation/models/tier_validation.py
@@ -70,7 +70,7 @@ class TierValidation(models.AbstractModel):
         for rec in self:
             has_comment = rec.review_ids.filtered(
                 lambda r: r.status in ("waiting", "pending")
-                and (self.env.user in r.reviewer_ids)
+                and self.env.user in r.reviewer_ids
             ).mapped("has_comment")
             rec.has_comment = True in has_comment
 
@@ -330,7 +330,7 @@ class TierValidation(models.AbstractModel):
         waiting_reviews = tier_reviews.filtered(
             lambda r: r.status == "waiting"
             or r.approve_sequence_bypass
-            and (self.env.user in r.reviewer_ids)
+            and self.env.user in r.reviewer_ids
         )
         if waiting_reviews:
             waiting_reviews.write(
@@ -449,7 +449,7 @@ class TierValidation(models.AbstractModel):
         tier_reviews = tiers or self.review_ids
         user_reviews = tier_reviews.filtered(
             lambda r: r.status in ("waiting", "pending")
-            and (self.env.user in r.reviewer_ids)
+            and self.env.user in r.reviewer_ids
         )
         user_reviews.write(
             {
@@ -636,10 +636,10 @@ class TierValidation(models.AbstractModel):
                     and r.res_id == x.id
                 ).mapped("reviewer_ids")
                 # Subscribe reviewers and notify
-                getattr(rec, subscribe)(
+                rec.message_subscribe(
                     partner_ids=users_to_notify.mapped("partner_id").ids
                 )
-                getattr(rec, post)(
+                rec.message_post(
                     subtype_xmlid=self._get_requested_notification_subtype(),
                     body=rec._notify_requested_review_body(),
                 )

--- a/base_tier_validation/readme/CONFIGURE.md
+++ b/base_tier_validation/readme/CONFIGURE.md
@@ -9,6 +9,8 @@ To configure this module, you need to:
 
 - If check *Notify Reviewers on Creation*, all possible reviewers will
   be notified by email when this definition is triggered.
+- If check *Notify reviewers on reaching pending* if you want to send a notification when pending status is reached.
+  This is usefull in a approve by sequence scenario to only notify reviewers when it is their turn in the sequence.
 - If check *Comment*, reviewers can comment after click Validate or
   Reject.
 - If check *Approve by sequence*, reviewers is forced to review by

--- a/base_tier_validation/readme/CONTRIBUTORS.md
+++ b/base_tier_validation/readme/CONTRIBUTORS.md
@@ -6,3 +6,5 @@
 - Kitti U. \<<kittiu@ecosoft.co.th>\>
 - Saran Lim. \<<saranl@ecosoft.co.th>\>
 - Carlos Lopez \<<celm1990@gmail.com>\>
+- Javier Colmeiro \<<javier.colmeiro@braintec.com>\>
+- bosd

--- a/base_tier_validation/readme/HISTORY.md
+++ b/base_tier_validation/readme/HISTORY.md
@@ -1,3 +1,9 @@
+## 17.0.1.0.0 (2024-01-10)
+
+Migrated to Odoo 17.
+Merged module with tier_validation_waiting.
+To support sending messages in a validation sequence when it is their turn to validate.
+
 ## 14.0.1.0.0 (2020-11-19)
 
 Migrated to Odoo 14.

--- a/base_tier_validation/static/description/index.html
+++ b/base_tier_validation/static/description/index.html
@@ -387,27 +387,28 @@ as an example of implementation.</p>
 <li><a class="reference internal" href="#configuration" id="toc-entry-1">Configuration</a></li>
 <li><a class="reference internal" href="#known-issues-roadmap" id="toc-entry-2">Known issues / Roadmap</a></li>
 <li><a class="reference internal" href="#changelog" id="toc-entry-3">Changelog</a><ul>
-<li><a class="reference internal" href="#section-1" id="toc-entry-4">14.0.1.0.0 (2020-11-19)</a></li>
-<li><a class="reference internal" href="#section-2" id="toc-entry-5">13.0.1.2.2 (2020-08-30)</a></li>
-<li><a class="reference internal" href="#section-3" id="toc-entry-6">12.0.3.3.1 (2019-12-02)</a></li>
-<li><a class="reference internal" href="#section-4" id="toc-entry-7">12.0.3.3.0 (2019-11-27)</a></li>
-<li><a class="reference internal" href="#section-5" id="toc-entry-8">12.0.3.2.1 (2019-11-26)</a></li>
-<li><a class="reference internal" href="#section-6" id="toc-entry-9">12.0.3.2.0 (2019-11-25)</a></li>
-<li><a class="reference internal" href="#section-7" id="toc-entry-10">12.0.3.1.0 (2019-07-08)</a></li>
-<li><a class="reference internal" href="#section-8" id="toc-entry-11">12.0.3.0.0 (2019-12-02)</a></li>
-<li><a class="reference internal" href="#section-9" id="toc-entry-12">12.0.2.1.0 (2019-05-29)</a></li>
-<li><a class="reference internal" href="#section-10" id="toc-entry-13">12.0.2.0.0 (2019-05-28)</a></li>
-<li><a class="reference internal" href="#section-11" id="toc-entry-14">12.0.1.0.0 (2019-02-18)</a></li>
-<li><a class="reference internal" href="#section-12" id="toc-entry-15">11.0.1.0.0 (2018-05-09)</a></li>
-<li><a class="reference internal" href="#section-13" id="toc-entry-16">10.0.1.0.0 (2018-03-26)</a></li>
-<li><a class="reference internal" href="#section-14" id="toc-entry-17">9.0.1.0.0 (2017-12-02)</a></li>
+<li><a class="reference internal" href="#section-1" id="toc-entry-4">17.0.1.0.0 (2024-01-10)</a></li>
+<li><a class="reference internal" href="#section-2" id="toc-entry-5">14.0.1.0.0 (2020-11-19)</a></li>
+<li><a class="reference internal" href="#section-3" id="toc-entry-6">13.0.1.2.2 (2020-08-30)</a></li>
+<li><a class="reference internal" href="#section-4" id="toc-entry-7">12.0.3.3.1 (2019-12-02)</a></li>
+<li><a class="reference internal" href="#section-5" id="toc-entry-8">12.0.3.3.0 (2019-11-27)</a></li>
+<li><a class="reference internal" href="#section-6" id="toc-entry-9">12.0.3.2.1 (2019-11-26)</a></li>
+<li><a class="reference internal" href="#section-7" id="toc-entry-10">12.0.3.2.0 (2019-11-25)</a></li>
+<li><a class="reference internal" href="#section-8" id="toc-entry-11">12.0.3.1.0 (2019-07-08)</a></li>
+<li><a class="reference internal" href="#section-9" id="toc-entry-12">12.0.3.0.0 (2019-12-02)</a></li>
+<li><a class="reference internal" href="#section-10" id="toc-entry-13">12.0.2.1.0 (2019-05-29)</a></li>
+<li><a class="reference internal" href="#section-11" id="toc-entry-14">12.0.2.0.0 (2019-05-28)</a></li>
+<li><a class="reference internal" href="#section-12" id="toc-entry-15">12.0.1.0.0 (2019-02-18)</a></li>
+<li><a class="reference internal" href="#section-13" id="toc-entry-16">11.0.1.0.0 (2018-05-09)</a></li>
+<li><a class="reference internal" href="#section-14" id="toc-entry-17">10.0.1.0.0 (2018-03-26)</a></li>
+<li><a class="reference internal" href="#section-15" id="toc-entry-18">9.0.1.0.0 (2017-12-02)</a></li>
 </ul>
 </li>
-<li><a class="reference internal" href="#bug-tracker" id="toc-entry-18">Bug Tracker</a></li>
-<li><a class="reference internal" href="#credits" id="toc-entry-19">Credits</a><ul>
-<li><a class="reference internal" href="#authors" id="toc-entry-20">Authors</a></li>
-<li><a class="reference internal" href="#contributors" id="toc-entry-21">Contributors</a></li>
-<li><a class="reference internal" href="#maintainers" id="toc-entry-22">Maintainers</a></li>
+<li><a class="reference internal" href="#bug-tracker" id="toc-entry-19">Bug Tracker</a></li>
+<li><a class="reference internal" href="#credits" id="toc-entry-20">Credits</a><ul>
+<li><a class="reference internal" href="#authors" id="toc-entry-21">Authors</a></li>
+<li><a class="reference internal" href="#contributors" id="toc-entry-22">Contributors</a></li>
+<li><a class="reference internal" href="#maintainers" id="toc-entry-23">Maintainers</a></li>
 </ul>
 </li>
 </ul>
@@ -424,6 +425,10 @@ functionality.</li>
 <ul class="simple">
 <li>If check <em>Notify Reviewers on Creation</em>, all possible reviewers will
 be notified by email when this definition is triggered.</li>
+<li>If check <em>Notify reviewers on reaching pending</em> if you want to send a
+notification when pending status is reached. This is usefull in a
+approve by sequence scenario to only notify reviewers when it is
+their turn in the sequence.</li>
 <li>If check <em>Comment</em>, reviewers can comment after click Validate or
 Reject.</li>
 <li>If check <em>Approve by sequence</em>, reviewers is forced to review by
@@ -456,11 +461,17 @@ value on our expected model.</p>
 <div class="section" id="changelog">
 <h1><a class="toc-backref" href="#toc-entry-3">Changelog</a></h1>
 <div class="section" id="section-1">
-<h2><a class="toc-backref" href="#toc-entry-4">14.0.1.0.0 (2020-11-19)</a></h2>
-<p>Migrated to Odoo 14.</p>
+<h2><a class="toc-backref" href="#toc-entry-4">17.0.1.0.0 (2024-01-10)</a></h2>
+<p>Migrated to Odoo 17. Merged module with tier_validation_waiting. To
+support sending messages in a validation sequence when it is their turn
+to validate.</p>
 </div>
 <div class="section" id="section-2">
-<h2><a class="toc-backref" href="#toc-entry-5">13.0.1.2.2 (2020-08-30)</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-5">14.0.1.0.0 (2020-11-19)</a></h2>
+<p>Migrated to Odoo 14.</p>
+</div>
+<div class="section" id="section-3">
+<h2><a class="toc-backref" href="#toc-entry-6">13.0.1.2.2 (2020-08-30)</a></h2>
 <p>Fixes:</p>
 <ul class="simple">
 <li>When using approve_sequence option in any tier.definition there can
@@ -469,84 +480,84 @@ be inconsistencies in the systray notifications</li>
 sequence, but also other sequence for the same approver</li>
 </ul>
 </div>
-<div class="section" id="section-3">
-<h2><a class="toc-backref" href="#toc-entry-6">12.0.3.3.1 (2019-12-02)</a></h2>
+<div class="section" id="section-4">
+<h2><a class="toc-backref" href="#toc-entry-7">12.0.3.3.1 (2019-12-02)</a></h2>
 <p>Fixes:</p>
 <ul class="simple">
 <li>Show comment on Reviews Table.</li>
 <li>Edit notification with approve_sequence.</li>
 </ul>
 </div>
-<div class="section" id="section-4">
-<h2><a class="toc-backref" href="#toc-entry-7">12.0.3.3.0 (2019-11-27)</a></h2>
+<div class="section" id="section-5">
+<h2><a class="toc-backref" href="#toc-entry-8">12.0.3.3.0 (2019-11-27)</a></h2>
 <p>New features:</p>
 <ul class="simple">
 <li>Add comment on Reviews Table.</li>
 <li>Approve by sequence.</li>
 </ul>
 </div>
-<div class="section" id="section-5">
-<h2><a class="toc-backref" href="#toc-entry-8">12.0.3.2.1 (2019-11-26)</a></h2>
+<div class="section" id="section-6">
+<h2><a class="toc-backref" href="#toc-entry-9">12.0.3.2.1 (2019-11-26)</a></h2>
 <p>Fixes:</p>
 <ul class="simple">
 <li>Remove message_subscribe_users</li>
 </ul>
 </div>
-<div class="section" id="section-6">
-<h2><a class="toc-backref" href="#toc-entry-9">12.0.3.2.0 (2019-11-25)</a></h2>
+<div class="section" id="section-7">
+<h2><a class="toc-backref" href="#toc-entry-10">12.0.3.2.0 (2019-11-25)</a></h2>
 <p>New features:</p>
 <ul class="simple">
 <li>Notify reviewers</li>
 </ul>
 </div>
-<div class="section" id="section-7">
-<h2><a class="toc-backref" href="#toc-entry-10">12.0.3.1.0 (2019-07-08)</a></h2>
+<div class="section" id="section-8">
+<h2><a class="toc-backref" href="#toc-entry-11">12.0.3.1.0 (2019-07-08)</a></h2>
 <p>Fixes:</p>
 <ul class="simple">
 <li>Singleton error</li>
 </ul>
 </div>
-<div class="section" id="section-8">
-<h2><a class="toc-backref" href="#toc-entry-11">12.0.3.0.0 (2019-12-02)</a></h2>
+<div class="section" id="section-9">
+<h2><a class="toc-backref" href="#toc-entry-12">12.0.3.0.0 (2019-12-02)</a></h2>
 <p>Fixes:</p>
 <ul class="simple">
 <li>Edit Reviews Table</li>
 </ul>
 </div>
-<div class="section" id="section-9">
-<h2><a class="toc-backref" href="#toc-entry-12">12.0.2.1.0 (2019-05-29)</a></h2>
+<div class="section" id="section-10">
+<h2><a class="toc-backref" href="#toc-entry-13">12.0.2.1.0 (2019-05-29)</a></h2>
 <p>Fixes:</p>
 <ul class="simple">
 <li>Edit drop-down style width and position</li>
 </ul>
 </div>
-<div class="section" id="section-10">
-<h2><a class="toc-backref" href="#toc-entry-13">12.0.2.0.0 (2019-05-28)</a></h2>
+<div class="section" id="section-11">
+<h2><a class="toc-backref" href="#toc-entry-14">12.0.2.0.0 (2019-05-28)</a></h2>
 <p>New features:</p>
 <ul class="simple">
 <li>Pass parameters as functions.</li>
 <li>Add Systray.</li>
 </ul>
 </div>
-<div class="section" id="section-11">
-<h2><a class="toc-backref" href="#toc-entry-14">12.0.1.0.0 (2019-02-18)</a></h2>
+<div class="section" id="section-12">
+<h2><a class="toc-backref" href="#toc-entry-15">12.0.1.0.0 (2019-02-18)</a></h2>
 <p>Migrated to Odoo 12.</p>
 </div>
-<div class="section" id="section-12">
-<h2><a class="toc-backref" href="#toc-entry-15">11.0.1.0.0 (2018-05-09)</a></h2>
+<div class="section" id="section-13">
+<h2><a class="toc-backref" href="#toc-entry-16">11.0.1.0.0 (2018-05-09)</a></h2>
 <p>Migrated to Odoo 11.</p>
 </div>
-<div class="section" id="section-13">
-<h2><a class="toc-backref" href="#toc-entry-16">10.0.1.0.0 (2018-03-26)</a></h2>
+<div class="section" id="section-14">
+<h2><a class="toc-backref" href="#toc-entry-17">10.0.1.0.0 (2018-03-26)</a></h2>
 <p>Migrated to Odoo 10.</p>
 </div>
-<div class="section" id="section-14">
-<h2><a class="toc-backref" href="#toc-entry-17">9.0.1.0.0 (2017-12-02)</a></h2>
+<div class="section" id="section-15">
+<h2><a class="toc-backref" href="#toc-entry-18">9.0.1.0.0 (2017-12-02)</a></h2>
 <p>First version.</p>
 </div>
 </div>
 <div class="section" id="bug-tracker">
-<h1><a class="toc-backref" href="#toc-entry-18">Bug Tracker</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-19">Bug Tracker</a></h1>
 <p>Bugs are tracked on <a class="reference external" href="https://github.com/OCA/server-ux/issues">GitHub Issues</a>.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us to smash it by providing a detailed and welcomed
@@ -554,15 +565,16 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">
-<h1><a class="toc-backref" href="#toc-entry-19">Credits</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-20">Credits</a></h1>
 <div class="section" id="authors">
-<h2><a class="toc-backref" href="#toc-entry-20">Authors</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-21">Authors</a></h2>
 <ul class="simple">
+<li>brain-tec AG</li>
 <li>ForgeFlow</li>
 </ul>
 </div>
 <div class="section" id="contributors">
-<h2><a class="toc-backref" href="#toc-entry-21">Contributors</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-22">Contributors</a></h2>
 <ul class="simple">
 <li>Lois Rilo &lt;<a class="reference external" href="mailto:lois.rilo&#64;forgeflow.com">lois.rilo&#64;forgeflow.com</a>&gt;</li>
 <li>Naglis Jonaitis &lt;<a class="reference external" href="mailto:naglis&#64;versada.eu">naglis&#64;versada.eu</a>&gt;</li>
@@ -572,10 +584,12 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <li>Kitti U. &lt;<a class="reference external" href="mailto:kittiu&#64;ecosoft.co.th">kittiu&#64;ecosoft.co.th</a>&gt;</li>
 <li>Saran Lim. &lt;<a class="reference external" href="mailto:saranl&#64;ecosoft.co.th">saranl&#64;ecosoft.co.th</a>&gt;</li>
 <li>Carlos Lopez &lt;<a class="reference external" href="mailto:celm1990&#64;gmail.com">celm1990&#64;gmail.com</a>&gt;</li>
+<li>Javier Colmeiro &lt;<a class="reference external" href="mailto:javier.colmeiro&#64;braintec.com">javier.colmeiro&#64;braintec.com</a>&gt;</li>
+<li>bosd</li>
 </ul>
 </div>
 <div class="section" id="maintainers">
-<h2><a class="toc-backref" href="#toc-entry-22">Maintainers</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-23">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
 <a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose

--- a/base_tier_validation/tests/common.py
+++ b/base_tier_validation/tests/common.py
@@ -78,13 +78,51 @@ class CommonTierValidation(common.TransactionCase):
                 "model_id": cls.tester_model.id,
                 "review_type": "individual",
                 "reviewer_id": cls.test_user_1.id,
-                "definition_domain": "[('test_field', '>', 1.0)]",
+                "definition_domain": "[('test_field', '=', 1.0)]",
                 "sequence": 30,
             }
         )
 
-        cls.test_record = cls.test_model.create({"test_field": 2.5})
-        cls.test_record_2 = cls.test_model_2.create({"test_field": 2.5})
+        cls.test_record = cls.test_model.create({"test_field": 1.0})
+        cls.test_record_2 = cls.test_model_2.create({"test_field": 1.0})
+
+        cls.tier_def_obj.create(
+            {
+                "model_id": cls.tester_model.id,
+                "review_type": "individual",
+                "reviewer_id": cls.test_user_1.id,
+                "definition_domain": "[('test_field', '>', 3.0)]",
+                "approve_sequence": True,
+                "notify_on_pending": False,
+                "sequence": 20,
+                "name": "Definition for test 19 - sequence - user 1",
+            }
+        )
+        cls.tier_def_obj.create(
+            {
+                "model_id": cls.tester_model.id,
+                "review_type": "individual",
+                "reviewer_id": cls.test_user_2.id,
+                "definition_domain": "[('test_field', '>', 3.0)]",
+                "approve_sequence": True,
+                "notify_on_pending": True,
+                "sequence": 10,
+                "name": "Definition for test 19 - sequence - user 2",
+            }
+        )
+        # Create definition for test 20
+        cls.tier_def_obj.create(
+            {
+                "model_id": cls.tester_model.id,
+                "review_type": "individual",
+                "reviewer_id": cls.test_user_1.id,
+                "definition_domain": "[('test_field', '=', 0.9)]",
+                "approve_sequence": False,
+                "notify_on_pending": True,
+                "sequence": 10,
+                "name": "Definition for test 20 - no sequence -  user 1 - no sequence",
+            }
+        )
 
     @classmethod
     def tearDownClass(cls):

--- a/base_tier_validation/views/tier_definition_view.xml
+++ b/base_tier_validation/views/tier_definition_view.xml
@@ -99,6 +99,7 @@
                             <group name="more_option">
                                 <group name="notify">
                                     <field name="notify_on_create" />
+                                    <field name="notify_on_pending" />
                                     <field name="has_comment" />
                                 </group>
                             </group>


### PR DESCRIPTION
As proposed as an idea in:
https://github.com/OCA/server-ux/pull/787#issuecomment-1871461565
This is the PR for the migration of base_tier_validation_waiting into the base module `base_tier_validation_waiting`.


Please fasstrack, as v17 is not deployed yet in production, this is the best time to introduce this refactor.

To the contributors/authers/reviewers of the migration pr..

@celm1990, @nguyenminhchien, @bofiltd, @moitabenfdz, @sonhd91, @Dranyel-Bosd, @BT-jcolmeiro
Can you please review?