### PR TITLE
[17.0][PORT] 699 from 14.0: base_tier_validation multiple comment with approve_sequence_bypass

### DIFF
--- a/base_tier_validation/wizard/comment_wizard.py
+++ b/base_tier_validation/wizard/comment_wizard.py
@@ -17,7 +17,8 @@ class CommentWizard(models.TransientModel):
     def add_comment(self):
         self.ensure_one()
         rec = self.env[self.res_model].browse(self.res_id)
-        self.review_ids.write({"comment": self.comment})
+        reviews_tocomment = self.review_ids.filtered(lambda r: r.status == "pending")
+        reviews_tocomment.write({"comment": self.comment})
         if self.validate_reject == "validate":
             rec._validate_tier(self.review_ids)
         if self.validate_reject == "reject":


### PR DESCRIPTION
Port #699 from 14.0 to 17.0.

when option approve_sequence_bypass is enabled and comments option with
sequence, the user add a comment and all level add this
comment.
This code add comment only for appropriate tier validation