### PR TITLE
[16.0][IMP] base_tier_validation_server_action: pass active_ids in context

### DIFF
--- a/base_tier_validation_server_action/models/tier_validation.py
+++ b/base_tier_validation_server_action/models/tier_validation.py
@@ -23,6 +23,7 @@ class TierValidation(models.AbstractModel):
                     server_action_tier=server_action.id,
                     active_model=self._name,
                     active_id=self.id,
+                    active_ids=self.ids,
                 ).sudo().run()
 
     def _validate_tier(self, tiers=False):

--- a/base_tier_validation_server_action/tests/test_tier_validation.py
+++ b/base_tier_validation_server_action/tests/test_tier_validation.py
@@ -187,7 +187,7 @@ class TierTierValidation(common.TransactionCase):
                 "name": "Set test_bool = True",
                 "model_id": self.tester_model.id,
                 "state": "code",
-                "code": "record.write({'test_bool': True})",
+                "code": "records.write({'test_bool': True})",
             }
         )
         # Create tier definitions
@@ -204,5 +204,5 @@ class TierTierValidation(common.TransactionCase):
         test_record.with_user(self.test_user_2).request_validation()
         record = test_record.with_user(self.test_user_1)
         record.invalidate_recordset()
-        record.reject_tier()
+        record.with_context(active_ids=[]).reject_tier()
         self.assertTrue(record.test_bool)


### PR DESCRIPTION
without this, the server action will get passed the wrong value in `records` if the context it's called in has `active_ids` set. The test below then also fails without the addition.