### PR TITLE
[16.0][FIX][base_tier_validation] fix validation date timezone

### DIFF
--- a/base_tier_validation/models/tier_review.py
+++ b/base_tier_validation/models/tier_review.py
@@ -71,7 +71,7 @@ class TierReview(models.Model):
             if not review.reviewed_date:
                 review.reviewed_formated_date = False
                 continue
-            requested_date_utc = pytz.timezone(timezone).localize(review.reviewed_date)
+            requested_date_utc = pytz.timezone("UTC").localize(review.reviewed_date)
             requested_date = requested_date_utc.astimezone(pytz.timezone(timezone))
             review.reviewed_formated_date = requested_date.replace(tzinfo=None)
 

--- a/base_tier_validation/models/tier_review.py
+++ b/base_tier_validation/models/tier_review.py
@@ -71,9 +71,9 @@ class TierReview(models.Model):
             if not review.reviewed_date:
                 review.reviewed_formated_date = False
                 continue
-            requested_date_utc = pytz.timezone("UTC").localize(review.reviewed_date)
-            requested_date = requested_date_utc.astimezone(pytz.timezone(timezone))
-            review.reviewed_formated_date = requested_date.replace(tzinfo=None)
+            reviewed_date_utc = pytz.timezone("UTC").localize(review.reviewed_date)
+            reviewed_date_tz = reviewed_date_utc.astimezone(pytz.timezone(timezone))
+            review.reviewed_formated_date = reviewed_date_tz.replace(tzinfo=None)
 
     @api.depends("definition_id.approve_sequence")
     def _compute_can_review(self):

--- a/base_tier_validation/readme/CONTRIBUTORS.rst
+++ b/base_tier_validation/readme/CONTRIBUTORS.rst
@@ -5,3 +5,4 @@
 * Pedro Gonzalez <pedro.gonzalez@pesol.es>
 * Kitti U. <kittiu@ecosoft.co.th>
 * Saran Lim. <saranl@ecosoft.co.th>
+* Evan Soh <evan.soh@omnisoftsolution.com>


### PR DESCRIPTION
Validation Date for tier reviews shows in UTC instead of user timezone.

requested_date_utc should be localized to UTC instead of user timezone