### PR TITLE
[16.0][FIX] base_tier_validation: Change web_ribbon text to title to make it translatable

### DIFF
--- a/base_tier_validation/views/tier_definition_view.xml
+++ b/base_tier_validation/views/tier_definition_view.xml
@@ -28,7 +28,7 @@
                     <div class="oe_button_box" name="button_box" />
                     <widget
                         name="web_ribbon"
-                        text="Archived"
+                        title="Archived"
                         bg_color="bg-danger"
                         attrs="{'invisible': [('active', '=', True)]}"
                     />


### PR DESCRIPTION
FWP from 15.0: https://github.com/OCA/server-ux/pull/812

Change web_ribbon text to title to make it translatable

@Tecnativa