### PR TITLE
[17.0][RFC] base_tier_validation: remove unused code

### DIFF
--- a/base_tier_validation/models/res_users.py
+++ b/base_tier_validation/models/res_users.py
@@ -45,19 +45,3 @@ class Users(models.Model):
                         "pending_count": len(records),
                     }
         return list(user_reviews.values())
-
-    @api.model
-    def get_reviews(self, data):
-        review_obj = self.env["tier.review"].with_context(lang=self.env.user.lang)
-        res = review_obj.search_read([("id", "in", data.get("res_ids"))])
-        for r in res:
-            # Get the translated status value.
-            r["display_status"] = dict(
-                review_obj.fields_get("status")["status"]["selection"]
-            ).get(r.get("status"))
-            # Convert to datetime timezone
-            if r["reviewed_date"]:
-                r["reviewed_date"] = fields.Datetime.context_timestamp(
-                    self, r["reviewed_date"]
-                )
-        return res

--- a/base_tier_validation/tests/test_tier_validation.py
+++ b/base_tier_validation/tests/test_tier_validation.py
@@ -417,9 +417,7 @@ class TierTierValidation(CommonTierValidation):
         # Request validation
         review = test_record.with_user(self.test_user_2).request_validation()
         self.assertTrue(review)
-        self.assertTrue(self.test_user_1.get_reviews({"res_ids": review.ids}))
-        self.assertTrue(self.test_user_1.review_ids)
-        test_record.invalidate_model()
+        self.env.invalidate_all()
         self.assertTrue(test_record.review_ids)
         # Used by front-end
         count = self.test_user_1.with_user(self.test_user_1).review_user_count()
@@ -475,8 +473,6 @@ class TierTierValidation(CommonTierValidation):
         self.assertEqual(len(records), 1)
         review = self.test_record.with_user(self.test_user_2.id).request_validation()
         self.assertTrue(review)
-        self.assertTrue(self.test_user_1.get_reviews({"res_ids": review.ids}))
-        self.assertTrue(self.test_user_1.review_ids)
         self.test_record.with_user(self.test_user_1.id).request_validation()
 
     def test_18_test_review_by_res_users_field(self):


### PR DESCRIPTION
remove the code, which was needed for the review widget pre V16.