### PR TITLE
[17.0][FIX] base_tier_validation: Do not write review fields in pending state

### DIFF
--- a/base_tier_validation/models/tier_validation.py
+++ b/base_tier_validation/models/tier_validation.py
@@ -339,8 +339,6 @@ class TierValidation(models.AbstractModel):
             waiting_reviews.write(
                 {
                     "status": "pending",
-                    "done_by": self.env.user.id,
-                    "reviewed_date": fields.Datetime.now(),
                 }
             )
 

--- a/base_tier_validation/tests/test_tier_validation.py
+++ b/base_tier_validation/tests/test_tier_validation.py
@@ -514,12 +514,20 @@ class TierTierValidation(CommonTierValidation):
         # first reviewer does not want notifications
         # chatter should be empty
         self.assertFalse(test_record.message_ids)
+        self.assertTrue(review_1.done_by.id is False)
+        self.assertTrue(review_1.reviewed_date is False)
         self.assertTrue(review_2.status == "waiting")
+        self.assertTrue(review_2.done_by.id is False)
+        self.assertTrue(review_2.reviewed_date is False)
         record = test_record.with_user(self.test_user_1.id)
         record.invalidate_model()
         record.validate_tier()
         self.assertTrue(review_1.status == "approved")
+        self.assertFalse(review_1.reviewed_date is False)
+        self.assertTrue(review_1.done_by.id == self.test_user_1.id)
         self.assertTrue(review_2.status == "pending")
+        self.assertTrue(review_2.done_by.id is False)
+        self.assertTrue(review_2.reviewed_date is False)
 
     def test_20_no_sequence(self):
         # Create new test record

--- a/base_tier_validation/tests/test_tier_validation.py
+++ b/base_tier_validation/tests/test_tier_validation.py
@@ -420,6 +420,8 @@ class TierTierValidation(CommonTierValidation):
         self.assertEqual(len(count), 1)
         # False Review
         self.assertFalse(self.test_record._calc_reviews_validated(False))
+        # test notification message bodies
+        self.assertIn("created", self.test_record._notify_created_review_body())
         self.assertIn("requested", self.test_record._notify_requested_review_body())
         self.assertIn("rejected", self.test_record._notify_rejected_review_body())
         self.assertIn("accepted", self.test_record._notify_accepted_reviews_body())


### PR DESCRIPTION
Before this PR, review fields `done by`, `validation date` where written.

[base_tier_Before_fix.webm](https://github.com/OCA/server-ux/assets/11499387/ee65f9d6-b450-4bd3-87f3-b25b042553ab)


After:
[base_tier_after_fix.webm](https://github.com/OCA/server-ux/assets/11499387/9c1e7e86-d42c-4dd0-8645-ea37c1b29c1d)


Added test for this to improve coverage.
