### PR TITLE
[FIX] mass_editing : Prevent to crash if the module is installed, but if there are no data

### DIFF
--- a/mass_editing/migrations/13.0.1.0.0/post-migration.py
+++ b/mass_editing/migrations/13.0.1.0.0/post-migration.py
@@ -7,6 +7,10 @@ def migrate(cr, version):
     if not version:
         return
     # Don't execute if already migrated in v12
+    cr.execute("SELECT 1 FROM pg_class WHERE relname = %s", ("mass_field_rel",))
+    if not cr.fetchone():
+        return
+
     cr.execute("SELECT COUNT(*) FROM mass_editing_line")
     if cr.fetchone()[0] > 0:
         return


### PR DESCRIPTION
For that reason, do not populate mass_editing_line, if mass_field_rel doesn't exist, that occures if we come from the latest version of the module in 12.0