### PR TITLE
[16.0][FIX] template_content_swapper

### DIFF
--- a/template_content_swapper/models/template_content_mapping.py
+++ b/template_content_swapper/models/template_content_mapping.py
@@ -22,6 +22,7 @@ class TemplateContentMapping(models.Model):
         compute="_compute_template_id",
         store=True,
         readonly=False,
+        precompute=True,
         help="Select the main template of the report / frontend page to be modified.",
     )
     lang = fields.Selection(


### PR DESCRIPTION
This PR fixes the issue when we add `report_id` and `template_id` is computed. The issue was occurred because of `template_id` is required field and this should be computed before record insertion.

@qrtl