### PR TITLE
[17.0] [IMP] base_tier_validation: Block notifications

### DIFF
--- a/base_tier_validation/README.rst
+++ b/base_tier_validation/README.rst
@@ -234,6 +234,7 @@ Contributors
 -  Javier Colmeiro <javier.colmeiro@braintec.com>
 -  bosd
 -  Evan Soh <evan.soh@omnisoftsolution.com>
+-  Manuel Regidor <manuel.regidor@sygel.es>
 
 Maintainers
 -----------

--- a/base_tier_validation/models/tier_definition.py
+++ b/base_tier_validation/models/tier_definition.py
@@ -74,6 +74,21 @@ class TierDefinition(models.Model):
         "Usefull in an Approve by sequence scenario. "
         "An notification request to review is sent out when it's their turn to review.",
     )
+    notify_on_accepted = fields.Boolean(
+        string="Notify Reviewers on Accepted",
+        help="If set, reviewers will be notified by email when a review related "
+        "to this definition is accepted.",
+    )
+    notify_on_rejected = fields.Boolean(
+        string="Notify Reviewers on Rejected",
+        help="If set, reviewers will be notified by email when a review related "
+        "to this definition is rejected.",
+    )
+    notify_on_restarted = fields.Boolean(
+        string="Notify Reviewers on Restarted",
+        help="If set, reviewers will be notified by email when a reviews related "
+        "to this definition are restarted.",
+    )
     has_comment = fields.Boolean(string="Comment", default=False)
     approve_sequence = fields.Boolean(
         string="Approve by sequence",

--- a/base_tier_validation/readme/CONTRIBUTORS.md
+++ b/base_tier_validation/readme/CONTRIBUTORS.md
@@ -9,3 +9,4 @@
 - Javier Colmeiro \<<javier.colmeiro@braintec.com>\>
 - bosd
 - Evan Soh \<<evan.soh@omnisoftsolution.com>\>
+- Manuel Regidor \<<manuel.regidor@sygel.es>\>

--- a/base_tier_validation/static/description/index.html
+++ b/base_tier_validation/static/description/index.html
@@ -587,6 +587,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <li>Javier Colmeiro &lt;<a class="reference external" href="mailto:javier.colmeiro&#64;braintec.com">javier.colmeiro&#64;braintec.com</a>&gt;</li>
 <li>bosd</li>
 <li>Evan Soh &lt;<a class="reference external" href="mailto:evan.soh&#64;omnisoftsolution.com">evan.soh&#64;omnisoftsolution.com</a>&gt;</li>
+<li>Manuel Regidor &lt;<a class="reference external" href="mailto:manuel.regidor&#64;sygel.es">manuel.regidor&#64;sygel.es</a>&gt;</li>
 </ul>
 </div>
 <div class="section" id="maintainers">

--- a/base_tier_validation/tests/test_tier_validation.py
+++ b/base_tier_validation/tests/test_tier_validation.py
@@ -547,6 +547,376 @@ class TierTierValidation(CommonTierValidation):
         request = test_record2._notify_requested_review_body()
         self.assertIn(request, msg2)
 
+    def test_21_notify_on_create(self):
+        # notify on create
+        tier_definition = self.env["tier.definition"].search([])
+        tier_definition.write(
+            {
+                "notify_on_create": True,
+                "notify_on_accepted": False,
+                "notify_on_rejected": False,
+                "notify_on_restarted": False,
+                "review_type": "group",
+                "reviewer_group_id": self.env.ref("base.group_system").id,
+            }
+        )
+        test_record_1 = self.test_model.create({"test_field": 1})
+        notifications_no_1 = len(
+            self.env["mail.notification"].search(
+                [("res_partner_id", "=", self.test_user_1.partner_id.id)]
+            )
+        )
+        test_record_1.request_validation()
+        notifications_no_2 = len(
+            self.env["mail.notification"].search(
+                [("res_partner_id", "=", self.test_user_1.partner_id.id)]
+            )
+        )
+        self.assertEqual(notifications_no_2, notifications_no_1 + 1)
+
+        # do not notify on create
+        tier_definition.write({"notify_on_create": False})
+        test_record_2 = self.test_model.create({"test_field": 1})
+        notifications_no_1 = len(
+            self.env["mail.notification"].search(
+                [("res_partner_id", "=", self.test_user_1.partner_id.id)]
+            )
+        )
+        test_record_2.request_validation()
+        notifications_no_2 = len(
+            self.env["mail.notification"].search(
+                [("res_partner_id", "=", self.test_user_1.partner_id.id)]
+            )
+        )
+        self.assertEqual(notifications_no_2, notifications_no_1)
+
+    def test_22_notify_on_accepted(self):
+        self.test_user_2.write(
+            {
+                "groups_id": [(6, 0, self.env.ref("base.group_system").ids)],
+            }
+        )
+
+        # notify on accepted
+        tier_definition = self.env["tier.definition"].search([])
+        tier_definition.write(
+            {
+                "notify_on_create": False,
+                "notify_on_accepted": True,
+                "notify_on_rejected": False,
+                "notify_on_restarted": False,
+                "review_type": "group",
+                "reviewer_group_id": self.env.ref("base.group_system").id,
+            }
+        )
+        test_record_1 = self.test_model.create({"test_field": 1})
+        test_record_1.request_validation()
+        test_record_1.invalidate_model()
+        record = test_record_1.with_user(self.test_user_2.id)
+        notifications_no_1 = len(
+            self.env["mail.notification"].search(
+                [("res_partner_id", "=", self.test_user_1.partner_id.id)]
+            )
+        )
+        record.validate_tier()
+        notifications_no_2 = len(
+            self.env["mail.notification"].search(
+                [("res_partner_id", "=", self.test_user_1.partner_id.id)]
+            )
+        )
+        self.assertEqual(notifications_no_2, notifications_no_1 + 1)
+
+        # do not notify on accepted
+        tier_definition.write({"notify_on_accepted": False})
+        test_record_2 = self.test_model.create({"test_field": 1})
+        test_record_2.request_validation()
+        test_record_2.invalidate_model()
+        test_record_2.with_user(self.test_user_2.id)
+        notifications_no_1 = len(
+            self.env["mail.notification"].search(
+                [("res_partner_id", "=", self.test_user_1.partner_id.id)]
+            )
+        )
+        test_record_2.validate_tier()
+        notifications_no_2 = len(
+            self.env["mail.notification"].search(
+                [("res_partner_id", "=", self.test_user_1.partner_id.id)]
+            )
+        )
+        self.assertEqual(notifications_no_2, notifications_no_1)
+
+    def test_23_notify_on_rejected(self):
+        self.test_user_2.write(
+            {
+                "groups_id": [(6, 0, self.env.ref("base.group_system").ids)],
+            }
+        )
+
+        # notify on rejected
+        tier_definition = self.env["tier.definition"].search([])
+        tier_definition.write(
+            {
+                "notify_on_create": False,
+                "notify_on_accepted": False,
+                "notify_on_rejected": True,
+                "notify_on_restarted": False,
+                "review_type": "group",
+                "reviewer_group_id": self.env.ref("base.group_system").id,
+            }
+        )
+        test_record_1 = self.test_model.create({"test_field": 1})
+        test_record_1.request_validation()
+        test_record_1.invalidate_model()
+        record = test_record_1.with_user(self.test_user_2.id)
+        notifications_no_1 = len(
+            self.env["mail.notification"].search(
+                [("res_partner_id", "=", self.test_user_1.partner_id.id)]
+            )
+        )
+        record.reject_tier()
+        notifications_no_2 = len(
+            self.env["mail.notification"].search(
+                [("res_partner_id", "=", self.test_user_1.partner_id.id)]
+            )
+        )
+        self.assertEqual(notifications_no_2, notifications_no_1 + 1)
+
+        # do not notify on rejected
+        tier_definition.write({"notify_on_rejected": False})
+        test_record_2 = self.test_model.create({"test_field": 1})
+        test_record_2.request_validation()
+        test_record_2.invalidate_model()
+        test_record_2.with_user(self.test_user_2.id)
+
+        notifications_no_1 = len(
+            self.env["mail.notification"].search(
+                [("res_partner_id", "=", self.test_user_1.partner_id.id)]
+            )
+        )
+        test_record_2.reject_tier()
+        notifications_no_2 = len(
+            self.env["mail.notification"].search(
+                [("res_partner_id", "=", self.test_user_1.partner_id.id)]
+            )
+        )
+        self.assertEqual(notifications_no_2, notifications_no_1)
+
+    def test_24_notify_on_restarted(self):
+        self.test_user_2.write(
+            {
+                "groups_id": [(6, 0, self.env.ref("base.group_system").ids)],
+            }
+        )
+
+        # notify on restarted
+        tier_definition = self.env["tier.definition"].search([])
+        tier_definition.write(
+            {
+                "notify_on_create": False,
+                "notify_on_accepted": False,
+                "notify_on_rejected": False,
+                "notify_on_restarted": True,
+                "review_type": "group",
+                "reviewer_group_id": self.env.ref("base.group_system").id,
+            }
+        )
+        test_record_1 = self.test_model.create({"test_field": 1})
+        test_record_1.request_validation()
+        test_record_1.invalidate_model()
+        record = test_record_1.with_user(self.test_user_2.id)
+        notifications_no_1 = len(
+            self.env["mail.notification"].search(
+                [("res_partner_id", "=", self.test_user_1.partner_id.id)]
+            )
+        )
+        record.restart_validation()
+        notifications_no_2 = len(
+            self.env["mail.notification"].search(
+                [("res_partner_id", "=", self.test_user_1.partner_id.id)]
+            )
+        )
+        self.assertEqual(notifications_no_2, notifications_no_1 + 1)
+
+        # do not notify on restarted
+        tier_definition.write({"notify_on_restarted": False})
+        test_record_2 = self.test_model.create({"test_field": 1})
+        test_record_2.request_validation()
+        test_record_2.with_user(self.test_user_2.id)
+        notifications_no_1 = len(
+            self.env["mail.notification"].search(
+                [("res_partner_id", "=", self.test_user_1.partner_id.id)]
+            )
+        )
+        test_record_2.restart_validation()
+        notifications_no_2 = len(
+            self.env["mail.notification"].search(
+                [("res_partner_id", "=", self.test_user_1.partner_id.id)]
+            )
+        )
+        self.assertEqual(notifications_no_2, notifications_no_1)
+
+    def test_25_all_notification(self):
+        self.test_user_2.write(
+            {
+                "groups_id": [(6, 0, self.env.ref("base.group_system").ids)],
+            }
+        )
+
+        # notify on restarted
+        tier_definition = self.env["tier.definition"].search([])
+        tier_definition.write(
+            {
+                "notify_on_create": True,
+                "notify_on_accepted": True,
+                "notify_on_rejected": True,
+                "notify_on_restarted": True,
+                "review_type": "group",
+                "reviewer_group_id": self.env.ref("base.group_system").id,
+            }
+        )
+
+        test_record = self.test_model.create({"test_field": 1})
+
+        # request validation
+        notifications_no_1 = len(
+            self.env["mail.notification"].search(
+                [("res_partner_id", "=", self.test_user_1.partner_id.id)]
+            )
+        )
+        test_record.request_validation()
+        test_record.invalidate_model()
+        notifications_no_2 = len(
+            self.env["mail.notification"].search(
+                [("res_partner_id", "=", self.test_user_1.partner_id.id)]
+            )
+        )
+        self.assertEqual(notifications_no_2, notifications_no_1 + 1)
+
+        # accept validation
+        record = test_record.with_user(self.test_user_2.id)
+        notifications_no_1 = len(
+            self.env["mail.notification"].search(
+                [("res_partner_id", "=", self.test_user_1.partner_id.id)]
+            )
+        )
+        record.validate_tier()
+        notifications_no_2 = len(
+            self.env["mail.notification"].search(
+                [("res_partner_id", "=", self.test_user_1.partner_id.id)]
+            )
+        )
+        self.assertEqual(notifications_no_2, notifications_no_1 + 1)
+
+        # restart validation
+        notifications_no_1 = len(
+            self.env["mail.notification"].search(
+                [("res_partner_id", "=", self.test_user_1.partner_id.id)]
+            )
+        )
+        record.restart_validation()
+        notifications_no_2 = len(
+            self.env["mail.notification"].search(
+                [("res_partner_id", "=", self.test_user_1.partner_id.id)]
+            )
+        )
+        self.assertEqual(notifications_no_2, notifications_no_1 + 1)
+
+        # reject validation
+        record.request_validation()
+        notifications_no_1 = len(
+            self.env["mail.notification"].search(
+                [("res_partner_id", "=", self.test_user_1.partner_id.id)]
+            )
+        )
+        record.reject_tier()
+        notifications_no_2 = len(
+            self.env["mail.notification"].search(
+                [("res_partner_id", "=", self.test_user_1.partner_id.id)]
+            )
+        )
+        self.assertEqual(notifications_no_2, notifications_no_1 + 1)
+
+    def test_26_no_notification(self):
+        self.test_user_2.write(
+            {
+                "groups_id": [(6, 0, self.env.ref("base.group_system").ids)],
+            }
+        )
+
+        # notify on restarted
+        tier_definition = self.env["tier.definition"].search([])
+        tier_definition.write(
+            {
+                "notify_on_create": False,
+                "notify_on_accepted": False,
+                "notify_on_rejected": False,
+                "notify_on_restarted": False,
+                "review_type": "group",
+                "reviewer_group_id": self.env.ref("base.group_system").id,
+            }
+        )
+
+        test_record = self.test_model.create({"test_field": 1})
+
+        # request validation
+        notifications_no_1 = len(
+            self.env["mail.notification"].search(
+                [("res_partner_id", "=", self.test_user_1.partner_id.id)]
+            )
+        )
+        test_record.request_validation()
+        test_record.invalidate_model()
+        notifications_no_2 = len(
+            self.env["mail.notification"].search(
+                [("res_partner_id", "=", self.test_user_1.partner_id.id)]
+            )
+        )
+        self.assertEqual(notifications_no_2, notifications_no_1)
+
+        # accept validation
+        record = test_record.with_user(self.test_user_2.id)
+        notifications_no_1 = len(
+            self.env["mail.notification"].search(
+                [("res_partner_id", "=", self.test_user_1.partner_id.id)]
+            )
+        )
+        record.validate_tier()
+        notifications_no_2 = len(
+            self.env["mail.notification"].search(
+                [("res_partner_id", "=", self.test_user_1.partner_id.id)]
+            )
+        )
+        self.assertEqual(notifications_no_2, notifications_no_1)
+
+        # restart validation
+        notifications_no_1 = len(
+            self.env["mail.notification"].search(
+                [("res_partner_id", "=", self.test_user_1.partner_id.id)]
+            )
+        )
+        record.restart_validation()
+        notifications_no_2 = len(
+            self.env["mail.notification"].search(
+                [("res_partner_id", "=", self.test_user_1.partner_id.id)]
+            )
+        )
+        self.assertEqual(notifications_no_2, notifications_no_1)
+
+        # reject validation
+        record.request_validation()
+        notifications_no_1 = len(
+            self.env["mail.notification"].search(
+                [("res_partner_id", "=", self.test_user_1.partner_id.id)]
+            )
+        )
+        record.reject_tier()
+        notifications_no_2 = len(
+            self.env["mail.notification"].search(
+                [("res_partner_id", "=", self.test_user_1.partner_id.id)]
+            )
+        )
+        self.assertEqual(notifications_no_2, notifications_no_1)
+
 
 @tagged("at_install")
 class TierTierValidationView(CommonTierValidation):

--- a/base_tier_validation/views/tier_definition_view.xml
+++ b/base_tier_validation/views/tier_definition_view.xml
@@ -113,6 +113,9 @@
                                 <group name="notify">
                                     <field name="notify_on_create" />
                                     <field name="notify_on_pending" />
+                                    <field name="notify_on_accepted" />
+                                    <field name="notify_on_rejected" />
+                                    <field name="notify_on_restarted" />
                                     <field name="has_comment" />
                                 </group>
                             </group>


### PR DESCRIPTION
FW port of #834 

This imp adds three additional options to configure whether tier definitions have to cause the sending of notifications when reviews get accepted, rejected or restarted (the 'on create option' is already available). This options are located in the "More Options" tab in tier definitions.

T-5732