### PR TITLE
[16.0][FIX] base_tier_validation: Field merge in view

### DIFF
--- a/base_tier_validation/models/tier_validation.py
+++ b/base_tier_validation/models/tier_validation.py
@@ -713,12 +713,7 @@ class TierValidation(models.AbstractModel):
     @api.model
     def get_view(self, view_id=None, view_type="form", **options):
         res = super().get_view(view_id=view_id, view_type=view_type, **options)
-
         View = self.env["ir.ui.view"]
-
-        # Override context for postprocessing
-        if view_id and res.get("base_model", self._name) != self._name:
-            View = View.with_context(base_model_name=res["base_model"])
         if view_type == "form" and not self._tier_validation_manual_config:
             doc = etree.XML(res["arch"])
             params = {
@@ -726,7 +721,7 @@ class TierValidation(models.AbstractModel):
                 "state_operator": "not in",
                 "state_value": self._state_from,
             }
-            all_models = res["models"].copy()
+            all_models = res["models"].copy()  # {modelname(str) ➔ fields(tuple)}
             for node in doc.xpath(self._tier_validation_buttons_xpath):
                 # By default, after the last button of the header
                 # _add_tier_validation_buttons process
@@ -735,6 +730,7 @@ class TierValidation(models.AbstractModel):
                 new_node = etree.fromstring(new_arch)
                 for new_element in new_node:
                     node.addnext(new_element)
+                _merge_view_fields(all_models, new_models)
             for node in doc.xpath("/form/sheet"):
                 # _add_tier_validation_label process
                 new_node = self._add_tier_validation_label(node, params)
@@ -742,18 +738,13 @@ class TierValidation(models.AbstractModel):
                 new_node = etree.fromstring(new_arch)
                 for new_element in new_node:
                     node.addprevious(new_element)
+                _merge_view_fields(all_models, new_models)
                 # _add_tier_validation_reviews process
                 new_node = self._add_tier_validation_reviews(node, params)
                 new_arch, new_models = View.postprocess_and_fields(new_node, self._name)
-                for model in new_models:
-                    if model in all_models:
-                        continue
-                    if model not in res["models"]:
-                        all_models[model] = new_models[model]
-                    else:
-                        all_models[model] = res["models"][model]
                 new_node = etree.fromstring(new_arch)
                 node.append(new_node)
+                _merge_view_fields(all_models, new_models)
             excepted_fields = self._get_all_validation_exceptions()
             for node in doc.xpath("//field[@name][not(ancestor::field)]"):
                 if node.attrib.get("name") in excepted_fields:
@@ -772,3 +763,12 @@ class TierValidation(models.AbstractModel):
             res["arch"] = etree.tostring(doc)
             res["models"] = frozendict(all_models)
         return res
+
+
+def _merge_view_fields(all_models: dict, new_models: dict):
+    """Merge new_models into all_models. Both are {modelname(str) ➔ fields(tuple)}."""
+    for model, view_fields in new_models.items():
+        if model in all_models:
+            all_models[model] = tuple(set(all_models[model]) | set(view_fields))
+        else:
+            all_models[model] = tuple(view_fields)

--- a/base_tier_validation/readme/CONTRIBUTORS.rst
+++ b/base_tier_validation/readme/CONTRIBUTORS.rst
@@ -8,3 +8,6 @@
 * Evan Soh <evan.soh@omnisoftsolution.com>
 * Manuel Regidor <manuel.regidor@sygel.es>
 * Eduardo de Miguel <edu@moduon.team>
+* `XCG Consulting <https://xcg-consulting.fr>`_:
+
+  * Houzéfa Abbasbhay

--- a/base_tier_validation/tests/common.py
+++ b/base_tier_validation/tests/common.py
@@ -57,6 +57,24 @@ class CommonTierValidation(common.TransactionCase):
             }
         )
 
+        # Define views to avoid automatic views with all fields.
+        for model in cls.test_model._name, cls.test_model_2._name:
+            cls.env["ir.ui.view"].create(
+                {
+                    "model": model,
+                    "name": f"Demo view for {model}",
+                    "arch": """<form>
+                    <header>
+                        <button name="action_confirm" type="object" string="Confirm" />
+                        <field name="state" widget="statusbar" />
+                    </header>
+                    <sheet>
+                        <field name="test_field" />
+                    </sheet>
+                    </form>""",
+                }
+            )
+
         # Create users:
         group_ids = cls.env.ref("base.group_system").ids
         cls.test_user_1 = cls.env["res.users"].create(

--- a/base_tier_validation/tests/test_tier_validation.py
+++ b/base_tier_validation/tests/test_tier_validation.py
@@ -909,23 +909,6 @@ class TierTierValidation(CommonTierValidation):
 @tagged("at_install")
 class TierTierValidationView(CommonTierValidation):
     def test_view_manual(self):
-        # We need to add a view in order to ensure that an automatic view with all
-        # fields is not created
-        self.env["ir.ui.view"].create(
-            {
-                "model": self.test_record._name,
-                "name": "Demo view",
-                "arch": """<form>
-            <header>
-                <button name="action_confirm" type="object" string="Confirm" />
-                <field name="state" widget="statusbar" />
-            </header>
-            <sheet>
-                <field name="test_field" />
-            </sheet>
-            </form>""",
-            }
-        )
         with Form(self.test_record) as f:
             self.assertNotIn("review_ids", f._values)
             form = etree.fromstring(f._view["arch"])
@@ -934,26 +917,19 @@ class TierTierValidationView(CommonTierValidation):
             self.assertFalse(form.xpath("//button[@name='request_validation']"))
 
     def test_view_automatic(self):
-        # We need to add a view in order to ensure that an automatic view with all
-        # fields is not created
-        self.env["ir.ui.view"].create(
-            {
-                "model": self.test_record_2._name,
-                "name": "Demo view",
-                "arch": """<form>
-            <header>
-                <button name="action_confirm" type="object" string="Confirm" />
-                <field name="state" widget="statusbar" />
-            </header>
-            <sheet>
-                <field name="test_field" />
-            </sheet>
-            </form>""",
-            }
-        )
         with Form(self.test_record_2) as f:
             self.assertIn("review_ids", f._values)
             form = etree.fromstring(f._view["arch"])
             self.assertTrue(form.xpath("//field[@name='review_ids']"))
             self.assertTrue(form.xpath("//field[@name='can_review']"))
             self.assertTrue(form.xpath("//button[@name='request_validation']"))
+
+    def test_get_view(self):
+        view = self.test_record_2.get_view()
+        model = "tier.validation.tester2"
+        self.assertEqual(view["model"], model)
+        self.assertEqual(view["models"].keys(), {model, "tier.review"})
+        self.assertIn("id", view["models"][model])
+        self.assertIn("need_validation", view["models"][model])
+        self.assertIn("next_review", view["models"][model])
+        self.assertIn("review_ids", view["models"][model])


### PR DESCRIPTION
Previous implementation was losing fields in some cases; new one properly merges dicts/tuples.

This fixes odd "Missing field string information" errors in form-embedded lists.

This cset also removes an obsolete `base_model_name` context key no longer used in Odoo 16.

This cset adds a `test_get_view` test which checks for that `need_validation` field; it was failing with the previous impl.

Fixes #825.