### PR TITLE
[15.0][ENH] base_tier_validation, add Notify Reviewers by Sequence

### DIFF
--- a/base_tier_validation/models/tier_definition.py
+++ b/base_tier_validation/models/tier_definition.py
@@ -2,6 +2,7 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 from odoo import _, api, fields, models
+from odoo.exceptions import ValidationError
 
 
 class TierDefinition(models.Model):
@@ -67,6 +68,11 @@ class TierDefinition(models.Model):
         help="If set, all possible reviewers will be notified by email when "
         "this definition is triggered.",
     )
+    notify_by_sequence = fields.Boolean(
+        string="Notify Reviewers by Sequence",
+        help="If set, all possible reviewers will be notified by email when "
+        "just prior to their turn to approve (by sequence)",
+    )
     has_comment = fields.Boolean(string="Comment", default=False)
     approve_sequence = fields.Boolean(
         string="Approve by sequence",
@@ -76,6 +82,12 @@ class TierDefinition(models.Model):
     approve_sequence_bypass = fields.Boolean(
         help="Bypassed (auto validated), if previous tier was validated by same reviewer",
     )
+
+    @api.constrains("notify_on_create", "notify_by_sequence")
+    def _check_notify_option(self):
+        for rec in self:
+            if rec.notify_on_create and rec.notify_by_sequence:
+                raise ValidationError(_("Please select only 1 notify option"))
 
     @api.onchange("review_type")
     def onchange_review_type(self):

--- a/base_tier_validation/models/tier_review.py
+++ b/base_tier_validation/models/tier_review.py
@@ -58,6 +58,7 @@ class TierReview(models.Model):
     approve_sequence_bypass = fields.Boolean(
         related="definition_id.approve_sequence_bypass", readonly=True
     )
+    notified = fields.Boolean(default=False, help="The reviewer was notified by email.")
 
     @api.depends("definition_id.approve_sequence")
     def _compute_can_review(self):

--- a/base_tier_validation/static/src/xml/tier_review_template.xml
+++ b/base_tier_validation/static/src/xml/tier_review_template.xml
@@ -33,6 +33,7 @@
                     <th name="th_done_by" class="text-right">Done by</th>
                     <th name="th_reviewed_date" class="text-right">Validation Date</th>
                     <th name="th_comment" class="text-right">Comment</th>
+                    <th name="th_notified" class="text-right">Notified</th>
                 </tr>
             </thead>
             <tbody class="sale_tbody">
@@ -79,6 +80,11 @@
                         <td name="td_comment" class="text-left">
                             <t t-if="review.comment">
                                 <span t-esc="review.comment" />
+                            </t>
+                        </td>
+                        <td name="td_notified" class="text-right">
+                            <t t-if="review.notified">
+                                <span t-esc="review.notified and 'Yes' or 'No'" />
                             </t>
                         </td>
                     </tr>

--- a/base_tier_validation/views/tier_definition_view.xml
+++ b/base_tier_validation/views/tier_definition_view.xml
@@ -99,6 +99,7 @@
                             <group name="more_option">
                                 <group name="notify">
                                     <field name="notify_on_create" />
+                                    <field name="notify_by_sequence" />
                                     <field name="has_comment" />
                                 </group>
                             </group>

--- a/base_tier_validation/views/tier_review_view.xml
+++ b/base_tier_validation/views/tier_review_view.xml
@@ -19,6 +19,7 @@
                 <field name="done_by" />
                 <field name="reviewed_date" />
                 <field name="comment" />
+                <field name="notified" />
             </tree>
         </field>
     </record>

--- a/base_tier_validation/wizard/comment_wizard.py
+++ b/base_tier_validation/wizard/comment_wizard.py
@@ -23,3 +23,4 @@ class CommentWizard(models.TransientModel):
         if self.validate_reject == "reject":
             rec._rejected_tier(self.review_ids)
         rec._update_counter()
+        rec._notify_review_requested()


### PR DESCRIPTION
This enhancement answer long time request we got from many customers, which is option to "Notify by Sequence" (in addition to "Notify on Creation"

![Selection_016](https://github.com/OCA/server-ux/assets/1973598/db821173-fd71-412c-ada5-7ed6825de4bf)

And so, the email notification will be sent out only when that approver can_review, and also marked in the tier review,

![Selection_015](https://github.com/OCA/server-ux/assets/1973598/609abc64-a517-46a2-a9c5-d0fbae078f5d)
