### PR TITLE
[17.0][IMP] Avoid WARNING ir_module.py:178

### DIFF
--- a/base_technical_features/static/description/index.html
+++ b/base_technical_features/static/description/index.html
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>


### PR DESCRIPTION
odoodb_test py.warnings: /odoo/src/odoo/addons/base/models/ir_module.py:178: DeprecationWarning: XML declarations in HTML module descriptions are deprecated since Odoo 17

<img width="1440" alt="Screenshot 2024-04-19 at 20 34 02" src="https://github.com/OCA/server-ux/assets/3788941/82237cbc-31b6-4227-9ba3-44b312b8193f">
