### PR TITLE
Update tier_validation.py

### DIFF
--- a/base_tier_validation/models/tier_validation.py
+++ b/base_tier_validation/models/tier_validation.py
@@ -279,9 +279,11 @@ class TierValidation(models.AbstractModel):
                 and not rec._check_allow_write_under_validation(vals)
                 and not rec._context.get("skip_validation_check")
             ):
-                raise ValidationError(_("The operation is under validation."))
-            if rec._allow_to_remove_reviews(vals):
-                rec.mapped("review_ids").unlink()
+                if self._state_field in vals:
+                    raise ValidationError(_("The operation is under validation."))
+            if self._state_field in vals:
+                if rec._allow_to_remove_reviews(vals):
+                    rec.mapped("review_ids").unlink()
         return super(TierValidation, self).write(vals)
 
     def _allow_to_remove_reviews(self, values):


### PR DESCRIPTION
When adding a validation in a model that in its confirmation process makes an update to a field other than the _state_field, it was left in a loop that needs a validation, when the validation was already applied previously, that is, there is no validation only when This is the field defined in the _state_field, this was tested in a custom module that was added for the validations prior to carrying out an inventory write-off with the stock.scrap model. Additionally, it is detected that the sequences are skipped every time you click on the confirm button and it has not yet been approved, which is not corrected in this push.