### PR TITLE
[16.0][ADD] base_tier_validation: compute validation flag dynamically

### DIFF
--- a/base_tier_validation/models/tier_definition.py
+++ b/base_tier_validation/models/tier_definition.py
@@ -140,3 +140,32 @@ class TierDefinition(models.Model):
             review_to_remind = record._get_review_needing_reminder()
             if review_to_remind:
                 review_to_remind._send_review_reminder()
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        result = super().create(vals_list)
+        result._update_registry()
+        return result
+
+    def write(self, vals):
+        result = super().write(vals)
+        if "definition_domain" in vals:
+            self._update_registry()
+        return result
+
+    def unlink(self):
+        models = set(self.mapped("model"))
+        result = super().unlink()
+        self._update_registry(models)
+        return result
+
+    def _update_registry(self, models=None):
+        """Update dependencies of validation flag"""
+        for model in models or set(self.mapped("model")):
+            depends = self.env[model]._compute_need_validation._depends
+            if not callable(depends):  # pragma: no cover
+                continue
+            self.pool.field_depends[
+                self.env[model]._fields["need_validation"]
+            ] = depends(self.env[model])
+            self.pool.registry_invalidated = True

--- a/base_tier_validation/tests/test_tier_validation.py
+++ b/base_tier_validation/tests/test_tier_validation.py
@@ -905,6 +905,22 @@ class TierTierValidation(CommonTierValidation):
             )
         self.assertEqual(self.test_record.test_validation_field, 4)
 
+    def test_26_update_registry(self):
+        """Test that changes to the tier definition reloads the registry"""
+        tier = self.env["tier.definition"].search(
+            [
+                ("model_id", "=", self.tester_model.id),
+            ]
+        )
+        field = self.env[self.test_model._name]._fields["need_validation"]
+        self.assertIn("test_field", self.env.registry.field_depends[field])
+        tier.write({"definition_domain": "[('user_id.name', '=', 'test')]"})
+        self.assertNotIn("test_field", self.env.registry.field_depends[field])
+        tier.unlink()
+        self.assertNotIn("test_field", self.env.registry.field_depends[field])
+        self.assertTrue(self.env.registry.registry_invalidated)
+        self.env.registry.registry_invalidated = False
+
 
 @tagged("at_install")
 class TierTierValidationView(CommonTierValidation):


### PR DESCRIPTION
the goal of this PR is that you see the validation UI immediately when creating a new record, and not only after saving.

Consider (for validating all vendor bills):

![qxWDchyDioHxEFuJQeqaNojM](https://github.com/OCA/server-ux/assets/2563186/9b9a116d-8424-4455-9d74-f95f4868865b)

we want the UI to look like

![SljqXJspmehIUcbkQCSMpGiW](https://github.com/OCA/server-ux/assets/2563186/69c5cbff-bbf9-49a4-991d-8996467cb7f4)

and not see the 'Confirm' button at all.