### PR TITLE
[FIX] base_tier_validation: allow sudo writes

### DIFF
--- a/base_tier_validation/models/tier_validation.py
+++ b/base_tier_validation/models/tier_validation.py
@@ -251,6 +251,11 @@ class TierValidation(models.AbstractModel):
         return True
 
     def write(self, vals):
+        if (
+            self.env.is_superuser()
+            and self.env.context.get("skip_validation_check") is not False
+        ):
+            return super().write(vals)
         for rec in self:
             if rec._check_state_conditions(vals):
                 if rec.need_validation:

--- a/base_tier_validation/tests/test_tier_validation.py
+++ b/base_tier_validation/tests/test_tier_validation.py
@@ -55,6 +55,9 @@ class TierTierValidation(CommonTierValidation):
         record.invalidate_model()
         with self.assertRaises(ValidationError):
             record.write({"test_field": 0.5})
+        # Sudo writes always allowed
+        record.sudo().write({"test_field": 0.5})
+        self.assertEqual(record.test_field, 0.5)
 
     def test_06_validation_process_open(self):
         """Operation forbidden while a validation process is open."""


### PR DESCRIPTION
Fix https://github.com/OCA/server-ux/issues/875 by always allowing superuser to write.

@moduon MT-5997