### PR TITLE
[17.0] [FIX] date_range: fix Translated stored related field warning

### DIFF
--- a/date_range/models/date_range.py
+++ b/date_range/models/date_range.py
@@ -8,7 +8,7 @@ from odoo.exceptions import ValidationError
 class DateRange(models.Model):
     _name = "date.range"
     _description = "Date Range"
-    _order = "type_name, date_start"
+    _order = "type_id, date_start"
     _check_company_auto = True
 
     @api.model
@@ -27,7 +27,6 @@ class DateRange(models.Model):
         domain="['|', ('company_id', '=', company_id), ('company_id', '=', False)]",
         check_company=True,
     )
-    type_name = fields.Char(related="type_id.name", store=True, string="Type Name")
     company_id = fields.Many2one(
         comodel_name="res.company", string="Company", index=1, default=_default_company
     )

--- a/date_range/models/date_range_type.py
+++ b/date_range/models/date_range_type.py
@@ -12,6 +12,7 @@ from odoo.exceptions import ValidationError
 class DateRangeType(models.Model):
     _name = "date.range.type"
     _description = "Date Range Type"
+    _order = "name,id"
 
     @api.model
     def _default_company(self):


### PR DESCRIPTION
Fix warning:

`2024-05-12 18:17:49,361 7526 WARNING odoo odoo.fields: Translated stored related field (date.range.type_name) will not be computed correctly in all languages `

Removed relatad field type_name used for order table and repaced with type_id