### PR TITLE
[16.0][FIX] base_tier_validation: use record from props instead of env in tier_review widget

### DIFF
--- a/base_tier_validation/models/tier_validation.py
+++ b/base_tier_validation/models/tier_validation.py
@@ -622,16 +622,21 @@ class TierValidation(models.AbstractModel):
                 new_node = etree.fromstring(new_arch)
                 for new_element in new_node:
                     node.addprevious(new_element)
+                for model in new_models:
+                    if model in all_models:
+                        all_models[model] = set(all_models[model])
+                        all_models[model] = all_models[model].union(new_models[model])
+                    else:
+                        all_models[model] = new_models[model]
                 # _add_tier_validation_reviews process
                 new_node = self._add_tier_validation_reviews(node, params)
                 new_arch, new_models = View.postprocess_and_fields(new_node, self._name)
                 for model in new_models:
                     if model in all_models:
-                        continue
-                    if model not in res["models"]:
-                        all_models[model] = new_models[model]
+                        all_models[model] = set(all_models[model])
+                        all_models[model] = all_models[model].union(new_models[model])
                     else:
-                        all_models[model] = res["models"][model]
+                        all_models[model] = new_models[model]
                 new_node = etree.fromstring(new_arch)
                 node.append(new_node)
             excepted_fields = self._get_under_validation_exceptions()

--- a/base_tier_validation/static/src/js/tier_review_widget.esm.js
+++ b/base_tier_validation/static/src/js/tier_review_widget.esm.js
@@ -14,7 +14,7 @@ export class ReviewsTable extends Component {
         this.reviews = [];
     }
     _getReviewData() {
-        const records = this.env.model.root.data.review_ids.records;
+        const records = this.props.record.data.review_ids.records;
         const reviews = [];
         for (var i = 0; i < records.length; i++) {
             reviews.push(records[i].data);


### PR DESCRIPTION
Based on #793 

I had an issue adding a Many2one of a model that uses tier validation (in my case: purchase.order) in the form view of an other model (in my case: maintenance.request).

The PR #793 was partially fixing my issue but I still had an issue in the tier_review widget:
`const records = this.env.model.root.data.review_ids.records;`
We are trying to take the model from the env but, `this.env.model` represents the other model (in my case: maintenance.request).

It is better to retrieve the data from the props instead