### PR TITLE
[16.0][IMP] configurable domain for readonly fields in validation

### DIFF
--- a/base_tier_validation/models/tier_validation.py
+++ b/base_tier_validation/models/tier_validation.py
@@ -590,6 +590,9 @@ class TierValidation(models.AbstractModel):
         new_node = etree.fromstring(str_element)
         return new_node
 
+    def _get_tier_validation_readonly_domain(self):
+        return [("review_ids", "!=", [])]
+
     @api.model
     def get_view(self, view_id=None, view_type="form", **options):
         res = super().get_view(view_id=view_id, view_type=view_type, **options)
@@ -645,7 +648,7 @@ class TierValidation(models.AbstractModel):
                     modifiers["readonly"] = OR(
                         [
                             modifiers.get("readonly", []) or [],
-                            [("review_ids", "!=", [])],
+                            self._get_tier_validation_readonly_domain(),
                         ]
                     )
                     node.attrib["modifiers"] = json.dumps(modifiers)


### PR DESCRIPTION
As discussed here : https://github.com/OCA/server-ux/pull/860
This PR make the domain easily editable for readonly fields in validation.