### PR TITLE
Replace author 'Camptocamp SA' with 'Camptocamp'

### DIFF
--- a/base_archive_security/__manifest__.py
+++ b/base_archive_security/__manifest__.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Camptocamp SA
+# Copyright 2023 Camptocamp
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 {

--- a/base_binary_url_import/__manifest__.py
+++ b/base_binary_url_import/__manifest__.py
@@ -1,4 +1,4 @@
-# Copyright 2022 Camptocamp SA
+# Copyright 2022 Camptocamp
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
 {
     "name": "Base Binary URL Import",

--- a/test_base_binary_url_import/__manifest__.py
+++ b/test_base_binary_url_import/__manifest__.py
@@ -1,4 +1,4 @@
-# Copyright 2022 Camptocamp SA
+# Copyright 2022 Camptocamp
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
 {
     "name": "Test Base Binary URL Import",


### PR DESCRIPTION
This pull request contains changes to replace 'Camptocamp SA' with 'Camptocamp' in __manifest__.py files for branch 16.0.