### PR TITLE
[13.0][FIX] base_optional_quick_create: add mail dependency

### DIFF
--- a/base_optional_quick_create/__manifest__.py
+++ b/base_optional_quick_create/__manifest__.py
@@ -9,7 +9,7 @@
     "author": "Agile Business Group,Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/server-ux",
     "license": "AGPL-3",
-    "depends": ["base"],
+    "depends": ["base", "mail"],
     "data": ["views/model_view.xml"],
     "installable": True,
 }


### PR DESCRIPTION
Fix

psycopg2.ProgrammingError: column ir_model.is_mail_activity does not exist
LINE 1: ...","ir_model"."is_mail_thread" as "is_mail_thread","ir_model"...

on upgrade from 12.0 to 13.0