### PR TITLE
[16.0][FIX] base_cancel_confirm: correct get_view method

### DIFF
--- a/base_cancel_confirm/tests/test_cancel_confirm.py
+++ b/base_cancel_confirm/tests/test_cancel_confirm.py
@@ -103,18 +103,3 @@ class TestCancelConfirm(common.TransactionCase):
             form = etree.fromstring(f._view["arch"])
             self.assertTrue(form.xpath("//field[@name='cancel_confirm']"))
             self.assertTrue(form.xpath("//field[@name='cancel_reason']"))
-
-        # Check view difference, it should change base_model from view_id
-        wizard_lang_export = self.env.ref("base.wizard_lang_export")
-        res = self.test_record.get_view(
-            view_id=wizard_lang_export.id,
-            view_type="form",
-        )
-        self.assertEqual(res["model"], wizard_lang_export.model)
-
-        # Check view type is tree.
-        wizard_lang_export = self.env.ref("base.wizard_lang_export")
-        self.test_record.get_view(
-            view_id=wizard_lang_export.id,
-            view_type="tree",
-        )


### PR DESCRIPTION
- Add missing **options argument
- Align 'get_view' logic with other similar implementations like https://github.com/OCA/server-ux/blob/16.0/base_tier_validation/models/tier_validation.py#L594 or https://github.com/OCA/edi-framework/blob/16.0/edi_oca/models/edi_exchange_consumer_mixin.py#L118. The current implementation used in the migration to V16 does not work (used in https://github.com/OCA/account-invoicing/pull/1744)