### PR TITLE
[16.0][FIX] base_tier_validation, search only active definitions

### DIFF
--- a/base_tier_validation/models/tier_validation.py
+++ b/base_tier_validation/models/tier_validation.py
@@ -220,11 +220,15 @@ class TierValidation(models.AbstractModel):
             if isinstance(rec.id, models.NewId):
                 rec.need_validation = False
                 continue
-            tiers = self.env["tier.definition"].search(
-                [
-                    ("model", "=", self._name),
-                    ("company_id", "in", [False] + self.env.company.ids),
-                ]
+            tiers = (
+                self.env["tier.definition"]
+                .with_context(active_test=True)
+                .search(
+                    [
+                        ("model", "=", self._name),
+                        ("company_id", "in", [False] + self.env.company.ids),
+                    ]
+                )
             )
             valid_tiers = any([rec.evaluate_tier(tier) for tier in tiers])
             rec.need_validation = (


### PR DESCRIPTION
If main context has active_test setup as false, can be processed inactive definitions, this commit force to search only active definitions

@ForgeFlow