### PR TITLE
[15.0][FIX] default_multi_user: incorrectly keeping cache after company switch

### DIFF
--- a/default_multi_user/hooks.py
+++ b/default_multi_user/hooks.py
@@ -1,4 +1,4 @@
-# Copyright 2020 ForgeFlow S.L.
+# Copyright 2020-24 ForgeFlow S.L.
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 import json
@@ -10,7 +10,7 @@ from odoo.addons.base.models.ir_default import IrDefault
 
 def post_load_hook():
     @api.model
-    @tools.ormcache("self.env.uid", "model_name", "condition")
+    @tools.ormcache("self.env.uid", "self.env.company.id", "model_name", "condition")
     def new_get_model_defaults(self, model_name, condition=False):
         if not hasattr(self, "_get_model_defaults_query_and_params"):
             return self.get_model_defaults_original(model_name, condition=condition)

--- a/default_multi_user/tests/test_default_multi_user.py
+++ b/default_multi_user/tests/test_default_multi_user.py
@@ -1,4 +1,4 @@
-# Copyright 2020 ForgeFlow S.L.
+# Copyright 2020-24 ForgeFlow S.L.
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 import json
@@ -148,3 +148,33 @@ class TestDefaultMultiUser(common.TransactionCase):
         self.user_1.company_id = self.other_company
         rec_3 = self.partner_model.with_user(self.user_1).create({"name": "Test"})
         self.assertNotEqual(rec_3.phone, self.test_value)
+
+    def test_06_user_switch_company(self):
+        """Test defaults changing when a user switches company"""
+        global_value = "+34 666 555 444"
+        self.default_model.create(
+            {
+                "field_id": self.field.id,
+                "json_value": json.dumps(global_value, ensure_ascii=False),
+            }
+        )
+        self.default_model.create(
+            {
+                "field_id": self.field.id,
+                "json_value": json.dumps(self.test_value, ensure_ascii=False),
+                "company_id": self.main_company.id,
+            }
+        )
+
+        rec_1 = (
+            self.partner_model.with_user(self.user_2)
+            .with_company(self.main_company)
+            .create({"name": "Test"})
+        )
+        self.assertEqual(rec_1.phone, self.test_value)
+        rec_2 = (
+            self.partner_model.with_user(self.user_2)
+            .with_company(self.other_company)
+            .create({"name": "Test"})
+        )
+        self.assertEqual(rec_2.phone, global_value)


### PR DESCRIPTION
This was fixed upstream but the signature of the method never got updated here in the corresponding hook.