### PR TITLE
[IMP] document_quick_access_folder_auto_classification: Remove edi_storage_oca unnecessary dependancy

### DIFF
--- a/document_quick_access_folder_auto_classification/README.rst
+++ b/document_quick_access_folder_auto_classification/README.rst
@@ -39,7 +39,8 @@ to its record. The record is found using the document quick access rules.
 Configuration
 =============
 
-# Create an storage on your system using the storage project from OCA
+# Create an storage on your system using the storage project from OCA.
+  Another option is using the endpoint project.
 
 Usage
 =====

--- a/document_quick_access_folder_auto_classification/__manifest__.py
+++ b/document_quick_access_folder_auto_classification/__manifest__.py
@@ -9,7 +9,7 @@
     "license": "AGPL-3",
     "author": "Creu Blanca,Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/server-ux",
-    "depends": ["document_quick_access", "edi_storage_oca"],
+    "depends": ["document_quick_access", "edi_oca"],
     "external_dependencies": {
         "deb": ["libzbar0", "poppler-utils"],
         "python": ["pyzbar", "pdf2image"],

--- a/document_quick_access_folder_auto_classification/data/edi_data.xml
+++ b/document_quick_access_folder_auto_classification/data/edi_data.xml
@@ -11,14 +11,8 @@
         <field name="direction">input</field>
         <field name="exchange_filename_pattern" />
     </record>
-    <record id="storage_backend" model="storage.backend">
-        <field name="name">Document Quick Access Storage Folder</field>
-        <field name="backend_type">filesystem</field>
-        <field name="directory_path">opt/qr_data</field>
-    </record>
     <record id="edi_backend" model="edi.backend">
         <field name="name">Document quick access auto classification</field>
         <field name="backend_type_id" ref="backend_type" />
-        <field name="storage_id" ref="storage_backend" />
     </record>
 </odoo>

--- a/document_quick_access_folder_auto_classification/readme/CONFIGURE.rst
+++ b/document_quick_access_folder_auto_classification/readme/CONFIGURE.rst
@@ -1,1 +1,2 @@
-# Create an storage on your system using the storage project from OCA
+# Create an storage on your system using the storage project from OCA.
+  Another option is using the endpoint project.

--- a/document_quick_access_folder_auto_classification/static/description/index.html
+++ b/document_quick_access_folder_auto_classification/static/description/index.html
@@ -387,7 +387,10 @@ to its record. The record is found using the document quick access rules.</p>
 </div>
 <div class="section" id="configuration">
 <h1><a class="toc-backref" href="#toc-entry-1">Configuration</a></h1>
-<p># Create an storage on your system using the storage project from OCA</p>
+<dl class="docutils">
+<dt># Create an storage on your system using the storage project from OCA.</dt>
+<dd>Another option is using the endpoint project.</dd>
+</dl>
 </div>
 <div class="section" id="usage">
 <h1><a class="toc-backref" href="#toc-entry-2">Usage</a></h1>

--- a/document_quick_access_folder_auto_classification/tests/test_document_quick_access_auto_classification.py
+++ b/document_quick_access_folder_auto_classification/tests/test_document_quick_access_auto_classification.py
@@ -1,9 +1,7 @@
 # Copyright 2019 Creu Blanca
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-import os
-import shutil
-import uuid
+import base64
 
 import cv2
 from mock import patch
@@ -36,24 +34,8 @@ class TestDocumentQuickAccessClassification(SavepointComponentRegistryCase):
 
         self._load_module_components(self, "component_event")
         self._load_module_components(self, "edi")
-        self._load_module_components(self, "edi_storage")
         self._load_module_components(
             self, "document_quick_access_folder_auto_classification"
-        )
-        self.base_dir = os.path.join(self.env["ir.attachment"]._filestore(), "storage")
-        try:
-            os.mkdir(self.base_dir)
-            self.clean_base_dir = True
-        except FileExistsError:
-            # If the directory exists we respect it and do not clean it on teardown.
-            self.clean_base_dir = False
-        self.tmpdir = os.path.join(self.base_dir, str(uuid.uuid4()))
-        self.storage = self.env["storage.backend"].create(
-            {
-                "name": "Demo Storage",
-                "backend_type": "filesystem",
-                "directory_path": self.tmpdir,
-            }
         )
         self.backend = self.env["edi.backend"].create(
             {
@@ -61,21 +43,9 @@ class TestDocumentQuickAccessClassification(SavepointComponentRegistryCase):
                 "backend_type_id": self.env.ref(
                     "document_quick_access_folder_auto_classification.backend_type"
                 ).id,
-                "storage_id": self.storage.id,
-                "input_dir_pending": self.tmpdir,
             }
         )
-        if not os.path.isdir(self.base_dir):
-            os.mkdir(self.base_dir)
-        os.mkdir(self.tmpdir)
         self.model_id = self.env.ref("base.model_res_partner")
-
-    @classmethod
-    def tearDownClass(cls):
-        shutil.rmtree(cls.tmpdir)
-        if cls.clean_base_dir:
-            shutil.rmtree(cls.base_dir)
-        super().tearDownClass()
 
     def test_ok_pdf_multi(self):
         partners = self.env["res.partner"].create({"name": "Partner 1"})
@@ -103,8 +73,6 @@ class TestDocumentQuickAccessClassification(SavepointComponentRegistryCase):
                 "barcode_format": "standard",
             }
         )
-        with open(os.path.join(self.tmpdir, "test_file.pdf"), "wb") as f:
-            f.write(file)
         code = [
             Encoded(partner.get_quick_access_code().encode("utf-8"))
             for partner in partners
@@ -114,9 +82,14 @@ class TestDocumentQuickAccessClassification(SavepointComponentRegistryCase):
             "components.document_quick_access_process.decode"
         ) as ptch:
             ptch.return_value = code
-            self.assertFalse(self.exchange_model.search([]))
-            self.backend._storage_cron_check_pending_input()
-            self.assertEqual(self.exchange_model.search_count([]), 1)
+            self.backend.create_record(
+                "document_quick_access",
+                {
+                    "exchange_filename": "test_file.pdf",
+                    "exchange_file": base64.b64encode(file),
+                    "edi_exchange_state": "input_received",
+                },
+            )
             self.backend._cron_check_input_exchange_sync()
             self.assertEqual(ptch.call_count, 1)
         self.assertTrue(partners)
@@ -135,11 +108,14 @@ class TestDocumentQuickAccessClassification(SavepointComponentRegistryCase):
             mode="rb",
             subdir="addons/document_quick_access_folder_auto_classification/" "tests",
         ).read()
-        with open(os.path.join(self.tmpdir, "test_file.pdf"), "wb") as f:
-            f.write(file)
-        self.assertFalse(self.exchange_model.search([]))
-        self.backend._storage_cron_check_pending_input()
-        self.assertEqual(self.exchange_model.search_count([]), 1)
+        self.backend.create_record(
+            "document_quick_access",
+            {
+                "exchange_filename": "test_file.pdf",
+                "exchange_file": base64.b64encode(file),
+                "edi_exchange_state": "input_received",
+            },
+        )
         self.backend._cron_check_input_exchange_sync()
         self.assertTrue(
             self.exchange_model.search(
@@ -189,16 +165,20 @@ class TestDocumentQuickAccessClassification(SavepointComponentRegistryCase):
             mode="rb",
             subdir="addons/document_quick_access_folder_auto_classification/" "tests",
         ).read()
-        with open(os.path.join(self.tmpdir, "test_file.pdf"), "wb") as f:
-            f.write(file)
         with self.assertRaises(TypeError):
             with patch(
                 "odoo.addons.document_quick_access_folder_auto_classification."
                 "components.document_quick_access_process.decode"
             ) as ptch:
                 ptch.return_value = 1
-                self.backend._storage_cron_check_pending_input()
-                self.assertEqual(self.exchange_model.search_count([]), 1)
+                self.backend.create_record(
+                    "document_quick_access",
+                    {
+                        "exchange_filename": "test_file.pdf",
+                        "exchange_file": base64.b64encode(file),
+                        "edi_exchange_state": "input_received",
+                    },
+                )
                 self.backend._cron_check_input_exchange_sync()
 
     @mute_logger("odoo.addons.queue_job.models.base")
@@ -209,10 +189,14 @@ class TestDocumentQuickAccessClassification(SavepointComponentRegistryCase):
             mode="rb",
             subdir="addons/document_quick_access_folder_auto_classification/" "tests",
         ).read()
-        with open(os.path.join(self.tmpdir, "test_file.pdf"), "wb") as f:
-            f.write(file)
-        self.backend._storage_cron_check_pending_input()
-        self.assertEqual(self.exchange_model.search_count([]), 1)
+        self.backend.create_record(
+            "document_quick_access",
+            {
+                "exchange_filename": "test_file.pdf",
+                "exchange_file": base64.b64encode(file),
+                "edi_exchange_state": "input_received",
+            },
+        )
         self.backend._cron_check_input_exchange_sync()
         missing = self.exchange_model.search(
             [
@@ -253,14 +237,17 @@ class TestDocumentQuickAccessClassification(SavepointComponentRegistryCase):
                 "barcode_format": "standard",
             }
         )
-        with open(os.path.join(self.tmpdir, "test_file.pdf"), "wb") as f:
-            f.write(file)
         code = [partner.get_quick_access_code() for partner in partners]
         with patch.object(cv2.QRCodeDetector, "detectAndDecodeMulti") as ptch:
             ptch.return_value = [True, code, [], []]
-            self.assertFalse(self.exchange_model.search([]))
-            self.backend._storage_cron_check_pending_input()
-            self.assertEqual(self.exchange_model.search_count([]), 1)
+            self.backend.create_record(
+                "document_quick_access",
+                {
+                    "exchange_filename": "test_file.pdf",
+                    "exchange_file": base64.b64encode(file),
+                    "edi_exchange_state": "input_received",
+                },
+            )
             self.backend._cron_check_input_exchange_sync()
             self.assertEqual(ptch.call_count, 1)
         self.assertTrue(partners)
@@ -279,14 +266,18 @@ class TestDocumentQuickAccessClassification(SavepointComponentRegistryCase):
             mode="rb",
             subdir="addons/document_quick_access_folder_auto_classification/" "tests",
         ).read()
-        with open(os.path.join(self.tmpdir, "test_file.pdf"), "wb") as f:
-            f.write(file[: int(len(file) / 2)])
         with mute_logger(
             "odoo.addons.document_quick_access_folder_auto_classification."
             "components.document_quick_access_process",
         ):
-            self.backend._storage_cron_check_pending_input()
-            self.assertEqual(self.exchange_model.search_count([]), 1)
+            self.backend.create_record(
+                "document_quick_access",
+                {
+                    "exchange_filename": "test_file.pdf",
+                    "exchange_file": base64.b64encode(file[: int(len(file) / 2)]),
+                    "edi_exchange_state": "input_received",
+                },
+            )
             self.backend._cron_check_input_exchange_sync()
         self.assertTrue(
             self.exchange_model.search(


### PR DESCRIPTION
The dependancy was only necessary for testing purpose, but it is really not needed