### PR TITLE
[FIX] [16.0] base_tier_validation: Group to bypass Validation rules

### DIFF
--- a/base_tier_validation/README.rst
+++ b/base_tier_validation/README.rst
@@ -78,6 +78,9 @@ To configure Tier Validation Exceptions, you need to:
 * If check *Write after Validation*, records will be able to be modified only in the defined fields when the Validation process is finished.
 * If check *Write after Validation* and *Write under Validation*, records will be able to be modified defined fields always.
 
+
+You can allow certain users to bypass Validations rules by adding them to the *Skip All Tier Validations* group.
+
 Known issues / Roadmap
 ======================
 

--- a/base_tier_validation/i18n/base_tier_validation.pot
+++ b/base_tier_validation/i18n/base_tier_validation.pot
@@ -6,6 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 16.0\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-07-04 08:23+0000\n"
+"PO-Revision-Date: 2024-07-04 08:23+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -22,28 +24,24 @@ msgstr ""
 
 #. module: base_tier_validation
 #: model_terms:ir.ui.view,arch_db:base_tier_validation.tier_validation_label
-msgid ""
-"<i class=\"fa fa-info-circle\"/>\n"
-"                This Record needs to be\n"
-"                validated."
+msgid "<i class=\"fa fa-info-circle\"/> This Record needs to be validated."
 msgstr ""
 
 #. module: base_tier_validation
 #: model_terms:ir.ui.view,arch_db:base_tier_validation.tier_validation_label
 msgid ""
-"<i class=\"fa fa-thumbs-down\"/>\n"
-"                Operation has been\n"
-"                <b>rejected</b>\n"
-"                ."
+"<i class=\"fa fa-info-circle\"/> This record has under Validation "
+"restrictions, but you have permission to modify it."
 msgstr ""
 
 #. module: base_tier_validation
 #: model_terms:ir.ui.view,arch_db:base_tier_validation.tier_validation_label
-msgid ""
-"<i class=\"fa fa-thumbs-up\"/>\n"
-"                Operation has been\n"
-"                <b>validated</b>\n"
-"                !"
+msgid "<i class=\"fa fa-thumbs-down\"/> Operation has been <b>rejected</b>."
+msgstr ""
+
+#. module: base_tier_validation
+#: model_terms:ir.ui.view,arch_db:base_tier_validation.tier_validation_label
+msgid "<i class=\"fa fa-thumbs-up\"/> Operation has been <b>validated</b>!"
 msgstr ""
 
 #. module: base_tier_validation
@@ -121,6 +119,11 @@ msgid "All"
 msgstr ""
 
 #. module: base_tier_validation
+#: model:ir.model.fields,help:base_tier_validation.field_tier_validation__user_can_skip_validation
+msgid "Allow user to skip validation process and allows to edit the record."
+msgstr ""
+
+#. module: base_tier_validation
 #: model:ir.model.fields.selection,name:base_tier_validation.selection__tier_definition__review_type__group
 msgid "Any user in a specific group"
 msgstr ""
@@ -193,8 +196,8 @@ msgid "Cancel"
 msgstr ""
 
 #. module: base_tier_validation
-#. odoo-python
 #. odoo-javascript
+#. odoo-python
 #: code:addons/base_tier_validation/models/tier_validation.py:0
 #: code:addons/base_tier_validation/static/src/xml/tier_review_template.xml:0
 #: model:ir.model.fields,field_description:base_tier_validation.field_comment_wizard__comment
@@ -607,9 +610,13 @@ msgstr ""
 #. odoo-javascript
 #: code:addons/base_tier_validation/static/src/xml/tier_review_template.xml:0
 #: model:ir.model.fields,field_description:base_tier_validation.field_tier_definition__sequence
-#: model:ir.model.fields,field_description:base_tier_validation.field_tier_review__sequence
 #, python-format
 msgid "Sequence"
+msgstr ""
+
+#. module: base_tier_validation
+#: model:res.groups,name:base_tier_validation.skip_all_validations_group
+msgid "Skip All Tier Validations"
 msgstr ""
 
 #. module: base_tier_validation
@@ -663,6 +670,11 @@ msgstr ""
 msgid ""
 "This action needs to be validated for at least one record. \n"
 "Please request a validation."
+msgstr ""
+
+#. module: base_tier_validation
+#: model:ir.model.fields,field_description:base_tier_validation.field_tier_review__sequence
+msgid "Tier"
 msgstr ""
 
 #. module: base_tier_validation
@@ -755,6 +767,11 @@ msgstr ""
 #. module: base_tier_validation
 #: model:ir.model,name:base_tier_validation.model_res_users
 msgid "User"
+msgstr ""
+
+#. module: base_tier_validation
+#: model:ir.model.fields,field_description:base_tier_validation.field_tier_validation__user_can_skip_validation
+msgid "User can skip validation"
 msgstr ""
 
 #. module: base_tier_validation

--- a/base_tier_validation/i18n/es.po
+++ b/base_tier_validation/i18n/es.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 16.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-06-27 08:13+0000\n"
-"PO-Revision-Date: 2024-06-27 10:19+0200\n"
+"POT-Creation-Date: 2024-07-04 08:23+0000\n"
+"PO-Revision-Date: 2024-07-04 10:26+0200\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "Language: es\n"
@@ -26,10 +26,7 @@ msgstr "0 Pendientes"
 
 #. module: base_tier_validation
 #: model_terms:ir.ui.view,arch_db:base_tier_validation.tier_validation_label
-msgid ""
-"<i class=\"fa fa-info-circle\"/>\n"
-"                This Record needs to be\n"
-"                validated."
+msgid "<i class=\"fa fa-info-circle\"/> This Record needs to be validated."
 msgstr ""
 "<i class=\"fa fa-info-circle\"/>\n"
 "                Este registro debe ser\n"
@@ -38,10 +35,15 @@ msgstr ""
 #. module: base_tier_validation
 #: model_terms:ir.ui.view,arch_db:base_tier_validation.tier_validation_label
 msgid ""
-"<i class=\"fa fa-thumbs-down\"/>\n"
-"                Operation has been\n"
-"                <b>rejected</b>\n"
-"                ."
+"<i class=\"fa fa-info-circle\"/> This record has under Validation restrictions, but you have "
+"permission to modify it."
+msgstr ""
+"<i class=\"fa fa-info-circle\"/>\n"
+"                This record has Validation restrictions, but you have permission to modify it."
+
+#. module: base_tier_validation
+#: model_terms:ir.ui.view,arch_db:base_tier_validation.tier_validation_label
+msgid "<i class=\"fa fa-thumbs-down\"/> Operation has been <b>rejected</b>."
 msgstr ""
 "<i class=\"fa fa-thumbs-down\"/>\n"
 "                La operación ha sido\n"
@@ -50,11 +52,7 @@ msgstr ""
 
 #. module: base_tier_validation
 #: model_terms:ir.ui.view,arch_db:base_tier_validation.tier_validation_label
-msgid ""
-"<i class=\"fa fa-thumbs-up\"/>\n"
-"                Operation has been\n"
-"                <b>validated</b>\n"
-"                !"
+msgid "<i class=\"fa fa-thumbs-up\"/> Operation has been <b>validated</b>!"
 msgstr ""
 "<i class=\"fa fa-thumbs-up\"/>\n"
 "                La operación ha sido\n"
@@ -74,8 +72,7 @@ msgstr "<span class=\"oe_edit_only\">Nombre</span>"
 #. module: base_tier_validation
 #: model_terms:ir.ui.view,arch_db:base_tier_validation.tier_definition_view_form
 msgid "<span>Bypassed, if previous tier was validated by same reviewer</span>"
-msgstr ""
-"<span>Omitido, si el nivel anterior fue validado por el mismo revisor</span>"
+msgstr "<span>Omitido, si el nivel anterior fue validado por el mismo revisor</span>"
 
 #. module: base_tier_validation
 #. odoo-python
@@ -137,6 +134,11 @@ msgid "All"
 msgstr "Todos"
 
 #. module: base_tier_validation
+#: model:ir.model.fields,help:base_tier_validation.field_tier_validation__user_can_skip_validation
+msgid "Allow user to skip validation process and allows to edit the record."
+msgstr "Permite al usuario saltarse el proceso de validación y editar el registro."
+
+#. module: base_tier_validation
 #: model:ir.model.fields.selection,name:base_tier_validation.selection__tier_definition__review_type__group
 msgid "Any user in a specific group"
 msgstr "Cualquier usuario de un grupo específico"
@@ -179,19 +181,16 @@ msgstr "Archivado"
 #: code:addons/base_tier_validation/models/tier_validation_exception.py:0
 #, python-format
 msgid ""
-"At least one of these fields must be checked! Write under Validation, Write "
-"after Validation"
+"At least one of these fields must be checked! Write under Validation, Write after Validation"
 msgstr ""
-"¡Al menos uno de estos campos debe estar marcado! Escribir en Validación, "
-"Escribir después de Validación"
+"¡Al menos uno de estos campos debe estar marcado! Escribir en Validación, Escribir después de "
+"Validación"
 
 #. module: base_tier_validation
 #: model:ir.model.fields,help:base_tier_validation.field_tier_definition__approve_sequence_bypass
 #: model:ir.model.fields,help:base_tier_validation.field_tier_review__approve_sequence_bypass
-msgid ""
-"Bypassed (auto validated), if previous tier was validated by same reviewer"
-msgstr ""
-"Omitido (validado automático), si el mismo revisor validó el nivel anterior"
+msgid "Bypassed (auto validated), if previous tier was validated by same reviewer"
+msgstr "Omitido (validado automático), si el mismo revisor validó el nivel anterior"
 
 #. module: base_tier_validation
 #: model:ir.model.fields,field_description:base_tier_validation.field_tier_review__can_review
@@ -214,8 +213,8 @@ msgid "Cancel"
 msgstr "Cancelar"
 
 #. module: base_tier_validation
-#. odoo-python
 #. odoo-javascript
+#. odoo-python
 #: code:addons/base_tier_validation/models/tier_validation.py:0
 #: code:addons/base_tier_validation/static/src/xml/tier_review_template.xml:0
 #: model:ir.model.fields,field_description:base_tier_validation.field_comment_wizard__comment
@@ -358,38 +357,37 @@ msgstr ""
 #. module: base_tier_validation
 #: model:ir.model.fields,help:base_tier_validation.field_tier_definition__notify_on_create
 msgid ""
-"If set, all possible reviewers will be notified by email when this "
-"definition is triggered."
+"If set, all possible reviewers will be notified by email when this definition is triggered."
 msgstr ""
-"Si se establece, todos los posibles revisores serán notificados por correo "
-"electrónico cuando se active esta definición."
+"Si se establece, todos los posibles revisores serán notificados por correo electrónico cuando "
+"se active esta definición."
 
 #. module: base_tier_validation
 #: model:ir.model.fields,help:base_tier_validation.field_tier_definition__notify_on_accepted
 msgid ""
-"If set, reviewers will be notified by email when a review related to this "
-"definition is accepted."
+"If set, reviewers will be notified by email when a review related to this definition is "
+"accepted."
 msgstr ""
-"Si está establecido, los revisores serán notificados por email cuando una "
-"revisión relativa a ésta definición es aceptada."
+"Si está establecido, los revisores serán notificados por email cuando una revisión relativa a "
+"ésta definición es aceptada."
 
 #. module: base_tier_validation
 #: model:ir.model.fields,help:base_tier_validation.field_tier_definition__notify_on_rejected
 msgid ""
-"If set, reviewers will be notified by email when a review related to this "
-"definition is rejected."
+"If set, reviewers will be notified by email when a review related to this definition is "
+"rejected."
 msgstr ""
-"Si está establecido, los revisores serán notificados por email cuando una "
-"revisión relativa a ésta definición es rechazada."
+"Si está establecido, los revisores serán notificados por email cuando una revisión relativa a "
+"ésta definición es rechazada."
 
 #. module: base_tier_validation
 #: model:ir.model.fields,help:base_tier_validation.field_tier_definition__notify_on_restarted
 msgid ""
-"If set, reviewers will be notified by email when a reviews related to this "
-"definition are restarted."
+"If set, reviewers will be notified by email when a reviews related to this definition are "
+"restarted."
 msgstr ""
-"Si está establecido, los revisores serán notificados por email cuando una "
-"revisión relativa a ésta definición se ha reiniciado."
+"Si está establecido, los revisores serán notificados por email cuando una revisión relativa a "
+"ésta definición se ha reiniciado."
 
 #. module: base_tier_validation
 #: model_terms:ir.actions.act_window,help:base_tier_validation.tier_validation_exception_action
@@ -491,12 +489,8 @@ msgstr "Notificar revisores cuando se Reinicia"
 
 #. module: base_tier_validation
 #: model_terms:ir.actions.act_window,help:base_tier_validation.tier_validation_exception_action
-msgid ""
-"Once created, you can decide which fields you want to be editable when the "
-"record:"
-msgstr ""
-"Una vez creada, puedes decidir qué campos quieres que sean editables en el "
-"registro:"
+msgid "Once created, you can decide which fields you want to be editable when the record:"
+msgstr "Una vez creada, puedes decidir qué campos quieres que sean editables en el registro:"
 
 #. module: base_tier_validation
 #. odoo-python
@@ -515,15 +509,12 @@ msgstr "¡La operación ha sido <b>validada</b>!"
 #. module: base_tier_validation
 #: model_terms:ir.ui.view,arch_db:base_tier_validation.res_config_settings_view_form_budget
 msgid "Option to forward a tier validation to other reviewer, and backward"
-msgstr ""
-"Opción de reenviar una validación de nivel a otro revisor, y hacia atrás"
+msgstr "Opción de reenviar una validación de nivel a otro revisor, y hacia atrás"
 
 #. module: base_tier_validation
 #: model_terms:ir.ui.view,arch_db:base_tier_validation.res_config_settings_view_form_budget
 msgid "Option to use python formula to get reviewers and find documents"
-msgstr ""
-"Opción de utilizar una fórmula python para obtener revisores y encontrar "
-"documentos"
+msgstr "Opción de utilizar una fórmula python para obtener revisores y encontrar documentos"
 
 #. module: base_tier_validation
 #. odoo-javascript
@@ -640,10 +631,14 @@ msgstr "Revisiones"
 #. odoo-javascript
 #: code:addons/base_tier_validation/static/src/xml/tier_review_template.xml:0
 #: model:ir.model.fields,field_description:base_tier_validation.field_tier_definition__sequence
-#: model:ir.model.fields,field_description:base_tier_validation.field_tier_review__sequence
 #, python-format
 msgid "Sequence"
 msgstr "Secuencia"
+
+#. module: base_tier_validation
+#: model:res.groups,name:base_tier_validation.skip_all_validations_group
+msgid "Skip All Tier Validations"
+msgstr "Evitar todos los Niveles de Validación"
 
 #. module: base_tier_validation
 #: model:ir.model.fields.selection,name:base_tier_validation.selection__tier_definition__review_type__individual
@@ -663,12 +658,9 @@ msgstr "Estado"
 #: code:addons/base_tier_validation/models/tier_validation_exception.py:0
 #: model:ir.model.constraint,message:base_tier_validation.constraint_tier_validation_exception_model_company_under_after_unique
 #, python-format
-msgid ""
-"The model already exists for this company with this Write Validation "
-"configuration!"
+msgid "The model already exists for this company with this Write Validation configuration!"
 msgstr ""
-"¡El modelo ya existe para la misma compañía con esta configuración de "
-"Escritura de Validación!"
+"¡El modelo ya existe para la misma compañía con esta configuración de Escritura de Validación!"
 
 #. module: base_tier_validation
 #. odoo-python
@@ -701,6 +693,11 @@ msgid ""
 msgstr ""
 "Esta acción necesita ser validada para algún registro.\n"
 "Por favor, solicita una validación."
+
+#. module: base_tier_validation
+#: model:ir.model.fields,field_description:base_tier_validation.field_tier_review__sequence
+msgid "Tier"
+msgstr "Secuencia"
 
 #. module: base_tier_validation
 #: model:ir.actions.act_window,name:base_tier_validation.tier_definition_action
@@ -793,6 +790,11 @@ msgstr "Para hacer por"
 #: model:ir.model,name:base_tier_validation.model_res_users
 msgid "User"
 msgstr "Usuario"
+
+#. module: base_tier_validation
+#: model:ir.model.fields,field_description:base_tier_validation.field_tier_validation__user_can_skip_validation
+msgid "User can skip validation"
+msgstr "El usuario puede evitar validaciones"
 
 #. module: base_tier_validation
 #: model:ir.model.fields,field_description:base_tier_validation.field_tier_validation_exception__valid_model_field_ids
@@ -917,6 +919,3 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:base_tier_validation.tier_definition_view_form
 msgid "e.g. Tier Validation for..."
 msgstr "ej. Validación de Nivel por..."
-
-#~ msgid "Tier"
-#~ msgstr "Secuencia"

--- a/base_tier_validation/readme/CONFIGURE.rst
+++ b/base_tier_validation/readme/CONFIGURE.rst
@@ -25,3 +25,6 @@ To configure Tier Validation Exceptions, you need to:
 * If check *Write under Validation*, records will be able to be modified only in the defined fields when the Validation process is ongoing.
 * If check *Write after Validation*, records will be able to be modified only in the defined fields when the Validation process is finished.
 * If check *Write after Validation* and *Write under Validation*, records will be able to be modified defined fields always.
+
+
+You can allow certain users to bypass Validations rules by adding them to the *Skip All Tier Validations* group.

--- a/base_tier_validation/security/tier_validation_security.xml
+++ b/base_tier_validation/security/tier_validation_security.xml
@@ -16,4 +16,9 @@
             ['|',('company_id','=',False),('company_id', 'in', company_ids)]
         </field>
     </record>
+    <!-- Allows the user to skip all Tier Validations -->
+    <record id="skip_all_validations_group" model="res.groups">
+        <field name="name">Skip All Tier Validations</field>
+        <field name="category_id" ref="base.module_category_hidden" />
+    </record>
 </odoo>

--- a/base_tier_validation/static/description/index.html
+++ b/base_tier_validation/static/description/index.html
@@ -8,10 +8,11 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
+:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
+Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -274,7 +275,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: grey; } /* line numbers */
+pre.code .ln { color: gray; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -300,7 +301,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic {
+span.problematic, pre.problematic {
   color: red }
 
 span.section-subtitle {
@@ -439,6 +440,7 @@ having tier validation functionality.</li>
 <li>If check <em>Write after Validation</em>, records will be able to be modified only in the defined fields when the Validation process is finished.</li>
 <li>If check <em>Write after Validation</em> and <em>Write under Validation</em>, records will be able to be modified defined fields always.</li>
 </ul>
+<p>You can allow certain users to bypass Validations rules by adding them to the <em>Skip All Tier Validations</em> group.</p>
 </div>
 <div class="section" id="known-issues-roadmap">
 <h1><a class="toc-backref" href="#toc-entry-2">Known issues / Roadmap</a></h1>
@@ -585,7 +587,9 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-22">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
+<a class="reference external image-reference" href="https://odoo-community.org">
+<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
+</a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>

--- a/base_tier_validation/templates/tier_validation_templates.xml
+++ b/base_tier_validation/templates/tier_validation_templates.xml
@@ -79,6 +79,16 @@
                 .
             </p>
         </div>
+        <div
+                class="alert alert-info mb-0 pb-1 px-4"
+                role="alert"
+                t-attf-attrs="{'invisible': ['|', ('review_ids', '=', []), ('user_can_skip_validation', '=', False)]}"
+            >
+            <p>
+                <i class="fa fa-info-circle" />
+                This record has Validation restrictions, but you have permission to modify it.
+            </p>
+        </div>
         </div>
     </template>
     <template id="tier_validation_reviews">

--- a/base_tier_validation/templates/tier_validation_templates.xml
+++ b/base_tier_validation/templates/tier_validation_templates.xml
@@ -5,90 +5,95 @@
             <button
                 name="request_validation"
                 string="Request Validation"
-                t-attf-attrs="{'invisible': ['|','|',('need_validation', '!=', True),('rejected','=',True),('#{state_field}', '#{state_operator}', #{state_value})]}"
+                t-attf-attrs="{'invisible': ['|', '|',
+                ('need_validation', '!=', True),
+                ('rejected','=',True),('#{state_field}', '#{state_operator}', #{state_value})]}"
                 type="object"
             />
             <button
                 name="restart_validation"
                 string="Restart Validation"
-                t-attf-attrs="{'invisible': ['|',('review_ids', '=', []),('#{state_field}', '#{state_operator}', #{state_value})]}"
+                t-attf-attrs="{'invisible': ['|',
+                ('review_ids', '=', []),
+                ('#{state_field}', '#{state_operator}', #{state_value})]}"
                 type="object"
             />
         </div>
     </template>
     <template id="tier_validation_label">
         <div>
-        <field name="need_validation" invisible="1" />
-        <field name="validated" invisible="1" />
-        <field name="rejected" invisible="1" />
-        <div
-                class="alert alert-warning"
+            <field name="need_validation" invisible="1" />
+            <field name="validated" invisible="1" />
+            <field name="rejected" invisible="1" />
+            <field name="user_can_skip_validation" invisible="1" />
+            <div
+                class="alert alert-warning mb-0 pb-1 px-4"
                 role="alert"
                 t-attf-attrs="{'invisible': ['|', '|', '|',
-             ('validated', '=', True), ('#{state_field}', '#{state_operator}', #{state_value}),
-             ('rejected', '=', True), ('review_ids', '=', [])]}"
-                style="margin-bottom:0px;"
+                ('validated', '=', True),
+                ('#{state_field}', '#{state_operator}', #{state_value}),
+                ('rejected', '=', True),
+                ('review_ids', '=', [])]}"
             >
-            <p>
-                <i class="fa fa-info-circle" />
-                This Record needs to be
-                validated.
-                <field name="can_review" invisible="1" />
-                <button
+                <p>
+                    <i class="fa fa-info-circle" /> This Record needs to be validated.
+                    <field name="can_review" invisible="1" />
+                    <button
                         name="validate_tier"
                         string="Validate"
                         attrs="{'invisible': [('can_review', '=', False)]}"
                         type="object"
-                        class="oe_inline oe_button btn-success"
+                        class="btn-sm btn-success mx-1"
                         icon="fa-thumbs-up"
                     />
-                <button
+                    <button
                         name="reject_tier"
                         string="Reject"
                         attrs="{'invisible': [('can_review', '=', False)]}"
                         type="object"
-                        class="btn-icon btn-danger"
+                        class="btn-sm btn-danger mx-1"
                         icon="fa-thumbs-down"
                     />
-                <br /><field name="next_review" readonly="1" />
-            </p>
-        </div>
-        <div
-                class="alert alert-success"
+                    <field name="next_review" readonly="1" class="float-end pt-1" />
+                </p>
+            </div>
+            <div
+                class="alert alert-success mb-0 pb-1 px-4"
                 role="alert"
-                t-attf-attrs="{'invisible': ['|', '|', ('validated', '!=', True), ('#{state_field}', '#{state_operator}', #{state_value}), ('review_ids', '=', [])]}"
-                style="margin-bottom:0px;"
+                t-attf-attrs="{'invisible': ['|', '|',
+                ('validated', '!=', True),
+                ('#{state_field}', '#{state_operator}', #{state_value}),
+                ('review_ids', '=', [])]}"
             >
-            <p>
-                <i class="fa fa-thumbs-up" />
-                Operation has been
-                <b>validated</b>
-                !
-            </p>
-        </div>
-        <div
-                class="alert alert-danger"
+                <p>
+                    <i class="fa fa-thumbs-up" /> Operation has been <b>validated</b>!
+                </p>
+            </div>
+            <div
+                class="alert alert-danger mb-0 pb-1 px-4"
                 role="alert"
-                t-attf-attrs="{'invisible': ['|', '|', ('rejected', '!=', True), ('#{state_field}', '#{state_operator}', #{state_value}), ('review_ids', '=', [])]}"
-                style="margin-bottom:0px;"
+                t-attf-attrs="{'invisible': ['|', '|',
+                ('rejected', '!=', True),
+                ('#{state_field}', '#{state_operator}', #{state_value}),
+                ('review_ids', '=', [])]}"
             >
-            <p>
-                <i class="fa fa-thumbs-down" />
-                Operation has been
-                <b>rejected</b>
-                .
-            </p>
-        </div>
-        <div
+                <p>
+                    <i class="fa fa-thumbs-down" /> Operation has been <b>rejected</b>.
+                </p>
+            </div>
+            <div
                 class="alert alert-info mb-0 pb-1 px-4"
                 role="alert"
-                t-attf-attrs="{'invisible': ['|', ('review_ids', '=', []), ('user_can_skip_validation', '=', False)]}"
+                t-attf-attrs="{'invisible': ['|',
+                ('review_ids', '=', []),
+                ('user_can_skip_validation', '=', False)]}"
             >
-            <p>
-                <i class="fa fa-info-circle" />
-                This record has Validation restrictions, but you have permission to modify it.
-            </p>
-        </div>
+                <p>
+                    <i
+                        class="fa fa-info-circle"
+                    /> This record has under Validation restrictions, but you have permission to modify it.
+                </p>
+            </div>
         </div>
     </template>
     <template id="tier_validation_reviews">
@@ -98,19 +103,19 @@
             attrs="{'invisible':[('review_ids', '=', [])]}"
             style="width:100%%; margin-top: 10px;"
         >
-        <tree>
-            <field name="id" />
-            <field name="name" />
-            <field name="sequence" />
-            <field name="requested_by" />
-            <field name="status" />
-            <field name="display_status" />
-            <field name="todo_by" />
-            <field name="done_by" />
-            <field name="reviewed_date" />
-            <field name="reviewed_formated_date" />
-            <field name="comment" />
-        </tree>
-            </field>
+            <tree>
+                <field name="id" />
+                <field name="name" />
+                <field name="sequence" />
+                <field name="requested_by" />
+                <field name="status" />
+                <field name="display_status" />
+                <field name="todo_by" />
+                <field name="done_by" />
+                <field name="reviewed_date" />
+                <field name="reviewed_formated_date" />
+                <field name="comment" />
+            </tree>
+        </field>
     </template>
 </odoo>


### PR DESCRIPTION
A security group has been added to allow skipping all validations and allowing you to edit records freely.

In submodules, security groups can be added to skip only validations that belong to a specific model or group.

PR Series:

- https://github.com/OCA/server-ux/pull/913 (This one)
- https://github.com/OCA/sale-workflow/pull/3222 (Group for sale)

MT-6238 @moduon @rafaelbn @Gelojr @yajo @fcvalgar @LoisRForgeFlow please reivew if you want :)