### PR TITLE
[FIX] [16.0] base_tier_validation: Tier Validation Exception Groups

### DIFF
--- a/base_tier_validation/README.rst
+++ b/base_tier_validation/README.rst
@@ -69,6 +69,7 @@ To configure Tier Validation Exceptions, you need to:
 #. Create as many tiers validation exceptions as you want for any model
    having tier validation functionality.
 #. Add desired fields to be checked in *Fields*.
+#. Add desired groups that can use this Exception in *Groups*.
 #. You must check *Write under Validation*, *Write after Validation* or both.
 
 **Note:**

--- a/base_tier_validation/i18n/base_tier_validation.pot
+++ b/base_tier_validation/i18n/base_tier_validation.pot
@@ -6,6 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 16.0\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-07-05 07:53+0000\n"
+"PO-Revision-Date: 2024-07-05 07:53+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -44,11 +46,6 @@ msgid ""
 "                Operation has been\n"
 "                <b>validated</b>\n"
 "                !"
-msgstr ""
-
-#. module: base_tier_validation
-#: model_terms:ir.ui.view,arch_db:base_tier_validation.tier_validation_exception_form
-msgid "<span class=\"oe_edit_only\">Model</span>"
 msgstr ""
 
 #. module: base_tier_validation
@@ -118,6 +115,11 @@ msgstr ""
 #. module: base_tier_validation
 #: model_terms:ir.ui.view,arch_db:base_tier_validation.tier_definition_view_search
 msgid "All"
+msgstr ""
+
+#. module: base_tier_validation
+#: model:ir.model.fields,help:base_tier_validation.field_tier_validation_exception__group_ids
+msgid "Allowed groups to use this Tier Validation Exception"
 msgstr ""
 
 #. module: base_tier_validation
@@ -193,8 +195,8 @@ msgid "Cancel"
 msgstr ""
 
 #. module: base_tier_validation
-#. odoo-python
 #. odoo-javascript
+#. odoo-python
 #: code:addons/base_tier_validation/models/tier_validation.py:0
 #: code:addons/base_tier_validation/static/src/xml/tier_review_template.xml:0
 #: model:ir.model.fields,field_description:base_tier_validation.field_comment_wizard__comment
@@ -322,6 +324,11 @@ msgid "Group By"
 msgstr ""
 
 #. module: base_tier_validation
+#: model:ir.model.fields,field_description:base_tier_validation.field_tier_validation_exception__group_ids
+msgid "Groups"
+msgstr ""
+
+#. module: base_tier_validation
 #: model:ir.model.fields,field_description:base_tier_validation.field_tier_validation__has_comment
 msgid "Has Comment"
 msgstr ""
@@ -401,12 +408,18 @@ msgstr ""
 #: model:ir.model.fields,field_description:base_tier_validation.field_tier_validation_exception__model_id
 #: model:ir.model.fields,field_description:base_tier_validation.field_tier_validation_exception__model_name
 #: model_terms:ir.ui.view,arch_db:base_tier_validation.tier_definition_view_search
+#: model_terms:ir.ui.view,arch_db:base_tier_validation.tier_validation_exception_search
 msgid "Model"
 msgstr ""
 
 #. module: base_tier_validation
 #: model_terms:ir.ui.view,arch_db:base_tier_validation.tier_definition_view_form
 msgid "More Options"
+msgstr ""
+
+#. module: base_tier_validation
+#: model:ir.model.fields,field_description:base_tier_validation.field_tier_validation_exception__name
+msgid "Name"
 msgstr ""
 
 #. module: base_tier_validation
@@ -494,6 +507,7 @@ msgstr ""
 #. module: base_tier_validation
 #. odoo-javascript
 #: code:addons/base_tier_validation/static/src/xml/systray.xml:0
+#: model:ir.model.fields.selection,name:base_tier_validation.selection__sale_order__validation_status__pending
 #: model:ir.model.fields.selection,name:base_tier_validation.selection__tier_review__status__pending
 #: model:ir.model.fields.selection,name:base_tier_validation.selection__tier_validation__validation_status__pending
 #, python-format
@@ -512,6 +526,7 @@ msgstr ""
 
 #. module: base_tier_validation
 #: model:ir.model.fields,field_description:base_tier_validation.field_tier_validation__rejected
+#: model:ir.model.fields.selection,name:base_tier_validation.selection__sale_order__validation_status__rejected
 #: model:ir.model.fields.selection,name:base_tier_validation.selection__tier_review__status__rejected
 #: model:ir.model.fields.selection,name:base_tier_validation.selection__tier_validation__validation_status__rejected
 msgid "Rejected"
@@ -607,7 +622,6 @@ msgstr ""
 #. odoo-javascript
 #: code:addons/base_tier_validation/static/src/xml/tier_review_template.xml:0
 #: model:ir.model.fields,field_description:base_tier_validation.field_tier_definition__sequence
-#: model:ir.model.fields,field_description:base_tier_validation.field_tier_review__sequence
 #, python-format
 msgid "Sequence"
 msgstr ""
@@ -623,16 +637,6 @@ msgstr ""
 #: model:ir.model.fields,field_description:base_tier_validation.field_tier_review__status
 #, python-format
 msgid "Status"
-msgstr ""
-
-#. module: base_tier_validation
-#. odoo-python
-#: code:addons/base_tier_validation/models/tier_validation_exception.py:0
-#: model:ir.model.constraint,message:base_tier_validation.constraint_tier_validation_exception_model_company_under_after_unique
-#, python-format
-msgid ""
-"The model already exists for this company with this Write Validation "
-"configuration!"
 msgstr ""
 
 #. module: base_tier_validation
@@ -663,6 +667,11 @@ msgstr ""
 msgid ""
 "This action needs to be validated for at least one record. \n"
 "Please request a validation."
+msgstr ""
+
+#. module: base_tier_validation
+#: model:ir.model.fields,field_description:base_tier_validation.field_tier_review__sequence
+msgid "Tier"
 msgstr ""
 
 #. module: base_tier_validation
@@ -779,6 +788,7 @@ msgstr ""
 
 #. module: base_tier_validation
 #: model:ir.model.fields,field_description:base_tier_validation.field_tier_validation__validated
+#: model:ir.model.fields.selection,name:base_tier_validation.selection__sale_order__validation_status__validated
 #: model:ir.model.fields.selection,name:base_tier_validation.selection__tier_validation__validation_status__validated
 msgid "Validated"
 msgstr ""
@@ -818,6 +828,7 @@ msgid "Validations"
 msgstr ""
 
 #. module: base_tier_validation
+#: model:ir.model.fields.selection,name:base_tier_validation.selection__sale_order__validation_status__no
 #: model:ir.model.fields.selection,name:base_tier_validation.selection__tier_validation__validation_status__no
 msgid "Without validation"
 msgstr ""

--- a/base_tier_validation/i18n/es.po
+++ b/base_tier_validation/i18n/es.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 16.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-06-27 08:13+0000\n"
-"PO-Revision-Date: 2024-06-27 10:19+0200\n"
+"POT-Creation-Date: 2024-07-05 07:53+0000\n"
+"PO-Revision-Date: 2024-07-05 09:54+0200\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "Language: es\n"
@@ -60,11 +60,6 @@ msgstr ""
 "                La operación ha sido\n"
 "                <b>validada</b>\n"
 "                !"
-
-#. module: base_tier_validation
-#: model_terms:ir.ui.view,arch_db:base_tier_validation.tier_validation_exception_form
-msgid "<span class=\"oe_edit_only\">Model</span>"
-msgstr "<span class=\"oe_edit_only\">Modelo</span>"
 
 #. module: base_tier_validation
 #: model_terms:ir.ui.view,arch_db:base_tier_validation.tier_definition_view_form
@@ -135,6 +130,11 @@ msgstr "Actividades"
 #: model_terms:ir.ui.view,arch_db:base_tier_validation.tier_definition_view_search
 msgid "All"
 msgstr "Todos"
+
+#. module: base_tier_validation
+#: model:ir.model.fields,help:base_tier_validation.field_tier_validation_exception__group_ids
+msgid "Allowed groups to use this Tier Validation Exception"
+msgstr "Grupos permitidos para utilizar esta Excepción de Validación de Nivel"
 
 #. module: base_tier_validation
 #: model:ir.model.fields.selection,name:base_tier_validation.selection__tier_definition__review_type__group
@@ -214,8 +214,8 @@ msgid "Cancel"
 msgstr "Cancelar"
 
 #. module: base_tier_validation
-#. odoo-python
 #. odoo-javascript
+#. odoo-python
 #: code:addons/base_tier_validation/models/tier_validation.py:0
 #: code:addons/base_tier_validation/static/src/xml/tier_review_template.xml:0
 #: model:ir.model.fields,field_description:base_tier_validation.field_comment_wizard__comment
@@ -343,6 +343,11 @@ msgid "Group By"
 msgstr "Agrupar por"
 
 #. module: base_tier_validation
+#: model:ir.model.fields,field_description:base_tier_validation.field_tier_validation_exception__group_ids
+msgid "Groups"
+msgstr "Grupos"
+
+#. module: base_tier_validation
 #: model:ir.model.fields,field_description:base_tier_validation.field_tier_validation__has_comment
 msgid "Has Comment"
 msgstr "Ha comentado"
@@ -430,6 +435,7 @@ msgstr "Última actualización en"
 #: model:ir.model.fields,field_description:base_tier_validation.field_tier_validation_exception__model_id
 #: model:ir.model.fields,field_description:base_tier_validation.field_tier_validation_exception__model_name
 #: model_terms:ir.ui.view,arch_db:base_tier_validation.tier_definition_view_search
+#: model_terms:ir.ui.view,arch_db:base_tier_validation.tier_validation_exception_search
 msgid "Model"
 msgstr "Modelo"
 
@@ -437,6 +443,11 @@ msgstr "Modelo"
 #: model_terms:ir.ui.view,arch_db:base_tier_validation.tier_definition_view_form
 msgid "More Options"
 msgstr "Más opciones"
+
+#. module: base_tier_validation
+#: model:ir.model.fields,field_description:base_tier_validation.field_tier_validation_exception__name
+msgid "Name"
+msgstr "Nombre"
 
 #. module: base_tier_validation
 #: model:ir.model.fields,field_description:base_tier_validation.field_tier_validation__need_validation
@@ -528,6 +539,7 @@ msgstr ""
 #. module: base_tier_validation
 #. odoo-javascript
 #: code:addons/base_tier_validation/static/src/xml/systray.xml:0
+#: model:ir.model.fields.selection,name:base_tier_validation.selection__sale_order__validation_status__pending
 #: model:ir.model.fields.selection,name:base_tier_validation.selection__tier_review__status__pending
 #: model:ir.model.fields.selection,name:base_tier_validation.selection__tier_validation__validation_status__pending
 #, python-format
@@ -546,6 +558,7 @@ msgstr "Rechazar"
 
 #. module: base_tier_validation
 #: model:ir.model.fields,field_description:base_tier_validation.field_tier_validation__rejected
+#: model:ir.model.fields.selection,name:base_tier_validation.selection__sale_order__validation_status__rejected
 #: model:ir.model.fields.selection,name:base_tier_validation.selection__tier_review__status__rejected
 #: model:ir.model.fields.selection,name:base_tier_validation.selection__tier_validation__validation_status__rejected
 msgid "Rejected"
@@ -640,7 +653,6 @@ msgstr "Revisiones"
 #. odoo-javascript
 #: code:addons/base_tier_validation/static/src/xml/tier_review_template.xml:0
 #: model:ir.model.fields,field_description:base_tier_validation.field_tier_definition__sequence
-#: model:ir.model.fields,field_description:base_tier_validation.field_tier_review__sequence
 #, python-format
 msgid "Sequence"
 msgstr "Secuencia"
@@ -657,18 +669,6 @@ msgstr "Usuario específico"
 #, python-format
 msgid "Status"
 msgstr "Estado"
-
-#. module: base_tier_validation
-#. odoo-python
-#: code:addons/base_tier_validation/models/tier_validation_exception.py:0
-#: model:ir.model.constraint,message:base_tier_validation.constraint_tier_validation_exception_model_company_under_after_unique
-#, python-format
-msgid ""
-"The model already exists for this company with this Write Validation "
-"configuration!"
-msgstr ""
-"¡El modelo ya existe para la misma compañía con esta configuración de "
-"Escritura de Validación!"
 
 #. module: base_tier_validation
 #. odoo-python
@@ -701,6 +701,11 @@ msgid ""
 msgstr ""
 "Esta acción necesita ser validada para algún registro.\n"
 "Por favor, solicita una validación."
+
+#. module: base_tier_validation
+#: model:ir.model.fields,field_description:base_tier_validation.field_tier_review__sequence
+msgid "Tier"
+msgstr "Secuencia"
 
 #. module: base_tier_validation
 #: model:ir.actions.act_window,name:base_tier_validation.tier_definition_action
@@ -816,6 +821,7 @@ msgstr "Validar Rechazar"
 
 #. module: base_tier_validation
 #: model:ir.model.fields,field_description:base_tier_validation.field_tier_validation__validated
+#: model:ir.model.fields.selection,name:base_tier_validation.selection__sale_order__validation_status__validated
 #: model:ir.model.fields.selection,name:base_tier_validation.selection__tier_validation__validation_status__validated
 msgid "Validated"
 msgstr "Validado"
@@ -855,6 +861,7 @@ msgid "Validations"
 msgstr "Validaciones"
 
 #. module: base_tier_validation
+#: model:ir.model.fields.selection,name:base_tier_validation.selection__sale_order__validation_status__no
 #: model:ir.model.fields.selection,name:base_tier_validation.selection__tier_validation__validation_status__no
 msgid "Without validation"
 msgstr "Sin validación"
@@ -917,6 +924,3 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:base_tier_validation.tier_definition_view_form
 msgid "e.g. Tier Validation for..."
 msgstr "ej. Validación de Nivel por..."
-
-#~ msgid "Tier"
-#~ msgstr "Secuencia"

--- a/base_tier_validation/models/tier_validation.py
+++ b/base_tier_validation/models/tier_validation.py
@@ -246,18 +246,22 @@ class TierValidation(models.AbstractModel):
         """Return Tier Validation Exception field names that matchs custom domain."""
         exception_fields = (
             self.env["tier.validation.exception"]
+            .sudo()
             .search(
                 [
                     ("model_name", "=", self._name),
                     ("company_id", "in", [False] + self.env.company.ids),
+                    "|",
+                    ("group_ids", "in", self.env.user.groups_id.ids),
+                    ("group_ids", "=", False),
                     *(extra_domain or []),
                 ]
             )
             .mapped("field_ids.name")
         )
         if add_base_exceptions:
-            exception_fields = list(set(exception_fields + BASE_EXCEPTION_FIELDS))
-        return exception_fields
+            exception_fields += BASE_EXCEPTION_FIELDS
+        return list(set(exception_fields))
 
     @api.model
     def _get_all_validation_exceptions(self):

--- a/base_tier_validation/models/tier_validation_exception.py
+++ b/base_tier_validation/models/tier_validation_exception.py
@@ -9,12 +9,16 @@ from .tier_validation import BASE_EXCEPTION_FIELDS
 class TierValidationException(models.Model):
     _name = "tier.validation.exception"
     _description = "Tier Validation Exceptions"
-    _rec_name = "model_name"
+    _rec_name = "name"
 
     @api.model
     def _get_tier_validation_model_names(self):
         return self.env["tier.definition"]._get_tier_validation_model_names()
 
+    name = fields.Char(
+        required=True,
+        default="New Tier Validation Exception",
+    )
     model_id = fields.Many2one(
         comodel_name="ir.model",
         string="Model",
@@ -52,6 +56,11 @@ class TierValidationException(models.Model):
         string="Write after Validation",
         default=True,
     )
+    group_ids = fields.Many2many(
+        comodel_name="res.groups",
+        string="Groups",
+        help="Allowed groups to use this Tier Validation Exception",
+    )
 
     @api.depends("model_id")
     def _compute_valid_model_field_ids(self):
@@ -77,15 +86,3 @@ class TierValidationException(models.Model):
                     "Write under Validation, Write after Validation"
                 )
             )
-
-    _sql_constraints = [
-        (
-            "model_company_under_after_unique",
-            "unique(model_id, company_id, "
-            "allowed_to_write_under_validation, allowed_to_write_after_validation)",
-            _(
-                "The model already exists for this company with this "
-                "Write Validation configuration!"
-            ),
-        )
-    ]

--- a/base_tier_validation/readme/CONFIGURE.rst
+++ b/base_tier_validation/readme/CONFIGURE.rst
@@ -17,6 +17,7 @@ To configure Tier Validation Exceptions, you need to:
 #. Create as many tiers validation exceptions as you want for any model
    having tier validation functionality.
 #. Add desired fields to be checked in *Fields*.
+#. Add desired groups that can use this Exception in *Groups*.
 #. You must check *Write under Validation*, *Write after Validation* or both.
 
 **Note:**

--- a/base_tier_validation/static/description/index.html
+++ b/base_tier_validation/static/description/index.html
@@ -8,10 +8,11 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
+:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
+Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -274,7 +275,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: grey; } /* line numbers */
+pre.code .ln { color: gray; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -300,7 +301,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic {
+span.problematic, pre.problematic {
   color: red }
 
 span.section-subtitle {
@@ -430,6 +431,7 @@ functionality.</li>
 <li>Create as many tiers validation exceptions as you want for any model
 having tier validation functionality.</li>
 <li>Add desired fields to be checked in <em>Fields</em>.</li>
+<li>Add desired groups that can use this Exception in <em>Groups</em>.</li>
 <li>You must check <em>Write under Validation</em>, <em>Write after Validation</em> or both.</li>
 </ol>
 <p><strong>Note:</strong></p>
@@ -585,7 +587,9 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-22">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
+<a class="reference external image-reference" href="https://odoo-community.org">
+<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
+</a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>

--- a/base_tier_validation/templates/tier_validation_templates.xml
+++ b/base_tier_validation/templates/tier_validation_templates.xml
@@ -5,80 +5,81 @@
             <button
                 name="request_validation"
                 string="Request Validation"
-                t-attf-attrs="{'invisible': ['|','|',('need_validation', '!=', True),('rejected','=',True),('#{state_field}', '#{state_operator}', #{state_value})]}"
+                t-attf-attrs="{'invisible': ['|', '|',
+                ('need_validation', '!=', True),
+                ('rejected','=',True),('#{state_field}', '#{state_operator}', #{state_value})]}"
                 type="object"
             />
             <button
                 name="restart_validation"
                 string="Restart Validation"
-                t-attf-attrs="{'invisible': ['|',('review_ids', '=', []),('#{state_field}', '#{state_operator}', #{state_value})]}"
+                t-attf-attrs="{'invisible': ['|',
+                ('review_ids', '=', []),
+                ('#{state_field}', '#{state_operator}', #{state_value})]}"
                 type="object"
             />
         </div>
     </template>
     <template id="tier_validation_label">
         <div>
-        <field name="need_validation" invisible="1" />
-        <field name="validated" invisible="1" />
-        <field name="rejected" invisible="1" />
-        <div
-                class="alert alert-warning"
+            <field name="need_validation" invisible="1" />
+            <field name="validated" invisible="1" />
+            <field name="rejected" invisible="1" />
+            <div
+                class="alert alert-warning mb-0 pb-1 px-4"
                 role="alert"
                 t-attf-attrs="{'invisible': ['|', '|', '|',
-             ('validated', '=', True), ('#{state_field}', '#{state_operator}', #{state_value}),
-             ('rejected', '=', True), ('review_ids', '=', [])]}"
-                style="margin-bottom:0px;"
+                ('validated', '=', True),
+                ('#{state_field}', '#{state_operator}', #{state_value}),
+                ('rejected', '=', True),
+                ('review_ids', '=', [])]}"
             >
-            <p>
-                <i class="fa fa-info-circle" />
-                This Record needs to be
-                validated.
-                <field name="can_review" invisible="1" />
-                <button
+                <p>
+                    <i class="fa fa-info-circle" /> This Record needs to be validated.
+                    <field name="can_review" invisible="1" />
+                    <button
                         name="validate_tier"
                         string="Validate"
                         attrs="{'invisible': [('can_review', '=', False)]}"
                         type="object"
-                        class="oe_inline oe_button btn-success"
+                        class="btn-sm btn-success mx-1"
                         icon="fa-thumbs-up"
                     />
-                <button
+                    <button
                         name="reject_tier"
                         string="Reject"
                         attrs="{'invisible': [('can_review', '=', False)]}"
                         type="object"
-                        class="btn-icon btn-danger"
+                        class="btn-sm btn-danger mx-1"
                         icon="fa-thumbs-down"
                     />
-                <br /><field name="next_review" readonly="1" />
-            </p>
-        </div>
-        <div
-                class="alert alert-success"
+                    <field name="next_review" readonly="1" class="float-end pt-1" />
+                </p>
+            </div>
+            <div
+                class="alert alert-success mb-0 pb-1 px-4"
                 role="alert"
-                t-attf-attrs="{'invisible': ['|', '|', ('validated', '!=', True), ('#{state_field}', '#{state_operator}', #{state_value}), ('review_ids', '=', [])]}"
-                style="margin-bottom:0px;"
+                t-attf-attrs="{'invisible': ['|', '|',
+                ('validated', '!=', True),
+                ('#{state_field}', '#{state_operator}', #{state_value}),
+                ('review_ids', '=', [])]}"
             >
-            <p>
-                <i class="fa fa-thumbs-up" />
-                Operation has been
-                <b>validated</b>
-                !
-            </p>
-        </div>
-        <div
-                class="alert alert-danger"
+                <p>
+                    <i class="fa fa-thumbs-up" /> Operation has been <b>validated</b>!
+                </p>
+            </div>
+            <div
+                class="alert alert-danger mb-0 pb-1 px-4"
                 role="alert"
-                t-attf-attrs="{'invisible': ['|', '|', ('rejected', '!=', True), ('#{state_field}', '#{state_operator}', #{state_value}), ('review_ids', '=', [])]}"
-                style="margin-bottom:0px;"
+                t-attf-attrs="{'invisible': ['|', '|',
+                ('rejected', '!=', True),
+                ('#{state_field}', '#{state_operator}', #{state_value}),
+                ('review_ids', '=', [])]}"
             >
-            <p>
-                <i class="fa fa-thumbs-down" />
-                Operation has been
-                <b>rejected</b>
-                .
-            </p>
-        </div>
+                <p>
+                    <i class="fa fa-thumbs-down" /> Operation has been <b>rejected</b>.
+                </p>
+            </div>
         </div>
     </template>
     <template id="tier_validation_reviews">
@@ -88,19 +89,19 @@
             attrs="{'invisible':[('review_ids', '=', [])]}"
             style="width:100%%; margin-top: 10px;"
         >
-        <tree>
-            <field name="id" />
-            <field name="name" />
-            <field name="sequence" />
-            <field name="requested_by" />
-            <field name="status" />
-            <field name="display_status" />
-            <field name="todo_by" />
-            <field name="done_by" />
-            <field name="reviewed_date" />
-            <field name="reviewed_formated_date" />
-            <field name="comment" />
-        </tree>
-            </field>
+            <tree>
+                <field name="id" />
+                <field name="name" />
+                <field name="sequence" />
+                <field name="requested_by" />
+                <field name="status" />
+                <field name="display_status" />
+                <field name="todo_by" />
+                <field name="done_by" />
+                <field name="reviewed_date" />
+                <field name="reviewed_formated_date" />
+                <field name="comment" />
+            </tree>
+        </field>
     </template>
 </odoo>

--- a/base_tier_validation/views/tier_validation_exception_view.xml
+++ b/base_tier_validation/views/tier_validation_exception_view.xml
@@ -7,11 +7,13 @@
         <field name="model">tier.validation.exception</field>
         <field name="arch" type="xml">
             <tree>
+                <field name="name" />
                 <field name="model_id" />
                 <field name="field_ids" widget="many2many_tags" optional="show" />
                 <field name="company_id" groups="base.group_multi_company" />
                 <field name="allowed_to_write_under_validation" />
                 <field name="allowed_to_write_after_validation" />
+                <field name="group_ids" widget="many2many_tags" />
             </tree>
         </field>
     </record>
@@ -23,16 +25,17 @@
             <form string="Tier Validation Exception">
                 <sheet>
                     <div class="oe_title">
-                        <span class="oe_edit_only">Model</span>
+                        <label for="name" />
                         <h1>
-                            <field
-                                name="model_id"
-                                options="{'no_create': True, 'no_open': True}"
-                            />
+                            <field name="name" nolabel="1" />
                         </h1>
                     </div>
                     <group>
                         <group name="left">
+                            <field
+                                name="model_id"
+                                options="{'no_create': True, 'no_open': True}"
+                            />
                             <field name="valid_model_field_ids" invisible="1" />
                             <field
                                 name="field_ids"
@@ -45,6 +48,7 @@
                             />
                         </group>
                         <group name="right">
+                            <field name="group_ids" widget="many2many_tags" />
                             <field name="allowed_to_write_under_validation" />
                             <field name="allowed_to_write_after_validation" />
                         </group>
@@ -59,9 +63,11 @@
         <field name="model">tier.validation.exception</field>
         <field name="arch" type="xml">
             <search>
+                <field name="name" />
                 <field name="model_id" />
                 <field name="field_ids" />
                 <field name="company_id" groups="base.group_multi_company" />
+                <field name="group_ids" />
                 <separator />
                 <filter
                     string="Write under validation"
@@ -74,6 +80,12 @@
                     domain="[('allowed_to_write_after_validation', '=', True)]"
                 />
                 <group>
+                    <filter
+                        string="Model"
+                        name="grp_model"
+                        domain="[]"
+                        context="{'group_by': 'model_id'}"
+                    />
                     <filter
                         string="Company"
                         name="grp_company"


### PR DESCRIPTION
Add groups to Tier Validation Exceptions.

This will allow to set some fields only to certain group of users.

This PR is a simplification of https://github.com/OCA/server-ux/pull/913 and https://github.com/OCA/sale-workflow/pull/3222

https://www.loom.com/share/543a78d46cef4323b30a56cc5ad7329f

MT-6238 @moduon @rafaelbn @yajo @LoisRForgeFlow please review if you want :)