### PR TITLE
[16.0][FIX] base_tier_validation, base_export_manager, add sudo call to models without explicit access

### DIFF
--- a/base_export_manager/models/ir_exports_line.py
+++ b/base_export_manager/models/ir_exports_line.py
@@ -61,7 +61,7 @@ class IrExportsLine(models.Model):
     @api.depends("field1_id")
     def _compute_model2_id(self):
         """Get the related model for the second field."""
-        IrModel = self.env["ir.model"]
+        IrModel = self.env["ir.model"].sudo()
         for one in self:
             one.model2_id = (
                 one.field1_id.ttype
@@ -72,7 +72,7 @@ class IrExportsLine(models.Model):
     @api.depends("field2_id")
     def _compute_model3_id(self):
         """Get the related model for the third field."""
-        IrModel = self.env["ir.model"]
+        IrModel = self.env["ir.model"].sudo()
         for one in self:
             one.model3_id = (
                 one.field2_id.ttype
@@ -83,7 +83,7 @@ class IrExportsLine(models.Model):
     @api.depends("field3_id")
     def _compute_model4_id(self):
         """Get the related model for the third field."""
-        IrModel = self.env["ir.model"]
+        IrModel = self.env["ir.model"].sudo()
         for one in self:
             one.model4_id = (
                 one.field3_id.ttype
@@ -177,8 +177,10 @@ class IrExportsLine(models.Model):
         :param str name:
             Technical name of the field, like ``child_ids``.
         """
-        field = self.env["ir.model.fields"].search(
-            [("name", "=", name), ("model_id", "=", model.id)]
+        field = (
+            self.env["ir.model.fields"]
+            .sudo()
+            .search([("name", "=", name), ("model_id", "=", model.id)])
         )
         if not field.exists():
             raise exceptions.ValidationError(

--- a/base_tier_validation/models/tier_definition.py
+++ b/base_tier_validation/models/tier_definition.py
@@ -100,6 +100,8 @@ class TierDefinition(models.Model):
     @api.depends("review_type", "model_id")
     def _compute_domain_reviewer_field(self):
         for rec in self:
-            rec.valid_reviewer_field_ids = self.env["ir.model.fields"].search(
-                [("model", "=", rec.model), ("relation", "=", "res.users")]
+            rec.valid_reviewer_field_ids = (
+                self.env["ir.model.fields"]
+                .sudo()
+                .search([("model", "=", rec.model), ("relation", "=", "res.users")])
             )

--- a/base_tier_validation/models/tier_validation_exception.py
+++ b/base_tier_validation/models/tier_validation_exception.py
@@ -56,11 +56,15 @@ class TierValidationException(models.Model):
     @api.depends("model_id")
     def _compute_valid_model_field_ids(self):
         for record in self:
-            record.valid_model_field_ids = self.env["ir.model.fields"].search(
-                [
-                    ("model", "=", record.model_name),
-                    ("name", "not in", BASE_EXCEPTION_FIELDS),
-                ]
+            record.valid_model_field_ids = (
+                self.env["ir.model.fields"]
+                .sudo()
+                .search(
+                    [
+                        ("model", "=", record.model_name),
+                        ("name", "not in", BASE_EXCEPTION_FIELDS),
+                    ]
+                )
             )
 
     @api.constrains(


### PR DESCRIPTION
This commit (https://github.com/odoo/odoo/commit/5dc4cff60a557e14b08440c227423291c407899b) explain why should be change access to this classes 

- ir.model
- ir.model.fields
- ir.model.data
- ir.model.fields.selection
- ir.ui.view