### PR TITLE
[FIX] DeprecationWarning: XML declarations in HTML module description…

### DIFF
--- a/base_technical_features/static/description/index.html
+++ b/base_technical_features/static/description/index.html
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>


### PR DESCRIPTION
…s are deprecated since Odoo 17, base_technical_features can just have a UTF8 description with not need for a declaration.