### PR TITLE
[17.0][IMP] base_tier_validation: Fix same label warning

### DIFF
--- a/base_tier_validation/models/tier_validation_exception.py
+++ b/base_tier_validation/models/tier_validation_exception.py
@@ -24,7 +24,7 @@ class TierValidationException(models.Model):
     )
     model_name = fields.Char(
         related="model_id.model",
-        string="Model",
+        string="Model Name",
         store=True,
         readonly=True,
         index=True,


### PR DESCRIPTION
Silence the warning: Two fields (model_name, model_id) of tier.validation.exception() have the same label: Model. [Modules: base_tier_validation and base_tier_validation]

![image](https://github.com/user-attachments/assets/6d32c883-c961-49ef-84e8-fc03896dcb9c)
