### PR TITLE
[16.0][IMP] base_tier_validation: Change _compute_need_validation()

### DIFF
--- a/base_tier_validation/templates/tier_validation_templates.xml
+++ b/base_tier_validation/templates/tier_validation_templates.xml
@@ -18,11 +18,18 @@
                 ('#{state_field}', '#{state_operator}', #{state_value})]}"
                 type="object"
             />
+            <button
+                name="reevaluate_reviews"
+                string="Reevaluate Reviews"
+                t-attf-attrs="{'invisible': ['|',('is_reevaluation_required', '!=', True),('#{state_field}', '#{state_operator}', #{state_value})]}"
+                type="object"
+            />
         </div>
     </template>
     <template id="tier_validation_label">
         <div>
             <field name="need_validation" invisible="1" />
+            <field name="is_reevaluation_required" invisible="1" />
             <field name="validated" invisible="1" />
             <field name="rejected" invisible="1" />
             <div


### PR DESCRIPTION
A document does not need validation only if there are no pending reviews, otherwise we should evaluate as True. We add a condition in request_validation to be able to request more than one time if there are new tier validations.