### PR TITLE
[16.0][IMP] announcement: Also show archived users.

### DIFF
--- a/announcement/models/announcement.py
+++ b/announcement/models/announcement.py
@@ -43,6 +43,7 @@ class Announcement(models.Model):
     )
     specific_user_ids = fields.Many2many(
         comodel_name="res.users",
+        context={"active_test": False},
         domain=[("share", "=", False)],
         inverse="_inverse_specific_user_ids",
     )


### PR DESCRIPTION
Also show archived users.

Example of use case:
- Create an announcement to a user
- Archive the user
- When accessing the advertisement, we want to know the user(s) even if he/she is now archived.

Please @chienandalu and @carolinafernandez-tecnativa can you review it?

@Tecnativa TT49077