### PR TITLE
[FIX] base_tier_validation: warning on install

### DIFF
--- a/base_tier_validation/models/tier_validation_exception.py
+++ b/base_tier_validation/models/tier_validation_exception.py
@@ -28,7 +28,7 @@ class TierValidationException(models.Model):
     )
     model_name = fields.Char(
         related="model_id.model",
-        string="Model",
+        string="Model Name",
         store=True,
         readonly=True,
         index=True,


### PR DESCRIPTION
This fixes removes the warning when install because two fields in tier_validation_exception model have the same name.