### PR TITLE
[17.0][IMP] base_tier_validation: support computed state field

### DIFF
--- a/base_tier_validation/README.rst
+++ b/base_tier_validation/README.rst
@@ -44,6 +44,12 @@ See
 `purchase_tier_validation <https://github.com/OCA/purchase-workflow>`__
 as an example of implementation.
 
+Additionally, if your state field is a (stored) computed field, you need
+to set ``_tier_validation_state_field_is_computed`` to ``True`` in your
+model Python file, and you will want to add the dependent fields of the
+compute method in ``_get_after_validation_exceptions`` and
+``_get_under_validation_exceptions``.
+
 **Table of contents**
 
 .. contents::
@@ -263,6 +269,8 @@ Contributors
 -  `XCG Consulting <https://xcg-consulting.fr>`__:
 
    -  Houzéfa Abbasbhay
+
+-  Stefan Rijnhart <stefan@opener.amsterdam>
 
 Maintainers
 -----------

--- a/base_tier_validation/readme/CONTRIBUTORS.md
+++ b/base_tier_validation/readme/CONTRIBUTORS.md
@@ -13,3 +13,4 @@
 - Eduardo de Miguel \<<edu@moduon.team>\>
 - [XCG Consulting](https://xcg-consulting.fr):
   - Houzéfa Abbasbhay
+- Stefan Rijnhart \<<stefan@opener.amsterdam>\>

--- a/base_tier_validation/readme/DESCRIPTION.md
+++ b/base_tier_validation/readme/DESCRIPTION.md
@@ -12,3 +12,8 @@ some development.
 
 See [purchase_tier_validation](https://github.com/OCA/purchase-workflow)
 as an example of implementation.
+
+Additionally, if your state field is a (stored) computed field, you need to
+set `_tier_validation_state_field_is_computed` to `True` in your model Python
+file, and you will want to add the dependent fields of the compute method
+in `_get_after_validation_exceptions` and `_get_under_validation_exceptions`.

--- a/base_tier_validation/static/description/index.html
+++ b/base_tier_validation/static/description/index.html
@@ -382,6 +382,11 @@ some development.</p>
 <p>See
 <a class="reference external" href="https://github.com/OCA/purchase-workflow">purchase_tier_validation</a>
 as an example of implementation.</p>
+<p>Additionally, if your state field is a (stored) computed field, you need
+to set <tt class="docutils literal">_tier_validation_state_field_is_computed</tt> to <tt class="docutils literal">True</tt> in your
+model Python file, and you will want to add the dependent fields of the
+compute method in <tt class="docutils literal">_get_after_validation_exceptions</tt> and
+<tt class="docutils literal">_get_under_validation_exceptions</tt>.</p>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">
@@ -618,6 +623,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <li>Houzéfa Abbasbhay</li>
 </ul>
 </li>
+<li>Stefan Rijnhart &lt;<a class="reference external" href="mailto:stefan&#64;opener.amsterdam">stefan&#64;opener.amsterdam</a>&gt;</li>
 </ul>
 </div>
 <div class="section" id="maintainers">

--- a/base_tier_validation/tests/common.py
+++ b/base_tier_validation/tests/common.py
@@ -19,14 +19,21 @@ class CommonTierValidation(common.TransactionCase):
             TierDefinition,
             TierValidationTester,
             TierValidationTester2,
+            TierValidationTesterComputed,
         )
 
         cls.loader.update_registry(
-            (TierValidationTester, TierValidationTester2, TierDefinition)
+            (
+                TierValidationTester,
+                TierValidationTester2,
+                TierValidationTesterComputed,
+                TierDefinition,
+            )
         )
 
         cls.test_model = cls.env[TierValidationTester._name]
         cls.test_model_2 = cls.env[TierValidationTester2._name]
+        cls.test_model_computed = cls.env[TierValidationTesterComputed._name]
 
         cls.tester_model = cls.env["ir.model"].search(
             [("model", "=", "tier.validation.tester")]
@@ -34,34 +41,32 @@ class CommonTierValidation(common.TransactionCase):
         cls.tester_model_2 = cls.env["ir.model"].search(
             [("model", "=", "tier.validation.tester2")]
         )
-
-        # Access record:
-        cls.env["ir.model.access"].create(
-            {
-                "name": "access.tester",
-                "model_id": cls.tester_model.id,
-                "perm_read": 1,
-                "perm_write": 1,
-                "perm_create": 1,
-                "perm_unlink": 1,
-            }
-        )
-        cls.env["ir.model.access"].create(
-            {
-                "name": "access.tester2",
-                "model_id": cls.tester_model_2.id,
-                "perm_read": 1,
-                "perm_write": 1,
-                "perm_create": 1,
-                "perm_unlink": 1,
-            }
+        cls.tester_model_computed = cls.env["ir.model"].search(
+            [("model", "=", "tier.validation.tester.computed")]
         )
 
-        # Define views to avoid automatic views with all fields.
-        for model in cls.test_model._name, cls.test_model_2._name:
+        models = (
+            cls.tester_model,
+            cls.tester_model_2,
+            cls.tester_model_computed,
+        )
+        for model in models:
+            # Access record:
+            cls.env["ir.model.access"].create(
+                {
+                    "name": f"access {model.name}",
+                    "model_id": model.id,
+                    "perm_read": 1,
+                    "perm_write": 1,
+                    "perm_create": 1,
+                    "perm_unlink": 1,
+                }
+            )
+
+            # Define views to avoid automatic views with all fields.
             cls.env["ir.ui.view"].create(
                 {
-                    "model": model,
+                    "model": model.model,
                     "name": f"Demo view for {model}",
                     "arch": """<form>
                     <header>
@@ -103,6 +108,7 @@ class CommonTierValidation(common.TransactionCase):
 
         cls.test_record = cls.test_model.create({"test_field": 1.0})
         cls.test_record_2 = cls.test_model_2.create({"test_field": 1.0})
+        cls.test_record_computed = cls.test_model_computed.create({"test_field": 1.0})
 
         cls.tier_def_obj.create(
             {
@@ -139,6 +145,19 @@ class CommonTierValidation(common.TransactionCase):
                 "notify_on_pending": True,
                 "sequence": 10,
                 "name": "Definition for test 20 - no sequence -  user 1 - no sequence",
+            }
+        )
+
+        cls.tier_def_obj.create(
+            {
+                "model_id": cls.tester_model_computed.id,
+                "review_type": "individual",
+                "reviewer_id": cls.test_user_1.id,
+                "definition_domain": "[]",
+                "approve_sequence": True,
+                "notify_on_pending": False,
+                "sequence": 20,
+                "name": "Definition for computed model",
             }
         )
 

--- a/base_tier_validation/tests/tier_validation_tester.py
+++ b/base_tier_validation/tests/tier_validation_tester.py
@@ -48,6 +48,59 @@ class TierValidationTester2(models.Model):
         self.write({"state": "confirmed"})
 
 
+class TierValidationTesterComputed(models.Model):
+    _name = "tier.validation.tester.computed"
+    _description = "Tier Validation Tester Computed"
+    _inherit = ["tier.validation"]
+    _tier_validation_manual_config = False
+    _tier_validation_state_field_is_computed = True
+
+    confirmed = fields.Boolean()
+    cancelled = fields.Boolean()
+    state = fields.Selection(
+        selection=[
+            ("draft", "Draft"),
+            ("confirmed", "Confirmed"),
+            ("cancel", "Cancel"),
+        ],
+        compute="_compute_state",
+        store=True,
+    )
+    test_field = fields.Float()
+    test_validation_field = fields.Float()
+    user_id = fields.Many2one(string="Assigned to:", comodel_name="res.users")
+
+    @api.model
+    def _get_after_validation_exceptions(self):
+        return super()._get_after_validation_exceptions() + [
+            "confirmed",
+            "cancelled",
+        ]
+
+    @api.model
+    def _get_under_validation_exceptions(self):
+        return super()._get_under_validation_exceptions() + [
+            "confirmed",
+            "cancelled",
+        ]
+
+    @api.depends("confirmed", "cancelled")
+    def _compute_state(self):
+        for rec in self:
+            if rec.cancelled:
+                rec.state = "cancel"
+            elif rec.confirmed:
+                rec.state = "confirmed"
+            else:
+                rec.state = "draft"
+
+    def action_confirm(self):
+        self.write({"confirmed": True})
+
+    def action_cancel(self):
+        self.write({"cancelled": True})
+
+
 class TierDefinition(models.Model):
     _inherit = "tier.definition"
 
@@ -56,4 +109,5 @@ class TierDefinition(models.Model):
         res = super()._get_tier_validation_model_names()
         res.append("tier.validation.tester")
         res.append("tier.validation.tester2")
+        res.append("tier.validation.tester.computed")
         return res


### PR DESCRIPTION
Computed fields bypass `write`, so we need to override `_write` for that case.
Also, the current value before the update needs to be fetched from the database
because the new value is already set in the cache.