### PR TITLE
[17.0][FIX] server_action_mass_edit: Application error when discard a x2many field

### DIFF
--- a/server_action_mass_edit/static/src/js/static_list.esm.js
+++ b/server_action_mass_edit/static/src/js/static_list.esm.js
@@ -10,9 +10,11 @@ patch(StaticList.prototype, {
 
         this._cache = markRaw({});
         this._commands = [];
+        this._initialCommands = [];
         this._savePoint = undefined;
         this._unknownRecordCommands = {};
         this._currentIds = [...this.resIds];
+        this._initialCurrentIds = [...this.currentIds];
         this._needsReordering = false;
         this._tmpIncreaseLimit = 0;
         this._extendedRecords = new Set();


### PR DESCRIPTION
The previous implementation from Odoo added some initial value for setup(). 

- Commit of the new implementation from Odoo:
https://github.com/odoo/odoo/commit/e450d03a5f4fc80198837cccf10fa349ecc205a9

- This will fix the application error when the user discards an x2many field.
![image](https://github.com/user-attachments/assets/c1c20f2d-56a9-44f1-9266-98dced4582a3)

