### PR TITLE
[16.0][FIX] server_action_mass_edit: group_field_list not found using form_view_ref in context

### DIFF
--- a/server_action_mass_edit/wizard/mass_editing_wizard.py
+++ b/server_action_mass_edit/wizard/mass_editing_wizard.py
@@ -196,6 +196,9 @@ class MassEditingWizard(models.TransientModel):
         server_action = self.env["ir.actions.server"].sudo().browse(server_action_id)
         if not server_action:
             return super().get_view(view_id, view_type, **options)
+        # Clean form_view_ref to avoid use that instead of this model view
+        if self.env.context.get("form_view_ref"):
+            self = self.with_context(form_view_ref=None)
         result = super().get_view(view_id, view_type, **options)
         arch = etree.fromstring(result["arch"])
         main_xml_group = arch.find('.//group[@name="group_field_list"]')


### PR DESCRIPTION
When using form_view_ref in context, this view is returned by get_view instead of the default form of the mass.editing.wizard model

@Tecnativa