### PR TITLE
[15.0][FIX] base_tier_validation: last comment instead of first comment

### DIFF
--- a/base_tier_validation/models/tier_validation.py
+++ b/base_tier_validation/models/tier_validation.py
@@ -354,7 +354,7 @@ class TierValidation(models.AbstractModel):
             lambda r: (self.env.user in r.reviewer_ids) and r.comment
         )
         if has_comment:
-            comment = has_comment.mapped("comment")[0]
+            comment = has_comment.mapped("comment")[-1]
             return _("A review was accepted. (%s)") % comment
         return _("A review was accepted")
 
@@ -404,7 +404,7 @@ class TierValidation(models.AbstractModel):
             lambda r: (self.env.user in r.reviewer_ids) and r.comment
         )
         if has_comment:
-            comment = has_comment.mapped("comment")[0]
+            comment = has_comment.mapped("comment")[-1]
             return _("A review was rejected by %(user)s. (%(comment)s)") % {
                 "user": self.env.user.name,
                 "comment": comment,


### PR DESCRIPTION
- With multiple approbation, the first comment is repeated into mail.message and propagate wrong message