### PR TITLE
[18.0][FIX] base_technical_features: fix incorrect replacement

### DIFF
--- a/base_technical_features/README.rst
+++ b/base_technical_features/README.rst
@@ -89,6 +89,7 @@ Contributors
 -  Jeroen Evens <jeroen.evens@dynapps.be>
 -  Jim Hoefnagels <jim.hoefnagels@dynapps.be>
 -  Khoi (Kien Kim) <khoikk@trobz.com>
+-  Tris Doan <tridm@trobz.com>
 
 Other credits
 -------------

--- a/base_technical_features/models/base.py
+++ b/base_technical_features/models/base.py
@@ -1,6 +1,8 @@
 # © 2016 Opener B.V. (<https://opener.am>)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
+import re
+
 from lxml import etree
 
 from odoo import api, models
@@ -13,13 +15,13 @@ class Base(models.AbstractModel):
     def _get_view(self, view_id=None, view_type="form", **options):
         arch, view = super()._get_view(view_id=view_id, view_type=view_type, **options)
         arch_str = etree.tostring(arch, encoding="unicode")
-        # Replace "base.group_no_one" with
-        # "base.group_no_one, base_technical_features.group_technical_features"
+        # Append base_technical_features.group_technical_features
         # This adds additional access to elements that were restricted to
         # "base.group_no_one"
-        arch_str = arch_str.replace(
-            "base.group_no_one",
-            "base.group_no_one,base_technical_features.group_technical_features",
+        arch_str = re.sub(
+            r"(!?)base\.group_no_one",
+            r"\1base.group_no_one,\1base_technical_features.group_technical_features",
+            arch_str,
         )
         arch = etree.fromstring(arch_str)
 

--- a/base_technical_features/readme/CONTRIBUTORS.md
+++ b/base_technical_features/readme/CONTRIBUTORS.md
@@ -2,3 +2,4 @@
 - Jeroen Evens \<<jeroen.evens@dynapps.be>\>
 - Jim Hoefnagels \<<jim.hoefnagels@dynapps.be>\>
 - Khoi (Kien Kim) \<<khoikk@trobz.com>\>
+- Tris Doan \<<tridm@trobz.com>\>

--- a/base_technical_features/static/description/index.html
+++ b/base_technical_features/static/description/index.html
@@ -424,6 +424,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <li>Jeroen Evens &lt;<a class="reference external" href="mailto:jeroen.evens&#64;dynapps.be">jeroen.evens&#64;dynapps.be</a>&gt;</li>
 <li>Jim Hoefnagels &lt;<a class="reference external" href="mailto:jim.hoefnagels&#64;dynapps.be">jim.hoefnagels&#64;dynapps.be</a>&gt;</li>
 <li>Khoi (Kien Kim) &lt;<a class="reference external" href="mailto:khoikk&#64;trobz.com">khoikk&#64;trobz.com</a>&gt;</li>
+<li>Tris Doan &lt;<a class="reference external" href="mailto:tridm&#64;trobz.com">tridm&#64;trobz.com</a>&gt;</li>
 </ul>
 </div>
 <div class="section" id="other-credits">


### PR DESCRIPTION
### Context
- Sometimes group is negated like this: `groups="!base.group_no_one"`
- Without this fix, result of arch is `groups="!base.group_no_one,base_technical_features.group_technical_features"`, which is wrong