### PR TITLE
[16.0][FIX] server_action_mass_edit: Don't do onchange

### DIFF
--- a/server_action_mass_edit/wizard/mass_editing_wizard.py
+++ b/server_action_mass_edit/wizard/mass_editing_wizard.py
@@ -94,22 +94,6 @@ class MassEditingWizard(models.TransientModel):
             res["selection__" + field.name] = "ignore"
         return res
 
-    def onchange(self, values, field_name, field_onchange):
-        server_action_id = self.env.context.get("server_action_id")
-        server_action = self.env["ir.actions.server"].sudo().browse(server_action_id)
-        if not server_action:
-            return super().onchange(values, field_name, field_onchange)
-        dynamic_fields = {}
-        for line in server_action.mapped("mass_edit_line_ids"):
-            dynamic_fields["selection__" + line.field_id.name] = fields.Selection(
-                [()], default="ignore"
-            )
-        self._fields.update(dynamic_fields)
-        res = super().onchange(values, field_name, field_onchange)
-        for field in dynamic_fields:
-            self._fields.pop(field)
-        return res
-
     @api.model
     def _prepare_fields(self, line, field, field_info):
         result = {}


### PR DESCRIPTION
This change was introduced unnoticed in the migration to 16.0 in #544, but it has several problems:

- The onchange is only executed for one record, not several, and this module is for mass actions.
- Not all the users want to play onchanges, being for one record or several.

Let's remove it for being consistent. An ongoing discussion for supporting onchanges through `onchange_helper` is meanwhile active.

@Tecnativa 