### PR TITLE
[17.0][FIX] base_tier_validation: rule tier.validation.exceptions has no group

### DIFF
--- a/base_tier_validation/security/ir.model.access.csv
+++ b/base_tier_validation/security/ir.model.access.csv
@@ -7,5 +7,5 @@ access_tier_review,access.tier.review,model_tier_review,base.group_user,1,1,1,1
 access_tier_definition_all,tier.definition.all,model_tier_definition,base.group_user,1,0,0,0
 access_tier_definition_settings,tier.definition.settings,model_tier_definition,base.group_erp_manager,1,1,1,1
 access_comment_wizard,access.comment.wizard,model_comment_wizard,base.group_user,1,1,1,1
-access_tier_validation_exceptions_all,tier.validation.exceptions,model_tier_validation_exception,,1,0,0,0
+access_tier_validation_exceptions_all,tier.validation.exceptions,model_tier_validation_exception,base.group_user,1,0,0,0
 access_tier_validation_exceptions_settings,tier.validation.exceptions,model_tier_validation_exception,base.group_system,1,1,1,1


### PR DESCRIPTION
Fixes warning in logs:
```
odoo.addons.base.models.ir_model: Rule tier.validation.exceptions has no group, this is a deprecated feature. Every access-granting rule should specify a group.
```