### PR TITLE
[16.0][FIX] base_technical_features: Add depends key in __manifest__.py

### DIFF
--- a/base_technical_features/__manifest__.py
+++ b/base_technical_features/__manifest__.py
@@ -10,4 +10,5 @@
     "data": ["security/res_groups.xml", "views/res_users.xml", "data/res_users.xml"],
     "license": "AGPL-3",
     "installable": True,
+    "depends": ["base"],
 }


### PR DESCRIPTION
Without this the module will not be listed by upstream_dependencies https://github.com/odoo/odoo/blob/05ce1a521d9702ce490100354d2b19007c35bb62/odoo/addons/base/models/ir_module.py#L537