### PR TITLE
[18.0][FIX] base_technical_features: Add depends key in __manifest__.py

### DIFF
--- a/base_technical_features/__manifest__.py
+++ b/base_technical_features/__manifest__.py
@@ -10,4 +10,5 @@
     "data": ["security/res_groups.xml", "views/res_users.xml", "data/res_users.xml"],
     "license": "AGPL-3",
     "installable": True,
+    "depends": ["base"],
 }


### PR DESCRIPTION
Same as https://github.com/OCA/server-ux/pull/996