### PR TITLE
[16.0][FIX] base_custom_filter: fix access right error

### DIFF
--- a/base_custom_filter/models/base.py
+++ b/base_custom_filter/models/base.py
@@ -56,7 +56,7 @@ class Base(models.AbstractModel):
                             "name": "ir_custom_filter_%s" % custom_groupby.id,
                             "string": custom_groupby.name,
                             "context": str(
-                                {"group_by": custom_groupby.groupby_field.name}
+                                {"group_by": custom_groupby.groupby_field.sudo().name}
                             ),
                         },
                     )


### PR DESCRIPTION
This PR fixes the access rights error that occurs when creating a custom filter to add a new groupby for a specific model, and when a user without the settings access rights tries to open the specific module's tree view.

@qrtl QT5153