### PR TITLE
[18.0][FIX] sequence_check_digit: fix ValueError: Expected singleton

### DIFF
--- a/sequence_check_digit/models/ir_sequence.py
+++ b/sequence_check_digit/models/ir_sequence.py
@@ -34,10 +34,11 @@ class IrSequence(models.Model):
 
     @api.constrains("check_digit_formula", "prefix", "suffix")
     def check_check_digit_formula(self):
-        try:
-            self.get_next_char(0)
-        except Exception as err:
-            raise ValidationError(self.env._("Format is not accepted")) from err
+        for record in self:
+            try:
+                record.get_next_char(0)
+            except Exception as err:
+                raise ValidationError(self.env._("Format is not accepted")) from err
 
     def get_check_digit(self, code):
         try:


### PR DESCRIPTION
was causing a ValueError: Expected singleton


```
Traceback (most recent call last):
  File "/odoo/external-src/server-ux/sequence_check_digit/models/ir_sequence.py", line 38, in check_check_digit_formula
    self.get_next_char(0)
  File "/odoo/external-src/server-ux/sequence_check_digit/models/ir_sequence.py", line 66, in get_next_char
    self.ensure_one()
  File "/odoo/src/odoo/models.py", line 6212, in ensure_one
    raise ValueError("Expected singleton: %s" % self)
ValueError: Expected singleton: ir.sequence(12, 13)
```