### PR TITLE
[16.0][FIX] base_export_manager: Handle id field case

### DIFF
--- a/base_export_manager/models/ir_exports_line.py
+++ b/base_export_manager/models/ir_exports_line.py
@@ -177,6 +177,10 @@ class IrExportsLine(models.Model):
         :param str name:
             Technical name of the field, like ``child_ids``.
         """
+
+        # Handle special case "id" field
+        name = "id" if name == ".id" else name
+
         field = (
             self.env["ir.model.fields"]
             .sudo()

--- a/base_export_manager/tests/test_ir_exports_line.py
+++ b/base_export_manager/tests/test_ir_exports_line.py
@@ -82,3 +82,9 @@ class TestIrExportsLineCase(TransactionCase):
         line = self._record_create("name")
         # This should end without errors
         line.name = "parent_id/name"
+
+    def test_field_id_case(self):
+        # id field is named .id in exports
+        line = self._record_create(".id")
+        self.assertEqual(line.field1_id.name, "id")
+        self.assertEqual(line.name, "id")


### PR DESCRIPTION
id field is a special case. It is named ".id" from the API.

So the name check in base_export_manager fail. We need to handle it

![image](https://github.com/user-attachments/assets/53d5f7a7-3280-4a8b-a62b-220b8b1cb7e3)


![image](https://github.com/user-attachments/assets/60f38f53-8aa2-4e92-be38-54dc181e78e0)


The new test without the fixe:

```
2025-02-04 10:00:28,082 1 ERROR devel odoo.addons.base_export_manager.tests.test_ir_exports_line: ERROR: TestIrExportsLineCase.test_field_id_case
Traceback (most recent call last):
  File "/opt/odoo/auto/addons/base_export_manager/tests/test_ir_exports_line.py", line 88, in test_field_id_case
    line = self._record_create(".id")
  File "/opt/odoo/auto/addons/base_export_manager/tests/test_ir_exports_line.py", line 30, in _record_create
    virt_line._inverse_name()
  File "/opt/odoo/auto/addons/base_export_manager/models/ir_exports_line.py", line 144, in _inverse_name
    one._get_field_id(model, field_name)
  File "/opt/odoo/auto/addons/base_export_manager/models/ir_exports_line.py", line 190, in _get_field_id
    raise exceptions.ValidationError(
odoo.exceptions.ValidationError: Field '.id' not found in model 'res.partner'
```
