### PR TITLE
[18.0][FIX] base_tier_validation: review table key undefined

### DIFF
--- a/base_tier_validation/static/src/components/tier_review_widget/tier_review_widget.xml
+++ b/base_tier_validation/static/src/components/tier_review_widget/tier_review_widget.xml
@@ -47,7 +47,7 @@
                                 <t
                                     t-foreach="_getReviewData()"
                                     t-as="review"
-                                    t-key="review.id"
+                                    t-key="review.sequence"
                                 >
                                     <t
                                         t-if="review.status == 'waiting'"


### PR DESCRIPTION
The following OwlError is received when multiple tier reviews are present:

```OwlError: Got duplicate key in t-foreach: undefined```

This happens due to `review.id` being undefined as it is not passed to the
template. We should use `review.sequence` instead as it gets passed and
is unique.