### PR TITLE
[IMP] document_quick_access_folder_auto_classification: Remove mock dependancy

### DIFF
--- a/document_quick_access_folder_auto_classification/tests/test_document_quick_access_auto_classification.py
+++ b/document_quick_access_folder_auto_classification/tests/test_document_quick_access_auto_classification.py
@@ -2,8 +2,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 import base64
-
-from mock import patch
+from unittest.mock import patch
 
 from odoo import tools
 from odoo.tools import mute_logger

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,2 +1,1 @@
-mock
 odoo-test-helper


### PR DESCRIPTION
With unittest we don't need it anymore