### PR TITLE
[17.0][FIX] base_tier_validation - wrong order of reviewer when click…

### DIFF
--- a/base_tier_validation/models/tier_validation.py
+++ b/base_tier_validation/models/tier_validation.py
@@ -719,7 +719,7 @@ class TierValidation(models.AbstractModel):
                         ("model", "=", self._name),
                         ("company_id", "in", [False] + self.env.company.ids),
                     ],
-                    order="sequence desc",
+                    order="sequence",
                 )
                 sequence = 0
                 for td in tier_definitions:


### PR DESCRIPTION
**Current Behavior**
the sequence order of review on Request Validation button be always reverted.

For example:
from Tier Definition, creating
 On Purchase Request, User A will be set as sequence 1 (this person review 1st).
  On Purchase Request, User B will be set as sequence 2 (this person review 2nd).

After clicking Request Validation button, User B always be asked to reviewed 1st.

**Expected Behavior**
Reviewing should be following the order of sequence.
