### PR TITLE
[16.0][FIX] base_tier_validation: Do not update the counter if it is not possible to review it.

### DIFF
--- a/base_tier_validation/models/tier_review.py
+++ b/base_tier_validation/models/tier_review.py
@@ -25,7 +25,11 @@ class TierReview(models.Model):
         default="pending",
     )
     model = fields.Char(string="Related Document Model", index=True)
-    res_id = fields.Integer(string="Related Document ID", index=True)
+    res_id = fields.Many2oneReference(
+        string="Related Document ID",
+        index=True,
+        model_field="model",
+    )
     definition_id = fields.Many2one(comodel_name="tier.definition")
     company_id = fields.Many2one(
         related="definition_id.company_id",

--- a/base_tier_validation/models/tier_validation.py
+++ b/base_tier_validation/models/tier_validation.py
@@ -655,8 +655,9 @@ class TierValidation(models.AbstractModel):
                     if rec.evaluate_tier(td):
                         sequence += 1
                         vals_list.append(rec._prepare_tier_review_vals(td, sequence))
-                self._update_counter({"review_created": True})
         created_trs = tr_obj.create(vals_list)
+        if any(self.mapped("can_review")):
+            self._update_counter({"review_created": True})
         self._notify_review_requested(created_trs)
         return created_trs
 

--- a/base_tier_validation/tests/test_tier_validation.py
+++ b/base_tier_validation/tests/test_tier_validation.py
@@ -127,11 +127,8 @@ class TierTierValidation(CommonTierValidation):
         )
         # Request validation
         self.test_record.with_user(self.test_user_2.id).request_validation()
-        self.test_record.invalidate_model()
         test_record.with_user(self.test_user_2.id).request_validation()
-        test_record.invalidate_model()
         self.test_record_2.with_user(self.test_user_2.id).request_validation()
-        self.test_record_2.invalidate_model()
         # Get review user count as systray icon would do and check count value
         docs = self.test_user_1.with_user(self.test_user_1).review_user_count()
         for doc in docs:
@@ -924,11 +921,14 @@ class TierTierValidation(CommonTierValidation):
         # Check need validation
         self.assertTrue(test_record.need_validation)
         self.assertEqual(len(reviews), 1)
+        self.assertEqual(reviews.definition_id, self.tier_definition)
+        self.assertEqual(len(test_record.review_ids), 1)
+        old_review = test_record.review_ids
 
         # Now record is not validated yet and new definition create,
         # and then we reevaluate object then it will add new definition validation
         # also in current object
-        self.tier_def_obj.create(
+        definition_extra = self.tier_def_obj.create(
             {
                 "model_id": self.tester_model.id,
                 "review_type": "individual",
@@ -941,7 +941,10 @@ class TierTierValidation(CommonTierValidation):
         reviews = test_record.with_user(self.test_user_2.id).reevaluate_reviews()
         # Check need validation
         self.assertTrue(test_record.need_validation)
-        self.assertEqual(len(reviews), 2)
+        self.assertEqual(len(reviews), 1)
+        self.assertEqual(reviews.definition_id, definition_extra)
+        self.assertEqual(len(test_record.review_ids), 2)
+        self.assertIn(old_review, test_record.review_ids)
 
     def test_28_reevaluate_validation(self):
         # Create new test record
@@ -976,6 +979,8 @@ class TierTierValidation(CommonTierValidation):
         # Check need validation
         self.assertTrue(test_record.need_validation)
         self.assertEqual(len(reviews), 1)
+        self.assertEqual(len(test_record.review_ids), 1)
+        old_review = test_record.review_ids
 
         # now post new message "This record need extra validation",
         # it will need to reevaluate record and will add new tier validation
@@ -985,7 +990,9 @@ class TierTierValidation(CommonTierValidation):
         reviews = test_record.with_user(self.test_user_2.id).reevaluate_reviews()
         # Check need validation
         self.assertTrue(test_record.need_validation)
-        self.assertEqual(len(reviews), 2)
+        self.assertEqual(len(reviews), 1)
+        self.assertEqual(len(test_record.review_ids), 2)
+        self.assertIn(old_review, test_record.review_ids)
 
 
 @tagged("at_install")


### PR DESCRIPTION
Do not update the counter if it is not possible to review it.

Example use case:
- Create tier definition with Mitchell Admin as reviewer user.
- Create a record (`purchase.requisition` for example) with Marc Demo and request a validation.
- Do not update the counter in Marc Demo (because you cannot review it).

**Before**
![antes-demo](https://github.com/user-attachments/assets/113b34a4-4e87-49e7-a35b-e50a4fb6c5c2)

**After**
![despues-demo](https://github.com/user-attachments/assets/50691127-3546-40dc-becf-6d0cb682cd73)
![despues-admin](https://github.com/user-attachments/assets/d47b4bd6-63ff-4307-8960-10f37135d8bd)

Please @pedrobaeza and @sergio-teruel can you review it?

@Tecnativa TT55411