### PR TITLE
[17.0][FIX] base_tier_validation: Do not update the counter if it is not possible to review it

### DIFF
--- a/base_tier_validation/models/tier_review.py
+++ b/base_tier_validation/models/tier_review.py
@@ -26,7 +26,11 @@ class TierReview(models.Model):
         default="waiting",
     )
     model = fields.Char(string="Related Document Model", index=True)
-    res_id = fields.Integer(string="Related Document ID", index=True)
+    res_id = fields.Many2oneReference(
+        string="Related Document ID",
+        index=True,
+        model_field="model",
+    )
     definition_id = fields.Many2one(comodel_name="tier.definition")
     company_id = fields.Many2one(
         related="definition_id.company_id",

--- a/base_tier_validation/models/tier_validation.py
+++ b/base_tier_validation/models/tier_validation.py
@@ -726,8 +726,9 @@ class TierValidation(models.AbstractModel):
                     if rec.evaluate_tier(td):
                         sequence += 1
                         vals_list.append(rec._prepare_tier_review_vals(td, sequence))
-                self._update_counter({"review_created": True})
         created_trs = tr_obj.create(vals_list)
+        if any(self.mapped("can_review")):
+            self._update_counter({"review_created": True})
         self._notify_review_requested(created_trs)
         return created_trs
 

--- a/base_tier_validation/tests/test_tier_validation.py
+++ b/base_tier_validation/tests/test_tier_validation.py
@@ -131,11 +131,8 @@ class TierTierValidation(CommonTierValidation):
         )
         # Request validation
         self.test_record.with_user(self.test_user_2.id).request_validation()
-        self.test_record.invalidate_model()
         test_record.with_user(self.test_user_2.id).request_validation()
-        test_record.invalidate_model()
         self.test_record_2.with_user(self.test_user_2.id).request_validation()
-        self.test_record_2.invalidate_model()
         # Get review user count as systray icon would do and check count value
         docs = self.test_user_1.with_user(self.test_user_1).review_user_count()
         for doc in docs:
@@ -295,18 +292,11 @@ class TierTierValidation(CommonTierValidation):
         self.assertTrue(reviews)
 
         record1 = test_record.with_user(self.test_user_1.id)
-        record1.invalidate_model()
         self.assertTrue(record1.can_review)
         # Validation will be all by sequence
+        self.assertEqual(len(record1.review_ids), 2)
         self.assertEqual(
-            2, len(record1.review_ids.filtered(lambda x: x.status == "waiting"))
-        )
-        self.assertEqual(
-            0, len(record1.review_ids.filtered(lambda x: x.status == "pending"))
-        )
-        record1.validate_tier()
-        self.assertEqual(
-            0, len(record1.review_ids.filtered(lambda x: x.status == "waiting"))
+            1, len(record1.review_ids.filtered(lambda x: x.status == "waiting"))
         )
         self.assertEqual(
             1, len(record1.review_ids.filtered(lambda x: x.status == "pending"))
@@ -315,9 +305,31 @@ class TierTierValidation(CommonTierValidation):
         self.assertEqual(
             0, len(record1.review_ids.filtered(lambda x: x.status == "waiting"))
         )
+        self.assertEqual(
+            1, len(record1.review_ids.filtered(lambda x: x.status == "pending"))
+        )
+        self.assertEqual(
+            1, len(record1.review_ids.filtered(lambda x: x.status == "approved"))
+        )
         record1.validate_tier()
         self.assertEqual(
+            0, len(record1.review_ids.filtered(lambda x: x.status == "waiting"))
+        )
+        self.assertEqual(
             0, len(record1.review_ids.filtered(lambda x: x.status == "pending"))
+        )
+        self.assertEqual(
+            2, len(record1.review_ids.filtered(lambda x: x.status == "approved"))
+        )
+        record1.validate_tier()
+        self.assertEqual(
+            0, len(record1.review_ids.filtered(lambda x: x.status == "waiting"))
+        )
+        self.assertEqual(
+            0, len(record1.review_ids.filtered(lambda x: x.status == "pending"))
+        )
+        self.assertEqual(
+            2, len(record1.review_ids.filtered(lambda x: x.status == "approved"))
         )
 
     def test_12_approve_sequence_same_user_bypassed(self):
@@ -354,14 +366,14 @@ class TierTierValidation(CommonTierValidation):
         self.assertTrue(reviews)
 
         record1 = test_record.with_user(self.test_user_1.id)
-        record1.invalidate_model()
         self.assertTrue(record1.can_review)
         # When the first tier is validated, all the rest will be approved.
+        self.assertEqual(len(record1.review_ids), 2)
         self.assertEqual(
-            2, len(record1.review_ids.filtered(lambda x: x.status == "waiting"))
+            1, len(record1.review_ids.filtered(lambda x: x.status == "waiting"))
         )
         self.assertEqual(
-            0, len(record1.review_ids.filtered(lambda x: x.status == "pending"))
+            1, len(record1.review_ids.filtered(lambda x: x.status == "pending"))
         )
         record1.validate_tier()
         self.assertEqual(
@@ -369,6 +381,9 @@ class TierTierValidation(CommonTierValidation):
         )
         self.assertEqual(
             0, len(record1.review_ids.filtered(lambda x: x.status == "waiting"))
+        )
+        self.assertEqual(
+            2, len(record1.review_ids.filtered(lambda x: x.status == "approved"))
         )
 
     def test_13_onchange_review_type(self):


### PR DESCRIPTION
FWP from 16.0: https://github.com/OCA/server-ux/pull/1038

Do not update the counter if it is not possible to review it.

Example use case:
- Create tier definition with Mitchell Admin as reviewer user.
- Create a record (`purchase.requisition` for example) with Marc Demo and request a validation.
- Do not update the counter in Marc Demo (because you cannot review it).

**Before**
![antes](https://github.com/user-attachments/assets/b7fb7e7d-f1de-4275-838a-096d6eee0dd6)

**After**
![despues](https://github.com/user-attachments/assets/211816bc-786e-4d4f-9ec3-0ea1aa88d1fd)
![despues-admin](https://github.com/user-attachments/assets/37a8ff92-bda7-4116-903b-26c94fe43016)

Please @pedrobaeza and @sergio-teruel can you review it?

@Tecnativa TT55411