### PR TITLE
[18.0][FIX] base_tier_validation: Do not update the counter if it is not possible to review it

### DIFF
--- a/base_tier_validation/models/tier_review.py
+++ b/base_tier_validation/models/tier_review.py
@@ -26,7 +26,11 @@ class TierReview(models.Model):
         default="waiting",
     )
     model = fields.Char(string="Related Document Model", index=True)
-    res_id = fields.Integer(string="Related Document ID", index=True)
+    res_id = fields.Many2oneReference(
+        string="Related Document ID",
+        index=True,
+        model_field="model",
+    )
     definition_id = fields.Many2one(comodel_name="tier.definition")
     company_id = fields.Many2one(
         related="definition_id.company_id",

--- a/base_tier_validation/models/tier_validation.py
+++ b/base_tier_validation/models/tier_validation.py
@@ -729,8 +729,9 @@ class TierValidation(models.AbstractModel):
                     if rec.evaluate_tier(td):
                         sequence += 1
                         vals_list.append(rec._prepare_tier_review_vals(td, sequence))
-                self._update_counter({"review_created": True})
         created_trs = tr_obj.create(vals_list)
+        if any(self.mapped("can_review")):
+            self._update_counter({"review_created": True})
         self._notify_review_requested(created_trs)
         return created_trs
 

--- a/base_tier_validation/models/tier_validation.py
+++ b/base_tier_validation/models/tier_validation.py
@@ -766,8 +766,9 @@ class TierValidation(models.AbstractModel):
                         .mapped("partner_id")
                         .ids
                     )
+                can_review = rec.can_review
                 rec.mapped("review_ids").unlink()
-                if to_update_counter:
+                if to_update_counter and can_review:
                     self._update_counter({"review_deleted": True})
             if partners_to_notify_ids:
                 subscribe = "message_subscribe"

--- a/base_tier_validation/tests/test_tier_validation.py
+++ b/base_tier_validation/tests/test_tier_validation.py
@@ -131,11 +131,8 @@ class TierTierValidation(CommonTierValidation):
         )
         # Request validation
         self.test_record.with_user(self.test_user_2.id).request_validation()
-        self.test_record.invalidate_model()
         test_record.with_user(self.test_user_2.id).request_validation()
-        test_record.invalidate_model()
         self.test_record_2.with_user(self.test_user_2.id).request_validation()
-        self.test_record_2.invalidate_model()
         # Get review user count as systray icon would do and check count value
         docs = self.test_user_1.with_user(self.test_user_1).review_user_count()
         for doc in docs:
@@ -295,18 +292,11 @@ class TierTierValidation(CommonTierValidation):
         self.assertTrue(reviews)
 
         record1 = test_record.with_user(self.test_user_1.id)
-        record1.invalidate_model()
         self.assertTrue(record1.can_review)
         # Validation will be all by sequence
+        self.assertEqual(len(record1.review_ids), 2)
         self.assertEqual(
-            2, len(record1.review_ids.filtered(lambda x: x.status == "waiting"))
-        )
-        self.assertEqual(
-            0, len(record1.review_ids.filtered(lambda x: x.status == "pending"))
-        )
-        record1.validate_tier()
-        self.assertEqual(
-            0, len(record1.review_ids.filtered(lambda x: x.status == "waiting"))
+            1, len(record1.review_ids.filtered(lambda x: x.status == "waiting"))
         )
         self.assertEqual(
             1, len(record1.review_ids.filtered(lambda x: x.status == "pending"))
@@ -315,9 +305,31 @@ class TierTierValidation(CommonTierValidation):
         self.assertEqual(
             0, len(record1.review_ids.filtered(lambda x: x.status == "waiting"))
         )
+        self.assertEqual(
+            1, len(record1.review_ids.filtered(lambda x: x.status == "pending"))
+        )
+        self.assertEqual(
+            1, len(record1.review_ids.filtered(lambda x: x.status == "approved"))
+        )
         record1.validate_tier()
         self.assertEqual(
+            0, len(record1.review_ids.filtered(lambda x: x.status == "waiting"))
+        )
+        self.assertEqual(
             0, len(record1.review_ids.filtered(lambda x: x.status == "pending"))
+        )
+        self.assertEqual(
+            2, len(record1.review_ids.filtered(lambda x: x.status == "approved"))
+        )
+        record1.validate_tier()
+        self.assertEqual(
+            0, len(record1.review_ids.filtered(lambda x: x.status == "waiting"))
+        )
+        self.assertEqual(
+            0, len(record1.review_ids.filtered(lambda x: x.status == "pending"))
+        )
+        self.assertEqual(
+            2, len(record1.review_ids.filtered(lambda x: x.status == "approved"))
         )
 
     def test_12_approve_sequence_same_user_bypassed(self):
@@ -354,14 +366,14 @@ class TierTierValidation(CommonTierValidation):
         self.assertTrue(reviews)
 
         record1 = test_record.with_user(self.test_user_1.id)
-        record1.invalidate_model()
         self.assertTrue(record1.can_review)
         # When the first tier is validated, all the rest will be approved.
+        self.assertEqual(len(record1.review_ids), 2)
         self.assertEqual(
-            2, len(record1.review_ids.filtered(lambda x: x.status == "waiting"))
+            1, len(record1.review_ids.filtered(lambda x: x.status == "waiting"))
         )
         self.assertEqual(
-            0, len(record1.review_ids.filtered(lambda x: x.status == "pending"))
+            1, len(record1.review_ids.filtered(lambda x: x.status == "pending"))
         )
         record1.validate_tier()
         self.assertEqual(
@@ -369,6 +381,9 @@ class TierTierValidation(CommonTierValidation):
         )
         self.assertEqual(
             0, len(record1.review_ids.filtered(lambda x: x.status == "waiting"))
+        )
+        self.assertEqual(
+            2, len(record1.review_ids.filtered(lambda x: x.status == "approved"))
         )
 
     def test_13_onchange_review_type(self):


### PR DESCRIPTION
FWP from 17.0: https://github.com/OCA/server-ux/pull/1041

<ins>Do not update the counter if it is not possible to review it.</ins>

Example use case:
- Create tier definition with Mitchell Admin as reviewer user.
- Create a record (`purchase.requisition` for example) with Marc Demo and request a validation.
- Do not update the counter in Marc Demo (because you cannot review it).

**Before**
![antes](https://github.com/user-attachments/assets/c42d8298-86ef-409e-89fd-15b46691d247)

**After**
![despues-demo](https://github.com/user-attachments/assets/f161d7d6-8432-445d-b33b-acd5a0fa55d7)
![despues-admin](https://github.com/user-attachments/assets/d27fd62b-3cc3-4b2d-887d-b4f525a5b4c6)

<ins>Do not update the counter when restarting the validation if you are unable to validate it.<i/ns>

**Before**
![antes-2](https://github.com/user-attachments/assets/fe122caf-2b31-4f0a-bda4-cad23c48d7e2)

**After**
![despues-2](https://github.com/user-attachments/assets/edddc16f-11f2-4923-9a81-b394102ed961)

Please @pedrobaeza and @sergio-teruel can you review it?

@Tecnativa TT55411