### PR TITLE
[16.0][IMP] base_tier_validation: Add subscription mode in tier definition

### DIFF
--- a/base_tier_validation/models/tier_definition.py
+++ b/base_tier_validation/models/tier_definition.py
@@ -62,6 +62,15 @@ class TierDefinition(models.Model):
         string="Company",
         default=lambda self: self.env.company,
     )
+    subscription_mode = fields.Selection(
+        [
+            ("standard", "Standard subscription mode"),
+            ("tier_validation", "Subscribe only to Tier Validation notifications"),
+        ],
+        default="standard",
+        required=True,
+        change_default=True,
+    )
     notify_on_create = fields.Boolean(
         string="Notify Reviewers on Creation",
         help="If set, all possible reviewers will be notified by email when "
@@ -79,8 +88,8 @@ class TierDefinition(models.Model):
     )
     notify_on_restarted = fields.Boolean(
         string="Notify Reviewers on Restarted",
-        help="If set, reviewers will be notified by email when a reviews related "
-        "to this definition are restarted.",
+        help="If set, reviewers will be notified by email when a review related "
+        "to this definition is restarted.",
     )
     has_comment = fields.Boolean(string="Comment", default=False)
     notify_reminder_delay = fields.Integer(

--- a/base_tier_validation/models/tier_validation.py
+++ b/base_tier_validation/models/tier_validation.py
@@ -475,6 +475,20 @@ class TierValidation(models.AbstractModel):
             and vals.get(self._state_field) in self._state_to
         )
 
+    def _notify_review_accepted(self, tier_reviews):
+        subscribe = "message_subscribe"
+        post = "message_post"
+        if hasattr(self, post) and hasattr(self, subscribe):
+            reviews_to_notify = tier_reviews.filtered(
+                lambda r: r.definition_id.notify_on_accepted
+            )
+            if reviews_to_notify:
+                self._subscribe_review(tier_reviews)
+                getattr(self.sudo(), post)(
+                    subtype_xmlid=self._get_accepted_notification_subtype(),
+                    body=self._notify_accepted_reviews_body(),
+                )
+
     def _validate_tier(self, tiers=False):
         self.ensure_one()
         tier_reviews = tiers or self.review_ids
@@ -488,36 +502,55 @@ class TierValidation(models.AbstractModel):
                 "reviewed_date": fields.Datetime.now(),
             }
         )
-        reviews_to_notify = user_reviews.filtered(
-            lambda r: r.definition_id.notify_on_accepted
-        )
-        # We need to notify all pending users if there is approve sequence
-        if tier_reviews and any(review.approve_sequence for review in tier_reviews):
-            reviews_to_notify = self.review_ids.filtered(
-                lambda r: r.status == "pending" and r.definition_id.notify_on_accepted
+        self._notify_review_accepted(user_reviews)
+
+    def _subscribe_review(self, tier_reviews):
+        subtype_ids = self._get_notification_subtypes(tier_reviews)
+        partners_to_notify_ids = self._get_partners_to_notify(tier_reviews, subtype_ids)
+        if subtype_ids is None or subtype_ids:
+            self.message_subscribe(
+                partner_ids=partners_to_notify_ids,
+                subtype_ids=subtype_ids,
             )
-            # If there are approve sequence, only the following should be
-            # considered to notify
-            if reviews_to_notify and any(
-                review.approve_sequence for review in reviews_to_notify
-            ):
-                reviews_to_notify = reviews_to_notify.filtered(
-                    lambda x: x.approve_sequence
-                )[0]
-        if reviews_to_notify:
-            subscribe = "message_subscribe"
-            if hasattr(self, subscribe):
-                getattr(self, subscribe)(
-                    partner_ids=reviews_to_notify.mapped("reviewer_ids")
-                    .mapped("partner_id")
-                    .ids,
-                    subtype_ids=self.env.ref(
-                        self._get_accepted_notification_subtype()
-                    ).ids,
-                )
-            for review in reviews_to_notify:
-                rec = self.env[review.model].browse(review.res_id)
-                rec._notify_accepted_reviews()
+
+    def _get_partners_to_notify(self, tier_reviews, subtype_ids):
+        if subtype_ids:
+            partner_ids = list(
+                set(tier_reviews.mapped("reviewer_ids.partner_id.id"))
+                - set(self.mapped("message_follower_ids.partner_id.id"))
+            )
+        else:
+            partner_ids = tier_reviews.mapped("reviewer_ids.partner_id.id")
+        return partner_ids
+
+    def _get_notification_subtypes(self, tier_reviews):
+        subtype_ids = self.env["mail.message.subtype"]
+        default_subscription_mode = tier_reviews.filtered(
+            lambda x: "standard" in x.definition_id.subscription_mode
+        )
+        if default_subscription_mode:
+            return None
+        notify_on_create = tier_reviews.filtered(
+            lambda r: r.definition_id.notify_on_create and r.res_id == self.id
+        )
+        if notify_on_create:
+            subtype_ids += self.env.ref(self._get_requested_notification_subtype())
+        notify_on_accepted = tier_reviews.filtered(
+            lambda r: r.definition_id.notify_on_accepted and r.res_id == self.id
+        )
+        if notify_on_accepted:
+            subtype_ids += self.env.ref(self._get_accepted_notification_subtype())
+        notify_on_rejected = tier_reviews.filtered(
+            lambda r: r.definition_id.notify_on_rejected and r.res_id == self.id
+        )
+        if notify_on_rejected:
+            subtype_ids += self.env.ref(self._get_rejected_notification_subtype())
+        notify_on_restarted = tier_reviews.filtered(
+            lambda r: r.definition_id.notify_on_restarted and r.res_id == self.id
+        )
+        if notify_on_restarted:
+            subtype_ids += self.env.ref(self._get_restarted_notification_subtype())
+        return subtype_ids.ids
 
     def _get_requested_notification_subtype(self):
         return "base_tier_validation.mt_tier_validation_requested"
@@ -602,14 +635,19 @@ class TierValidation(models.AbstractModel):
             }
         return _("A review was rejected by %s.") % (self.env.user.name)
 
-    def _notify_rejected_review(self):
+    def _notify_rejected_review(self, tier_reviews):
+        subscribe = "message_subscribe"
         post = "message_post"
-        if hasattr(self, post):
-            # Notify state change
-            getattr(self.sudo(), post)(
-                subtype_xmlid=self._get_rejected_notification_subtype(),
-                body=self._notify_rejected_review_body(),
+        if hasattr(self, post) and hasattr(self, subscribe):
+            reviews_to_notify = tier_reviews.filtered(
+                lambda r: r.definition_id.notify_on_rejected
             )
+            if reviews_to_notify:
+                self.sudo()._subscribe_review(tier_reviews)
+                getattr(self.sudo(), post)(
+                    subtype_xmlid=self._get_rejected_notification_subtype(),
+                    body=self._notify_rejected_review_body(),
+                )
 
     def _rejected_tier(self, tiers=False):
         self.ensure_one()
@@ -624,37 +662,7 @@ class TierValidation(models.AbstractModel):
                 "reviewed_date": fields.Datetime.now(),
             }
         )
-
-        reviews_to_notify = user_reviews.filtered(
-            lambda r: r.definition_id.notify_on_rejected
-        )
-        # We need to notify all pending users if there is approve sequence
-        if tier_reviews and any(review.approve_sequence for review in tier_reviews):
-            reviews_to_notify = self.review_ids.filtered(
-                lambda r: r.status == "pending" and r.definition_id.notify_on_rejected
-            )
-            # If there are approve sequence, only the following should be
-            # considered to notify
-            if reviews_to_notify and any(
-                review.approve_sequence for review in reviews_to_notify
-            ):
-                reviews_to_notify = reviews_to_notify.filtered(
-                    lambda x: x.approve_sequence
-                )[0]
-        if reviews_to_notify:
-            subscribe = "message_subscribe"
-            if hasattr(self, subscribe):
-                getattr(self, subscribe)(
-                    partner_ids=reviews_to_notify.mapped("reviewer_ids")
-                    .mapped("partner_id")
-                    .ids,
-                    subtype_ids=self.env.ref(
-                        self._get_rejected_notification_subtype()
-                    ).ids,
-                )
-            for review in reviews_to_notify:
-                rec = self.env[review.model].browse(review.res_id)
-                rec._notify_rejected_review()
+        self._notify_rejected_review(user_reviews)
 
     def _notify_requested_review_body(self):
         return _("A review has been requested by %s.") % (self.env.user.name)
@@ -664,17 +672,11 @@ class TierValidation(models.AbstractModel):
         post = "message_post"
         if hasattr(self, post) and hasattr(self, subscribe):
             for rec in self.sudo():
-                users_to_notify = tier_reviews.filtered(
-                    lambda r: r.definition_id.notify_on_create and r.res_id == rec.id
-                ).mapped("reviewer_ids")
-                # Subscribe reviewers and notify
-                if len(users_to_notify) > 0:
-                    getattr(rec, subscribe)(
-                        partner_ids=users_to_notify.mapped("partner_id").ids,
-                        subtype_ids=self.env.ref(
-                            self._get_requested_notification_subtype()
-                        ).ids,
-                    )
+                reviews_to_notify = tier_reviews.filtered(
+                    lambda r: r.definition_id.notify_on_create
+                )
+                if reviews_to_notify:
+                    rec._subscribe_review(tier_reviews)
                     getattr(rec, post)(
                         subtype_xmlid=self._get_requested_notification_subtype(),
                         body=rec._notify_requested_review_body(),
@@ -729,47 +731,30 @@ class TierValidation(models.AbstractModel):
         return _("The review has been reset by %s.") % (self.env.user.name)
 
     def _notify_restarted_review(self):
+        subscribe = "message_subscribe"
         post = "message_post"
-        if hasattr(self, post):
-            getattr(self.sudo(), post)(
-                subtype_xmlid=self._get_restarted_notification_subtype(),
-                body=self._notify_restarted_review_body(),
+        if hasattr(self, post) and hasattr(self, subscribe):
+            tier_reviews = self.mapped("review_ids")
+            reviews_to_notify = tier_reviews.filtered(
+                lambda r: r.definition_id.notify_on_restarted
             )
+            if reviews_to_notify:
+                self._subscribe_review(tier_reviews)
+                getattr(self.sudo(), post)(
+                    subtype_xmlid=self._get_restarted_notification_subtype(),
+                    body=self._notify_restarted_review_body(),
+                )
 
     def restart_validation(self):
         for rec in self:
-            partners_to_notify_ids = False
             if getattr(rec, self._state_field) in self._state_from:
-                to_update_counter = (
-                    rec.mapped("review_ids").filtered(lambda a: a.status == "pending")
-                    and True
-                    or False
+                to_update_counter = rec.mapped("review_ids").filtered(
+                    lambda a: a.status == "pending"
                 )
-                reviews_to_notify = rec.review_ids.filtered(
-                    lambda r: r.definition_id.notify_on_restarted
-                )
-                if reviews_to_notify:
-                    partners_to_notify_ids = (
-                        reviews_to_notify.mapped("reviewer_ids")
-                        .mapped("partner_id")
-                        .ids
-                    )
-                rec.mapped("review_ids").unlink()
                 if to_update_counter:
                     self._update_counter({"review_deleted": True})
-            if partners_to_notify_ids:
-                subscribe = "message_subscribe"
-                reviews_to_notify = rec.review_ids.filtered(
-                    lambda r: r.definition_id.notify_on_restarted
-                )
-                if hasattr(self, subscribe):
-                    getattr(self, subscribe)(
-                        partner_ids=partners_to_notify_ids,
-                        subtype_ids=self.env.ref(
-                            self._get_restarted_notification_subtype()
-                        ).ids,
-                    )
                 rec._notify_restarted_review()
+                rec.mapped("review_ids").unlink()
 
     def reevaluate_reviews(self):
         reviews = self.env["tier.review"]

--- a/base_tier_validation/tests/test_tier_validation.py
+++ b/base_tier_validation/tests/test_tier_validation.py
@@ -869,49 +869,84 @@ class TierTierValidation(CommonTierValidation):
             )
         self.assertEqual(self.test_record.test_validation_field, 4)
 
-    def test_26_reevaluate_validation(self):
-        # Create new test record
-        test_record = self.test_model.create(
-            {"test_field": 100, "test_validation_field": 15}
-        )
-        # Create tier definitions
-        self.tier_def_obj.create(
+    def test_26_notify_only_tier_validation(self):
+        tier_definition = self.env["tier.definition"].search([])
+        tier_definition.write(
             {
-                "model_id": self.tester_model.id,
-                "review_type": "individual",
-                "reviewer_id": self.test_user_1.id,
-                "definition_domain": "[('test_field', '>', 100)]",
+                "subscription_mode": "standard",
+                "notify_on_create": True,
+                "notify_on_accepted": True,
+                "notify_on_rejected": True,
+                "notify_on_restarted": True,
+                "review_type": "group",
+                "reviewer_group_id": self.env.ref("base.group_system").id,
             }
         )
-        # Request validation
-        reviews = test_record.with_user(self.test_user_2.id).request_validation()
-        # Check need validation
-        self.assertTrue(test_record.need_validation)
-        self.assertEqual(len(reviews), 1)
-        self.assertEqual(reviews.definition_id, self.tier_definition)
-        self.assertEqual(len(test_record.review_ids), 1)
-        old_review = test_record.review_ids
-
-        # Now record is not validated yet and new definition create,
-        # and then we reevaluate object then it will add new definition validation
-        # also in current object
-        definition_extra = self.tier_def_obj.create(
-            {
-                "model_id": self.tester_model.id,
-                "review_type": "individual",
-                "reviewer_id": self.test_user_1.id,
-                "definition_domain": "[('test_validation_field', '>', 10)]",
-            }
+        # notify on create
+        test_record_1 = self.test_model.create({"test_field": 2.5})
+        notifications_no_1 = len(
+            self.env["mail.notification"].search(
+                [("res_partner_id", "=", self.test_user_1.partner_id.id)]
+            )
         )
+        test_record_1.request_validation()
+        notifications_no_2 = len(
+            self.env["mail.notification"].search(
+                [("res_partner_id", "=", self.test_user_1.partner_id.id)]
+            )
+        )
+        self.assertEqual(notifications_no_2, notifications_no_1 + 1)
 
-        # Reevaluate Validation
-        reviews = test_record.with_user(self.test_user_2.id).reevaluate_reviews()
-        # Check need validation
-        self.assertTrue(test_record.need_validation)
-        self.assertEqual(len(reviews), 1)
-        self.assertEqual(reviews.definition_id, definition_extra)
-        self.assertEqual(len(test_record.review_ids), 2)
-        self.assertIn(old_review, test_record.review_ids)
+        # notify on message post
+        notifications_no_1 = len(
+            self.env["mail.notification"].search(
+                [("res_partner_id", "=", self.test_user_1.partner_id.id)]
+            )
+        )
+        test_record_1.message_post(
+            body="Message post on test_record.",
+            subtype_id=self.env.ref("mail.mt_comment").id,
+        )
+        notifications_no_2 = len(
+            self.env["mail.notification"].search(
+                [("res_partner_id", "=", self.test_user_1.partner_id.id)]
+            )
+        )
+        self.assertEqual(notifications_no_2, notifications_no_1 + 1)
+
+        tier_definition.write({"subscription_mode": "tier_validation"})
+
+        # notify on create
+        test_record_2 = self.test_model.create({"test_field": 2.5})
+        notifications_no_1 = len(
+            self.env["mail.notification"].search(
+                [("res_partner_id", "=", self.test_user_1.partner_id.id)]
+            )
+        )
+        test_record_2.request_validation()
+        notifications_no_2 = len(
+            self.env["mail.notification"].search(
+                [("res_partner_id", "=", self.test_user_1.partner_id.id)]
+            )
+        )
+        self.assertEqual(notifications_no_2, notifications_no_1 + 1)
+
+        # do not notify on message post
+        notifications_no_1 = len(
+            self.env["mail.notification"].search(
+                [("res_partner_id", "=", self.test_user_1.partner_id.id)]
+            )
+        )
+        test_record_2.message_post(
+            body="Message post on test_record.",
+            subtype_id=self.env.ref("mail.mt_comment").id,
+        )
+        notifications_no_2 = len(
+            self.env["mail.notification"].search(
+                [("res_partner_id", "=", self.test_user_1.partner_id.id)]
+            )
+        )
+        self.assertEqual(notifications_no_2, notifications_no_1)
 
     def test_27_reevaluate_validation(self):
         # Create new test record

--- a/base_tier_validation/views/tier_definition_view.xml
+++ b/base_tier_validation/views/tier_definition_view.xml
@@ -102,6 +102,7 @@
                         <page name="options" string="More Options">
                             <group name="more_option">
                                 <group name="notify">
+                                    <field name="subscription_mode" />
                                     <field name="notify_on_create" />
                                     <field name="notify_on_accepted" />
                                     <field name="notify_on_rejected" />


### PR DESCRIPTION
Sometimes we may use Tier Validation for records that are communicating with the customer, and we don't want validators to receive notifications for the entire discussion. We introduce a new field 'Subscription mode' that allows to configure if we only want to receive Tier Validation notifications.

Original: https://github.com/OCA/server-ux/pull/911