### PR TITLE
[18.0][FIX] base_tier_validation: request tier with multi-company

### DIFF
--- a/base_tier_validation/models/tier_validation.py
+++ b/base_tier_validation/models/tier_validation.py
@@ -22,6 +22,7 @@ class TierValidation(models.AbstractModel):
     _tier_validation_buttons_xpath = "/form/header/button[last()]"
     _tier_validation_manual_config = True
     _tier_validation_state_field_is_computed = False
+    _tier_validation_company_field = "company_id"
 
     _state_field = "state"
     _state_from = ["draft"]
@@ -250,7 +251,7 @@ class TierValidation(models.AbstractModel):
                 .search(
                     [
                         ("model", "=", self._name),
-                        ("company_id", "in", [False] + self.env.company.ids),
+                        ("company_id", "in", [False] + rec._get_company().ids),
                     ]
                 )
             )
@@ -275,7 +276,7 @@ class TierValidation(models.AbstractModel):
             .search(
                 [
                     ("model_name", "=", self._name),
-                    ("company_id", "in", [False] + self.env.company.ids),
+                    ("company_id", "in", [False] + self._get_company().ids),
                     "|",
                     ("group_ids", "in", self.env.user.groups_id.ids),
                     ("group_ids", "=", False),
@@ -711,6 +712,17 @@ class TierValidation(models.AbstractModel):
             "sequence": sequence,
         }
 
+    @api.model
+    def _get_company(self):
+        company_id = self.env.company
+        if (
+            self
+            and self._tier_validation_company_field in self.env[self._name]
+            and self[self._tier_validation_company_field]
+        ):
+            company_id = self[self._tier_validation_company_field]
+        return company_id
+
     def request_validation(self):
         td_obj = self.env["tier.definition"]
         tr_obj = self.env["tier.review"]
@@ -720,7 +732,7 @@ class TierValidation(models.AbstractModel):
                 tier_definitions = td_obj.search(
                     [
                         ("model", "=", self._name),
-                        ("company_id", "in", [False] + self.env.company.ids),
+                        ("company_id", "in", [False] + rec._get_company().ids),
                     ],
                     order="sequence desc",
                 )

--- a/base_tier_validation/tests/common.py
+++ b/base_tier_validation/tests/common.py
@@ -41,6 +41,9 @@ class CommonTierValidation(BaseCommon):
         cls.tester_model_computed = cls.env["ir.model"].search(
             [("model", "=", "tier.validation.tester.computed")]
         )
+        # Create a multi-company
+        cls.main_company = cls.env.ref("base.main_company")
+        cls.other_company = cls.env["res.company"].create({"name": "My Company"})
 
         models = (
             cls.tester_model,
@@ -89,6 +92,14 @@ class CommonTierValidation(BaseCommon):
         )
         cls.test_user_2 = cls.env["res.users"].create(
             {"name": "Mike", "login": "test2", "email": "mike@yourcompany.example.com"}
+        )
+        cls.test_user_3_multi_company = cls.env["res.users"].create(
+            {
+                "name": "Jane",
+                "login": "test3",
+                "email": "jane@mycompany.example.com",
+                "company_ids": [(6, 0, [cls.main_company.id, cls.other_company.id])],
+            }
         )
 
         # Create tier definitions:
@@ -155,6 +166,49 @@ class CommonTierValidation(BaseCommon):
                 "notify_on_pending": False,
                 "sequence": 20,
                 "name": "Definition for computed model",
+            }
+        )
+
+        # Create definition for test 30, 31
+        # Main company tier definition
+        cls.tier_def_obj.create(
+            {
+                "model_id": cls.tester_model_2.id,
+                "review_type": "individual",
+                "reviewer_id": cls.test_user_1.id,
+                "definition_domain": "[('test_field', '>=', 1.0)]",
+                "approve_sequence": True,
+                "notify_on_pending": False,
+                "sequence": 30,
+                "name": "Definition for test 30 - sequence - user 1 - main company",
+                "company_id": cls.main_company.id,
+            }
+        )
+        cls.tier_def_obj.create(
+            {
+                "model_id": cls.tester_model_2.id,
+                "review_type": "individual",
+                "reviewer_id": cls.test_user_3_multi_company.id,
+                "definition_domain": "[('test_field', '>=', 1.0)]",
+                "approve_sequence": True,
+                "notify_on_pending": False,
+                "sequence": 20,
+                "name": "Definition for test 30 - sequence - user 3 - main company",
+                "company_id": cls.main_company.id,
+            }
+        )
+        # Other company tier definition
+        cls.tier_def_obj.create(
+            {
+                "model_id": cls.tester_model_2.id,
+                "review_type": "individual",
+                "reviewer_id": cls.test_user_3_multi_company.id,
+                "definition_domain": "[('test_field', '>=', 1.0)]",
+                "approve_sequence": True,
+                "notify_on_pending": False,
+                "sequence": 30,
+                "name": "Definition for test 30 - sequence - user 3 - other company",
+                "company_id": cls.other_company.id,
             }
         )
 

--- a/base_tier_validation/tests/test_tier_validation.py
+++ b/base_tier_validation/tests/test_tier_validation.py
@@ -934,7 +934,7 @@ class TierTierValidation(CommonTierValidation):
         )
         self.assertEqual(notifications_no_2, notifications_no_1)
 
-    def test_25_change_field_exception_validation(self):
+    def test_27_change_field_exception_validation(self):
         """Test under and after validations"""
         # Cannot create `tier.validation.exception` records because
         # `tier.validation.tester` are fake model and its fields are
@@ -985,7 +985,7 @@ class TierTierValidation(CommonTierValidation):
             )
         self.assertEqual(self.test_record.test_validation_field, 4)
 
-    def test_26_computed_state_field(self):
+    def test_28_computed_state_field(self):
         """Test the regular flow on a model where state is a computed field"""
         # The record cannot be confirmed without validation
         with self.assertRaisesRegex(
@@ -1014,7 +1014,7 @@ class TierTierValidation(CommonTierValidation):
         self.assertFalse(self.test_record_computed.review_ids)
         self.test_record_computed.invalidate_recordset()
 
-    def test_27_allow_write_for_reviewers(self):
+    def test_29_allow_write_for_reviewers(self):
         reviews = self.test_record.with_user(self.test_user_2.id).request_validation()
         record = self.test_record.with_user(self.test_user_1.id)
         record.invalidate_recordset()
@@ -1024,6 +1024,62 @@ class TierTierValidation(CommonTierValidation):
             {"allow_write_for_reviewer": True}
         )
         record.with_user(self.test_user_1.id).write({"test_field": 0.3})
+
+    def test_30_request_validation_diff_company(self):
+        """
+        Test validation request behavior with multi-company setup.
+
+        Setup:
+        - Main company has 2 tier definitions:
+          - One for User1 (sequence 30)
+          - One for User3 (sequence 20)
+        - Other company has 1 tier definition:
+          - One for User3 (sequence 30)
+
+        When record's company is set to 'other company':
+        - Only User3's tier definition from other company should be applied
+        - Should create only 1 review
+        """
+        self.assertFalse(self.test_record_2.review_ids)
+        self.assertFalse(self.test_record_2.company_id)
+        self.assertEqual(self.test_user_3_multi_company.env.company, self.main_company)
+
+        self.test_record_2.company_id = self.other_company
+
+        reviews = self.test_record_2.with_user(
+            self.test_user_3_multi_company.id
+        ).request_validation()
+        self.test_record_2.invalidate_recordset()
+
+        self.assertEqual(len(reviews), 1)
+
+    def test_31_request_validation_same_company(self):
+        """
+        Test validation request behavior with multi-company setup.
+
+        Setup:
+        - Main company has 2 tier definitions:
+          - One for User1 (sequence 30)
+          - One for User3 (sequence 20)
+        - Other company has 1 tier definition:
+          - One for User3 (sequence 30)
+
+        When record's company is set to 'main company':
+        - Both User1 and User3's tier definitions from main company should be applied
+        - Should create 2 reviews
+        """
+        self.assertFalse(self.test_record_2.review_ids)
+        self.assertFalse(self.test_record_2.company_id)
+        self.assertEqual(self.test_user_3_multi_company.env.company, self.main_company)
+
+        self.test_record_2.company_id = self.main_company
+
+        reviews = self.test_record_2.with_user(
+            self.test_user_3_multi_company.id
+        ).request_validation()
+        self.test_record_2.invalidate_recordset()
+
+        self.assertEqual(len(reviews), 2)
 
 
 @tagged("at_install")

--- a/base_tier_validation/tests/tier_validation_tester.py
+++ b/base_tier_validation/tests/tier_validation_tester.py
@@ -43,6 +43,7 @@ class TierValidationTester2(models.Model):
     test_field = fields.Float()
     test_validation_field = fields.Float()
     user_id = fields.Many2one(string="Assigned to:", comodel_name="res.users")
+    company_id = fields.Many2one(comodel_name="res.company")
 
     def action_confirm(self):
         self.write({"state": "confirmed"})


### PR DESCRIPTION
Document belongs to `YourCompany`, but user requesting validation has multiple companies and has selected `MyCompany`. I think request should use the tier from document's company (YourCompany) instead of the currently selected company.

Steps to Reproduce (with Purchase):
1. Create purchase order -> it will default to `YourCompany`
2. The user has multi-company and the current selected company is `MyCompany`
3. User clicks Request Validation > It uses the tier from `MyCompany` (but it should use tier from `YourCompany`)
![Selection_002](https://github.com/user-attachments/assets/839a3401-3af8-4408-9273-7232f090472d)
