### PR TITLE
[17.0] [FIX] base_tier_validation: Fixed readonly behavior of fields.

### DIFF
--- a/base_tier_validation/models/tier_validation.py
+++ b/base_tier_validation/models/tier_validation.py
@@ -847,7 +847,9 @@ class TierValidation(models.AbstractModel):
                 if node.attrib.get("name") in excepted_fields:
                     continue
                 new_r_modifier = self._get_tier_validation_readonly_domain()
-                old_r_modifier = node.attrib.get("readonly")
+                old_r_modifier = node.attrib.get(
+                    "readonly", self._fields.get(node.attrib["name"]).readonly
+                )
                 if old_r_modifier:
                     new_r_modifier = f"({old_r_modifier}) or ({new_r_modifier})"
                 node.attrib["readonly"] = new_r_modifier

--- a/base_tier_validation/tests/common.py
+++ b/base_tier_validation/tests/common.py
@@ -19,6 +19,7 @@ class CommonTierValidation(common.TransactionCase):
             TierDefinition,
             TierValidationTester,
             TierValidationTester2,
+            TierValidationTester3,
             TierValidationTesterComputed,
         )
 
@@ -26,6 +27,7 @@ class CommonTierValidation(common.TransactionCase):
             (
                 TierValidationTester,
                 TierValidationTester2,
+                TierValidationTester3,
                 TierValidationTesterComputed,
                 TierDefinition,
             )
@@ -33,6 +35,7 @@ class CommonTierValidation(common.TransactionCase):
 
         cls.test_model = cls.env[TierValidationTester._name]
         cls.test_model_2 = cls.env[TierValidationTester2._name]
+        cls.test_model_3 = cls.env[TierValidationTester3._name]
         cls.test_model_computed = cls.env[TierValidationTesterComputed._name]
 
         cls.tester_model = cls.env["ir.model"].search(
@@ -40,6 +43,9 @@ class CommonTierValidation(common.TransactionCase):
         )
         cls.tester_model_2 = cls.env["ir.model"].search(
             [("model", "=", "tier.validation.tester2")]
+        )
+        cls.tester_model_3 = cls.env["ir.model"].search(
+            [("model", "=", "tier.validation.tester3")]
         )
         cls.tester_model_computed = cls.env["ir.model"].search(
             [("model", "=", "tier.validation.tester.computed")]
@@ -80,6 +86,51 @@ class CommonTierValidation(common.TransactionCase):
                 }
             )
 
+        # Custom view for tester3
+        # Access record:
+        cls.env["ir.model.access"].create(
+            {
+                "name": f"access {model.name}",
+                "model_id": model.id,
+                "perm_read": 1,
+                "perm_write": 1,
+                "perm_create": 1,
+                "perm_unlink": 1,
+            }
+        )
+        cls.env["ir.ui.view"].create(
+            {
+                "model": cls.tester_model_3.model,
+                "name": f"Demo view for {model}",
+                "arch": """<form>
+    <header>
+        <button name="action_confirm" type="object" string="Confirm" />
+        <field name="state" widget="statusbar" />
+    </header>
+
+    <sheet>
+        <div class="oe_button_box">
+            <button class="oe_stat_button" name="action_confirm" type="object">
+                <div class="o_field_widget o_stat_info">
+                    <span class="o_stat_value">
+                        <field name="readonly_store_field" />
+                    </span>
+                    <span class="o_stat_text">Readonly Field</span>
+                </div>
+            </button>
+        </div>
+
+        <group>
+            <group readonly="True">
+                <field name="inverse_field" />
+                <field name="readonly_non_store_field" readonly="True" />
+            </group>
+        </group>
+    </sheet>
+</form>""",
+            }
+        )
+
         # Create users:
         group_ids = cls.env.ref("base.group_system").ids
         cls.test_user_1 = cls.env["res.users"].create(
@@ -108,6 +159,7 @@ class CommonTierValidation(common.TransactionCase):
 
         cls.test_record = cls.test_model.create({"test_field": 1.0})
         cls.test_record_2 = cls.test_model_2.create({"test_field": 1.0})
+        cls.test_record_3 = cls.test_model_3.create({})
         cls.test_record_computed = cls.test_model_computed.create({"test_field": 1.0})
 
         cls.tier_def_obj.create(
@@ -158,6 +210,20 @@ class CommonTierValidation(common.TransactionCase):
                 "notify_on_pending": False,
                 "sequence": 20,
                 "name": "Definition for computed model",
+            }
+        )
+
+        # Create a tier definition for the readonly check
+        cls.tier_def_obj.create(
+            {
+                "model_id": cls.tester_model_3.id,
+                "review_type": "individual",
+                "reviewer_id": cls.test_user_1.id,
+                "definition_domain": "[]",
+                "approve_sequence": False,
+                "notify_on_pending": False,
+                "sequence": 10,
+                "name": 'Definition for test "readonly"',
             }
         )
 

--- a/base_tier_validation/tests/test_tier_validation.py
+++ b/base_tier_validation/tests/test_tier_validation.py
@@ -9,6 +9,7 @@ from lxml import etree
 from odoo.exceptions import ValidationError
 from odoo.tests import Form
 from odoo.tests.common import tagged
+from odoo.tools.safe_eval import safe_eval
 
 from ..models.tier_validation import BASE_EXCEPTION_FIELDS as BEF
 from ..models.tier_validation import TierValidation as TV
@@ -1055,3 +1056,92 @@ class TierTierValidationView(CommonTierValidation):
         self.assertIn("need_validation", view["models"][model])
         self.assertIn("next_review", view["models"][model])
         self.assertIn("review_ids", view["models"][model])
+
+    def test_readonly_field_view(self):
+        """
+        Tests that "readonly" fields are kept as read-only after installing the module.
+        """
+        view = self.test_record_3.get_view()
+
+        form = etree.fromstring(view["arch"])
+
+        # Checking that the readonly fields do contain a "readonly" evaluation.
+        self.assertTrue(
+            safe_eval(
+                form.xpath("//field[@name='readonly_non_store_field']")[0].attrib.get(
+                    "readonly"
+                ),
+                {**self.test_record_3.read()[0]},
+            )
+        )
+        self.assertTrue(
+            safe_eval(
+                form.xpath("//field[@name='readonly_store_field']")[0].attrib.get(
+                    "readonly"
+                ),
+                {**self.test_record_3.read()[0]},
+            )
+        )
+        self.assertFalse(
+            safe_eval(
+                form.xpath("//field[@name='inverse_field']")[0].attrib.get("readonly"),
+                {**self.test_record_3.read()[0]},
+            )
+        )
+
+        # Once the validation is triggered, this should cause all fields to be readonly
+        self.test_record_3.request_validation()
+        self.test_record_3.invalidate_recordset()
+
+        self.assertTrue(self.test_record_3.review_ids)
+
+        self.assertTrue(
+            safe_eval(
+                form.xpath("//field[@name='readonly_non_store_field']")[0].attrib.get(
+                    "readonly"
+                ),
+                {**self.test_record_3.read()[0]},
+            )
+        )
+        self.assertTrue(
+            safe_eval(
+                form.xpath("//field[@name='readonly_store_field']")[0].attrib.get(
+                    "readonly"
+                ),
+                {**self.test_record_3.read()[0]},
+            )
+        )
+        self.assertTrue(
+            safe_eval(
+                form.xpath("//field[@name='inverse_field']")[0].attrib.get("readonly"),
+                {**self.test_record_3.read()[0]},
+            )
+        )
+
+        # And, after validating, the field should maintaint their
+        #  readonly behavior.
+        self.test_record_3.validate_tier()
+        self.test_record_3.invalidate_recordset()
+
+        self.assertTrue(
+            safe_eval(
+                form.xpath("//field[@name='readonly_non_store_field']")[0].attrib.get(
+                    "readonly"
+                ),
+                {**self.test_record_3.read()[0]},
+            )
+        )
+        self.assertTrue(
+            safe_eval(
+                form.xpath("//field[@name='readonly_store_field']")[0].attrib.get(
+                    "readonly"
+                ),
+                {**self.test_record_3.read()[0]},
+            )
+        )
+        self.assertTrue(
+            safe_eval(
+                form.xpath("//field[@name='inverse_field']")[0].attrib.get("readonly"),
+                {**self.test_record_3.read()[0]},
+            )
+        )

--- a/base_tier_validation/tests/tier_validation_tester.py
+++ b/base_tier_validation/tests/tier_validation_tester.py
@@ -48,6 +48,62 @@ class TierValidationTester2(models.Model):
         self.write({"state": "confirmed"})
 
 
+class TierValidationTester3(models.Model):
+    _name = "tier.validation.tester3"
+    _description = "Tier Validation Tester 3"
+    _inherit = "tier.validation"
+    _tier_validation_manual_config = False
+
+    state = fields.Selection(
+        selection=[
+            ("draft", "Draft"),
+            ("confirmed", "Confirmed"),
+            ("cancel", "Cancel"),
+        ],
+        default="draft",
+    )
+
+    readonly_non_store_field = fields.Char(compute="_compute_readonly_non_store_field")
+    readonly_store_field = fields.Char(
+        compute="_compute_readonly_store_field", store=True
+    )
+    inverse_field = fields.Char(
+        compute="_compute_inverse_field", inverse="_inverse_inverse_field", store=True
+    )
+    inverse_counter = fields.Integer(string="Counter", default=0)
+
+    def _compute_readonly_non_store_field(self):
+        """
+        Assigns a default value to the non-store field.
+        """
+        for tester in self:
+            tester.readonly_non_store_field = "Default Value"
+
+    def _compute_readonly_field(self):
+        """
+        Assigns a default value, that the user won't be able to change in the views.
+        """
+        for tester in self:
+            tester.readonly_store_field = "Default Value"
+
+    def _compute_inverse_field(self):
+        """
+        Returns the readonly field value if none is present in the inverse field.
+        """
+        for tester in self:
+            tester.inverse_field = tester.readonly_field
+
+    def _inverse_inverse_field(self):
+        """
+        Any modification made to the field will increase by one the counter field
+        """
+        for tester in self:
+            tester.inverse_counter += 1
+
+    def action_confirm(self):
+        self.write({"state": "confirmed"})
+
+
 class TierValidationTesterComputed(models.Model):
     _name = "tier.validation.tester.computed"
     _description = "Tier Validation Tester Computed"
@@ -109,5 +165,6 @@ class TierDefinition(models.Model):
         res = super()._get_tier_validation_model_names()
         res.append("tier.validation.tester")
         res.append("tier.validation.tester2")
+        res.append("tier.validation.tester3")
         res.append("tier.validation.tester.computed")
         return res


### PR DESCRIPTION
The module `base_tier_validation` behaves strangely when computed fields are present. For example, the following screenshots come from a base installation of Odoo with the `sale_tier_validation` and `sale_purchase` module added, which causes the purchase order count to be editable when inside a smartbutton:

![image](https://github.com/user-attachments/assets/5e353f8c-7918-481c-b9d1-04d1841f61c2)

Or, when paired with the `sale_margin` module, it allows the editing of the margin when the field should be read-only:

![image](https://github.com/user-attachments/assets/4e4aa869-052b-4fec-9cd8-6a83cf286f3b)

This is because the base module doesn't take into account the read-onliness of the fields, especially computed fields. This PR should fix that behavior and add a test case to ensure the cases shown before remain patched.