### PR TITLE
[16.0][FIX] template_content_swapper: use _render()

### DIFF
--- a/template_content_swapper/README.rst
+++ b/template_content_swapper/README.rst
@@ -112,6 +112,17 @@ OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.
 
+.. |maintainer-yostashiro| image:: https://github.com/yostashiro.png?size=40px
+    :target: https://github.com/yostashiro
+    :alt: yostashiro
+.. |maintainer-AungKoKoLin1997| image:: https://github.com/AungKoKoLin1997.png?size=40px
+    :target: https://github.com/AungKoKoLin1997
+    :alt: AungKoKoLin1997
+
+Current `maintainers <https://odoo-community.org/page/maintainer-role>`__:
+
+|maintainer-yostashiro| |maintainer-AungKoKoLin1997| 
+
 This module is part of the `OCA/server-ux <https://github.com/OCA/server-ux/tree/16.0/template_content_swapper>`_ project on GitHub.
 
 You are welcome to contribute. To learn how please visit https://odoo-community.org/page/Contribute.

--- a/template_content_swapper/__manifest__.py
+++ b/template_content_swapper/__manifest__.py
@@ -12,5 +12,6 @@
         "security/ir.model.access.csv",
         "views/template_content_mapping_views.xml",
     ],
+    "maintainers": ["yostashiro", "AungKoKoLin1997"],
     "installable": True,
 }

--- a/template_content_swapper/models/__init__.py
+++ b/template_content_swapper/models/__init__.py
@@ -1,2 +1,2 @@
-from . import ir_ui_view
+from . import ir_qweb
 from . import template_content_mapping

--- a/template_content_swapper/models/ir_qweb.py
+++ b/template_content_swapper/models/ir_qweb.py
@@ -5,14 +5,19 @@ import re
 
 from markupsafe import Markup
 
-from odoo import models
+from odoo import api, models
+from odoo.tools.profiler import QwebTracker
 
 
-class IrUiView(models.Model):
-    _inherit = "ir.ui.view"
+class IrQWeb(models.AbstractModel):
+    _inherit = "ir.qweb"
 
-    def _render_template(self, template, values=None):
-        result = super()._render_template(template, values)
+    @QwebTracker.wrap_render
+    @api.model
+    def _render(self, template, values=None, **options):
+        result = super()._render(template, values=values, **options)
+        if not isinstance(template, str):
+            return result
         result_str = str(result)
         lang_code = "en_US"
         request = values.get("request")
@@ -24,7 +29,7 @@ class IrUiView(models.Model):
             lang_match = re.search(r'data-oe-lang="([^"]+)"', result_str)
             if lang_match:
                 lang_code = lang_match.group(1)
-        view = self._get(template).sudo()
+        view = self.env["ir.ui.view"]._get(template)
         content_mappings = (
             self.env["template.content.mapping"]
             .sudo()

--- a/template_content_swapper/static/description/index.html
+++ b/template_content_swapper/static/description/index.html
@@ -449,6 +449,8 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>
+<p>Current <a class="reference external" href="https://odoo-community.org/page/maintainer-role">maintainers</a>:</p>
+<p><a class="reference external image-reference" href="https://github.com/yostashiro"><img alt="yostashiro" src="https://github.com/yostashiro.png?size=40px" /></a> <a class="reference external image-reference" href="https://github.com/AungKoKoLin1997"><img alt="AungKoKoLin1997" src="https://github.com/AungKoKoLin1997.png?size=40px" /></a></p>
 <p>This module is part of the <a class="reference external" href="https://github.com/OCA/server-ux/tree/16.0/template_content_swapper">OCA/server-ux</a> project on GitHub.</p>
 <p>You are welcome to contribute. To learn how please visit <a class="reference external" href="https://odoo-community.org/page/Contribute">https://odoo-community.org/page/Contribute</a>.</p>
 </div>


### PR DESCRIPTION
Before this PR, when a user tried to swap the content of the survey questions page, it did not work because `_render_template` was called only once when the main page was opened.

This PR moves the content mapping logic from `_render_template` of `ir.ui.view` to `_render` of `ir.qweb`, which is used more consistently, ensuring content replacement works in all rendering scenarios.

@qrtl QT5304