### PR TITLE
[FIX] tier validation overrides readonly on form of readonly fields (…

### DIFF
--- a/base_tier_validation/__manifest__.py
+++ b/base_tier_validation/__manifest__.py
@@ -3,7 +3,7 @@
 {
     "name": "Base Tier Validation",
     "summary": "Implement a validation process based on tiers.",
-    "version": "18.0.1.1.0",
+    "version": "18.0.1.1.1",
     "development_status": "Mature",
     "maintainers": ["LoisRForgeFlow"],
     "category": "Tools",

--- a/base_tier_validation/models/tier_validation.py
+++ b/base_tier_validation/models/tier_validation.py
@@ -857,8 +857,13 @@ class TierValidation(models.AbstractModel):
                 node.append(new_node)
                 _merge_view_fields(all_models, new_models)
             excepted_fields = self._get_all_validation_exceptions()
+            readonly_fields = self.env['ir.model.fields'].search([('model', '=', self._name), ('readonly', '=', True)]).mapped('name')
             for node in doc.xpath("//field[@name][not(ancestor::field)]"):
                 if node.attrib.get("name") in excepted_fields:
+                    continue
+                if node.attrib.get("name") in readonly_fields and not node.attrib.get("readonly"):
+                    """Readonly field with readonly not set on form -> odoo will set this as readonly=True
+                    Make sure not to override"""
                     continue
                 new_r_modifier = self._get_tier_validation_readonly_domain()
                 old_r_modifier = node.attrib.get("readonly")


### PR DESCRIPTION
…computed fields for example)

Added a skip on adding the custom reaonly attribute on forms when the field is readonly (computed field for example), but the readonly attribute on the form is empty.
Without this Odoo wil not readonly=True on the fields because the custom readonly condition is set and readonly fields become writeable.