### PR TITLE
[16.0][IMP] base_tier_validation: Add message_main_attachment_id field to BASE_EXCEPTION_FIELDS

### DIFF
--- a/base_tier_validation/models/tier_validation.py
+++ b/base_tier_validation/models/tier_validation.py
@@ -12,7 +12,12 @@ from odoo.exceptions import ValidationError
 from odoo.osv.expression import OR
 from odoo.tools.misc import frozendict
 
-BASE_EXCEPTION_FIELDS = ["message_follower_ids", "access_token", "need_validation"]
+BASE_EXCEPTION_FIELDS = [
+    "message_main_attachment_id",
+    "message_follower_ids",
+    "access_token",
+    "need_validation",
+]
 
 
 class TierValidation(models.AbstractModel):


### PR DESCRIPTION
Add `message_main_attachment_id` field to BASE_EXCEPTION_FIELDS

Allow adding an attachment when validation has been requested

Please @pedrobaeza and @pilarvargas-tecnativa can you review it?

@Tecnativa TT56198