### PR TITLE
[16.0][IMP] base_tier_validation: Filter the definitions by all selected companies and by the company of record.

### DIFF
--- a/base_tier_validation/models/tier_definition.py
+++ b/base_tier_validation/models/tier_definition.py
@@ -111,6 +111,18 @@ class TierDefinition(models.Model):
                 .search([("model", "=", rec.model), ("relation", "=", "res.users")])
             )
 
+    def _get_domain_from_record(self, record):
+        domain = [
+            ("model", "=", record._name),
+            ("company_id", "in", [False] + self.env.companies.ids),
+        ]
+        # If the record has the company_id field and it is defined, we must take
+        # it into account to obtain only the definitions of that company, even if
+        # more companies are selected.
+        if "company_id" in list(record._fields.keys()) and record.company_id:
+            domain += [("company_id", "=", record.company_id.id)]
+        return domain
+
     def _get_review_needing_reminder(self):
         """Return all the reviews that have the reminder setup."""
         self.ensure_one()

--- a/base_tier_validation/models/tier_validation.py
+++ b/base_tier_validation/models/tier_validation.py
@@ -215,19 +215,13 @@ class TierValidation(models.AbstractModel):
             rec.next_review = review and _("Next: %s") % review.name or ""
 
     def _compute_is_reevaluation_required(self):
+        td_obj = self.env["tier.definition"]
         for rec in self:
             if isinstance(rec.id, models.NewId):
                 rec.is_reevaluation_required = False
                 continue
-            tiers = (
-                self.env["tier.definition"]
-                .with_context(active_test=True)
-                .search(
-                    [
-                        ("model", "=", self._name),
-                        ("company_id", "in", [False] + self.env.company.ids),
-                    ]
-                )
+            tiers = td_obj.with_context(active_test=True).search(
+                td_obj._get_domain_from_record(rec)
             )
             rec.is_reevaluation_required = False
             valid_tiers = tiers.filtered(lambda x: rec.evaluate_tier(x))
@@ -248,19 +242,13 @@ class TierValidation(models.AbstractModel):
         return any([s == "rejected" for s in reviews.mapped("status")])
 
     def _compute_need_validation(self):
+        td_obj = self.env["tier.definition"]
         for rec in self:
             if isinstance(rec.id, models.NewId):
                 rec.need_validation = False
                 continue
-            tiers = (
-                self.env["tier.definition"]
-                .with_context(active_test=True)
-                .search(
-                    [
-                        ("model", "=", self._name),
-                        ("company_id", "in", [False] + self.env.company.ids),
-                    ]
-                )
+            tiers = td_obj.with_context(active_test=True).search(
+                td_obj._get_domain_from_record(rec)
             )
             valid_tiers = tiers.filtered(lambda x: rec.evaluate_tier(x))
             requested_tiers = rec.review_ids.filtered(
@@ -285,7 +273,7 @@ class TierValidation(models.AbstractModel):
             .search(
                 [
                     ("model_name", "=", self._name),
-                    ("company_id", "in", [False] + self.env.company.ids),
+                    ("company_id", "in", [False] + self.env.companies.ids),
                     "|",
                     ("group_ids", "in", self.env.user.groups_id.ids),
                     ("group_ids", "=", False),
@@ -647,12 +635,10 @@ class TierValidation(models.AbstractModel):
         vals_list = []
         for rec in self:
             if rec._check_state_from_condition() and rec.need_validation:
+                domain = td_obj._get_domain_from_record(rec)
+                domain += [("id", "not in", rec.review_ids.mapped("definition_id").ids)]
                 tier_definitions = td_obj.search(
-                    [
-                        ("model", "=", self._name),
-                        ("company_id", "in", [False] + self.env.company.ids),
-                        ("id", "not in", rec.review_ids.mapped("definition_id").ids),
-                    ],
+                    domain,
                     order="sequence desc",
                 )
                 sequence = 0


### PR DESCRIPTION
Filter the definitions by all selected companies and by the company of record.

Example use case:
- There are several definitions (each linked to a different company).
- If a user has several companies selected at the same time, when requesting a validation, reviews should only be generated for the definitions of the corresponding company of record (purchase.order for example).

@Tecnativa TT56204