### PR TITLE
[18.0][IMP] base_tier_validation: Allow attachment generation after validation

### DIFF
--- a/base_tier_validation/models/tier_validation.py
+++ b/base_tier_validation/models/tier_validation.py
@@ -12,7 +12,11 @@ from odoo.exceptions import ValidationError
 from odoo.tools import SQL
 from odoo.tools.misc import frozendict
 
-BASE_EXCEPTION_FIELDS = ["message_follower_ids", "access_token"]
+BASE_EXCEPTION_FIELDS = [
+    "message_follower_ids",
+    "access_token",
+    "message_main_attachment_id",
+]
 
 
 class TierValidation(models.AbstractModel):


### PR DESCRIPTION
On a lot of models, it is a regular flow to have a pdf file generated after the validation flow has finished.
e.g. on sale orders or invoices.

As discovered / discussed in: https://github.com/OCA/account-invoicing/issues/1998#issuecomment-2862437855