### PR TITLE
[16.0][FIX] base_tier_validation: Proper notifications on reviews

### DIFF
--- a/base_tier_validation/data/mail_data.xml
+++ b/base_tier_validation/data/mail_data.xml
@@ -6,7 +6,7 @@
         forcecreate="1"
     >
         <field name="name">Tier Validation Requested</field>
-        <field name="default" eval="True" />
+        <field name="default" eval="False" />
         <field name="internal" eval="True" />
         <field name="hidden" eval="True" />
     </record>
@@ -16,7 +16,7 @@
         forcecreate="1"
     >
         <field name="name">Tier Validation Accepted Notification</field>
-        <field name="default" eval="True" />
+        <field name="default" eval="False" />
         <field name="internal" eval="True" />
         <field name="hidden" eval="True" />
     </record>
@@ -26,7 +26,7 @@
         forcecreate="1"
     >
         <field name="name">Tier Validation Rejected Notification</field>
-        <field name="default" eval="True" />
+        <field name="default" eval="False" />
         <field name="internal" eval="True" />
         <field name="hidden" eval="True" />
     </record>
@@ -36,7 +36,7 @@
         forcecreate="1"
     >
         <field name="name">Tier Validation Restarted</field>
-        <field name="default" eval="True" />
+        <field name="default" eval="False" />
         <field name="internal" eval="True" />
         <field name="hidden" eval="True" />
     </record>

--- a/base_tier_validation/models/tier_validation.py
+++ b/base_tier_validation/models/tier_validation.py
@@ -479,13 +479,29 @@ class TierValidation(models.AbstractModel):
         reviews_to_notify = user_reviews.filtered(
             lambda r: r.definition_id.notify_on_accepted
         )
+        # We need to notify all pending users if there is approve sequence
+        if tier_reviews and any(review.approve_sequence for review in tier_reviews):
+            reviews_to_notify = self.review_ids.filtered(
+                lambda r: r.status == "pending" and r.definition_id.notify_on_accepted
+            )
+            # If there are approve sequence, only the following should be
+            # considered to notify
+            if reviews_to_notify and any(
+                review.approve_sequence for review in reviews_to_notify
+            ):
+                reviews_to_notify = reviews_to_notify.filtered(
+                    lambda x: x.approve_sequence
+                )[0]
         if reviews_to_notify:
             subscribe = "message_subscribe"
             if hasattr(self, subscribe):
                 getattr(self, subscribe)(
                     partner_ids=reviews_to_notify.mapped("reviewer_ids")
                     .mapped("partner_id")
-                    .ids
+                    .ids,
+                    subtype_ids=self.env.ref(
+                        self._get_accepted_notification_subtype()
+                    ).ids,
                 )
             for review in reviews_to_notify:
                 rec = self.env[review.model].browse(review.res_id)
@@ -600,13 +616,29 @@ class TierValidation(models.AbstractModel):
         reviews_to_notify = user_reviews.filtered(
             lambda r: r.definition_id.notify_on_rejected
         )
+        # We need to notify all pending users if there is approve sequence
+        if tier_reviews and any(review.approve_sequence for review in tier_reviews):
+            reviews_to_notify = self.review_ids.filtered(
+                lambda r: r.status == "pending" and r.definition_id.notify_on_rejected
+            )
+            # If there are approve sequence, only the following should be
+            # considered to notify
+            if reviews_to_notify and any(
+                review.approve_sequence for review in reviews_to_notify
+            ):
+                reviews_to_notify = reviews_to_notify.filtered(
+                    lambda x: x.approve_sequence
+                )[0]
         if reviews_to_notify:
             subscribe = "message_subscribe"
             if hasattr(self, subscribe):
                 getattr(self, subscribe)(
                     partner_ids=reviews_to_notify.mapped("reviewer_ids")
                     .mapped("partner_id")
-                    .ids
+                    .ids,
+                    subtype_ids=self.env.ref(
+                        self._get_rejected_notification_subtype()
+                    ).ids,
                 )
             for review in reviews_to_notify:
                 rec = self.env[review.model].browse(review.res_id)
@@ -626,7 +658,10 @@ class TierValidation(models.AbstractModel):
                 # Subscribe reviewers and notify
                 if len(users_to_notify) > 0:
                     getattr(rec, subscribe)(
-                        partner_ids=users_to_notify.mapped("partner_id").ids
+                        partner_ids=users_to_notify.mapped("partner_id").ids,
+                        subtype_ids=self.env.ref(
+                            self._get_requested_notification_subtype()
+                        ).ids,
                     )
                     getattr(rec, post)(
                         subtype_xmlid=self._get_requested_notification_subtype(),
@@ -716,7 +751,12 @@ class TierValidation(models.AbstractModel):
                     lambda r: r.definition_id.notify_on_restarted
                 )
                 if hasattr(self, subscribe):
-                    getattr(self, subscribe)(partner_ids=partners_to_notify_ids)
+                    getattr(self, subscribe)(
+                        partner_ids=partners_to_notify_ids,
+                        subtype_ids=self.env.ref(
+                            self._get_restarted_notification_subtype()
+                        ).ids,
+                    )
                 rec._notify_restarted_review()
 
     def reevaluate_reviews(self):

--- a/base_tier_validation/tests/__init__.py
+++ b/base_tier_validation/tests/__init__.py
@@ -1,5 +1,4 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
-from . import common
 from . import test_tier_validation
 from . import test_tier_validation_reminder

--- a/base_tier_validation/tests/test_tier_validation.py
+++ b/base_tier_validation/tests/test_tier_validation.py
@@ -1050,6 +1050,159 @@ class TierTierValidation(CommonTierValidation):
 
         self.assertEqual(len(reviews), 2)
 
+    def test_30_request_validation(self):
+        # Create new test record
+        test_record = self.test_model.create({"test_field": 2.5})
+        # Create tier definitions for both tester models
+        self.tier_definition.write(
+            {
+                "approve_sequence": True,
+                "notify_on_create": True,
+            }
+        )
+        def_2 = self.tier_def_obj.create(
+            {
+                "model_id": self.tester_model.id,
+                "review_type": "individual",
+                "reviewer_id": self.test_user_2.id,
+                "sequence": 20,
+                "approve_sequence": True,
+                "notify_on_create": False,
+                "notify_on_accepted": True,
+            }
+        )
+        def_3 = self.tier_def_obj.create(
+            {
+                "model_id": self.tester_model.id,
+                "review_type": "individual",
+                "reviewer_id": self.test_user_3_multi_company.id,
+                "sequence": 10,
+                "approve_sequence": True,
+                "notify_on_create": False,
+                "notify_on_accepted": True,
+            }
+        )
+        mt_tier_validation_requested = self.env.ref(
+            "base_tier_validation.mt_tier_validation_requested"
+        )
+        mt_tier_validation_accepted = self.env.ref(
+            "base_tier_validation.mt_tier_validation_accepted"
+        )
+        test_record.request_validation()
+        review_1 = test_record.review_ids.filtered(
+            lambda x: x.definition_id == self.tier_definition
+        )
+        self.assertEqual(review_1.status, "pending")
+        review_2 = test_record.review_ids.filtered(lambda x: x.definition_id == def_2)
+        self.assertEqual(review_2.status, "pending")
+        review_3 = test_record.review_ids.filtered(lambda x: x.definition_id == def_3)
+        self.assertEqual(review_3.status, "pending")
+        followers = test_record.message_follower_ids
+        self.assertIn(self.test_user_1.partner_id, followers.mapped("partner_id"))
+        follower_1 = followers.filtered(
+            lambda x: x.partner_id == self.test_user_1.partner_id
+        )
+        self.assertIn(mt_tier_validation_requested, follower_1.subtype_ids)
+        self.assertNotIn(mt_tier_validation_accepted, follower_1.subtype_ids)
+        self.assertNotIn(self.test_user_2.partner_id, followers.mapped("partner_id"))
+        self.assertNotIn(
+            self.test_user_3_multi_company.partner_id, followers.mapped("partner_id")
+        )
+        old_messages = test_record.message_ids
+        test_record.with_user(self.test_user_1).validate_tier()
+        new_messages = test_record.message_ids - old_messages
+        self.assertEqual(len(new_messages), 1)
+        self.assertEqual(new_messages.subtype_id, mt_tier_validation_accepted)
+        self.assertEqual(self.test_user_2.partner_id, new_messages.notified_partner_ids)
+        self.assertEqual(review_1.status, "approved")
+        self.assertEqual(review_2.status, "pending")
+        self.assertEqual(review_3.status, "pending")
+        followers = test_record.message_follower_ids
+        self.assertIn(self.test_user_1.partner_id, followers.mapped("partner_id"))
+        self.assertIn(self.test_user_2.partner_id, followers.mapped("partner_id"))
+        follower_2 = followers.filtered(
+            lambda x: x.partner_id == self.test_user_2.partner_id
+        )
+        self.assertNotIn(mt_tier_validation_requested, follower_2.subtype_ids)
+        self.assertIn(mt_tier_validation_accepted, follower_2.subtype_ids)
+        self.assertNotIn(
+            self.test_user_3_multi_company.partner_id, followers.mapped("partner_id")
+        )
+        old_messages = test_record.message_ids
+        test_record.with_user(self.test_user_2).validate_tier()
+        new_messages = test_record.message_ids - old_messages
+        self.assertEqual(len(new_messages), 1)
+        self.assertEqual(new_messages.subtype_id, mt_tier_validation_accepted)
+        self.assertEqual(
+            self.test_user_3_multi_company.partner_id, new_messages.notified_partner_ids
+        )
+        self.assertEqual(review_1.status, "approved")
+        self.assertEqual(review_2.status, "approved")
+        self.assertEqual(review_3.status, "pending")
+        followers = test_record.message_follower_ids
+        self.assertIn(self.test_user_1.partner_id, followers.mapped("partner_id"))
+        self.assertIn(self.test_user_2.partner_id, followers.mapped("partner_id"))
+        self.assertIn(
+            self.test_user_3_multi_company.partner_id, followers.mapped("partner_id")
+        )
+        follower_3 = followers.filtered(
+            lambda x: x.partner_id == self.test_user_3_multi_company.partner_id
+        )
+        self.assertNotIn(mt_tier_validation_requested, follower_3.subtype_ids)
+        self.assertIn(mt_tier_validation_accepted, follower_3.subtype_ids)
+        old_messages = test_record.message_ids
+        test_record.with_user(self.test_user_3_multi_company).validate_tier()
+        new_messages = test_record.message_ids - old_messages
+        self.assertEqual(len(new_messages), 0)
+
+    def test_31_request_validation(self):
+        # Create new test record
+        test_record = self.test_model.create({"test_field": 2.5})
+        # Create tier definitions for both tester models
+        self.tier_definition.write(
+            {
+                "approve_sequence": True,
+                "notify_on_create": True,
+            }
+        )
+        def_2 = self.tier_def_obj.create(
+            {
+                "model_id": self.tester_model.id,
+                "review_type": "individual",
+                "reviewer_id": self.test_user_2.id,
+                "sequence": 20,
+                "approve_sequence": True,
+                "notify_on_create": True,
+                "notify_on_accepted": True,
+            }
+        )
+        def_3 = self.tier_def_obj.create(
+            {
+                "model_id": self.tester_model.id,
+                "review_type": "individual",
+                "reviewer_id": self.test_user_3_multi_company.id,
+                "sequence": 10,
+                "approve_sequence": True,
+                "notify_on_create": True,
+                "notify_on_accepted": True,
+            }
+        )
+        test_record.request_validation()
+        review_1 = test_record.review_ids.filtered(
+            lambda x: x.definition_id == self.tier_definition
+        )
+        self.assertEqual(review_1.status, "pending")
+        review_2 = test_record.review_ids.filtered(lambda x: x.definition_id == def_2)
+        self.assertEqual(review_2.status, "pending")
+        review_3 = test_record.review_ids.filtered(lambda x: x.definition_id == def_3)
+        self.assertEqual(review_3.status, "pending")
+        followers = test_record.message_follower_ids
+        self.assertIn(self.test_user_1.partner_id, followers.mapped("partner_id"))
+        self.assertIn(self.test_user_2.partner_id, followers.mapped("partner_id"))
+        self.assertIn(
+            self.test_user_3_multi_company.partner_id, followers.mapped("partner_id")
+        )
+
 
 @tagged("at_install")
 class TierTierValidationView(CommonTierValidation):


### PR DESCRIPTION
Proper notifications on reviews

Changes done:
- The subtypes should not be defined as default=True to avoid that a follower receives notifications of everything (even if he/she doesn't really need it).
- When adding followers they are added to the corresponding subtype so that the notification arrives to whom it corresponds.
- Improve the code so that the reviews to notify are the "following ones according to the sequence".

@Tecnativa TT56354