### PR TITLE
[16.0][FIX] base_search_custom_field_filter: Avoid hiding model fields in other parts of the UI

### DIFF
--- a/base_search_custom_field_filter/README.rst
+++ b/base_search_custom_field_filter/README.rst
@@ -121,10 +121,13 @@ promote its widespread use.
 .. |maintainer-pedrobaeza| image:: https://github.com/pedrobaeza.png?size=40px
     :target: https://github.com/pedrobaeza
     :alt: pedrobaeza
+.. |maintainer-CarlosRoca13| image:: https://github.com/CarlosRoca13.png?size=40px
+    :target: https://github.com/CarlosRoca13
+    :alt: CarlosRoca13
 
-Current `maintainer <https://odoo-community.org/page/maintainer-role>`__:
+Current `maintainers <https://odoo-community.org/page/maintainer-role>`__:
 
-|maintainer-pedrobaeza| 
+|maintainer-pedrobaeza| |maintainer-CarlosRoca13| 
 
 This module is part of the `OCA/server-ux <https://github.com/OCA/server-ux/tree/16.0/base_search_custom_field_filter>`_ project on GitHub.
 

--- a/base_search_custom_field_filter/__manifest__.py
+++ b/base_search_custom_field_filter/__manifest__.py
@@ -16,5 +16,5 @@
     "depends": ["web"],
     "license": "AGPL-3",
     "installable": True,
-    "maintainers": ["pedrobaeza"],
+    "maintainers": ["pedrobaeza", "CarlosRoca13"],
 }

--- a/base_search_custom_field_filter/models/base.py
+++ b/base_search_custom_field_filter/models/base.py
@@ -53,8 +53,11 @@ class Base(models.AbstractModel):
             field = custom_filter._get_related_field()
             field_name = custom_filter.expression
             res["models"][self._name][field_name] = field.get_description(self.env)
-            # force this for avoiding to appear on the rest of the UI
-            res["models"][self._name][field_name]["selectable"] = False
-            res["models"][self._name][field_name]["sortable"] = False
-            res["models"][self._name][field_name]["store"] = False
+            # The fields of the current model still need to work with group by, so just hide
+            # the fields that has different model_name than self._name.
+            if field.model_name != self._name:
+                # force this for avoiding to appear on the rest of the UI
+                res["models"][self._name][field_name]["selectable"] = False
+                res["models"][self._name][field_name]["sortable"] = False
+                res["models"][self._name][field_name]["store"] = False
         return res

--- a/base_search_custom_field_filter/static/description/index.html
+++ b/base_search_custom_field_filter/static/description/index.html
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
@@ -9,10 +8,11 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
+:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
+Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -275,7 +275,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: grey; } /* line numbers */
+pre.code .ln { color: gray; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -301,7 +301,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic {
+span.problematic, pre.problematic {
   color: red }
 
 span.section-subtitle {
@@ -456,12 +456,14 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-7">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
+<a class="reference external image-reference" href="https://odoo-community.org">
+<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
+</a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>
-<p>Current <a class="reference external" href="https://odoo-community.org/page/maintainer-role">maintainer</a>:</p>
-<p><a class="reference external image-reference" href="https://github.com/pedrobaeza"><img alt="pedrobaeza" src="https://github.com/pedrobaeza.png?size=40px" /></a></p>
+<p>Current <a class="reference external" href="https://odoo-community.org/page/maintainer-role">maintainers</a>:</p>
+<p><a class="reference external image-reference" href="https://github.com/pedrobaeza"><img alt="pedrobaeza" src="https://github.com/pedrobaeza.png?size=40px" /></a> <a class="reference external image-reference" href="https://github.com/CarlosRoca13"><img alt="CarlosRoca13" src="https://github.com/CarlosRoca13.png?size=40px" /></a></p>
 <p>This module is part of the <a class="reference external" href="https://github.com/OCA/server-ux/tree/16.0/base_search_custom_field_filter">OCA/server-ux</a> project on GitHub.</p>
 <p>You are welcome to contribute. To learn how please visit <a class="reference external" href="https://odoo-community.org/page/Contribute">https://odoo-community.org/page/Contribute</a>.</p>
 </div>


### PR DESCRIPTION
Before these changes, if a model field was added to the custom filters, it would become disabled in other parts of the interface — for example, when trying to group by that field.

After these changes, the filter for the simple field is added while preserving the ability to group by it. Only fields that don't belong to the data model itself — that is, those using '.' notation — are hidden.

cc @Tecnativa TT56518

ping @pedrobaeza @pilarvargas-tecnativa 