### PR TITLE
[18.0][FIX] base_tier_validation: fix reviewer field check

### DIFF
--- a/base_tier_validation/models/tier_review.py
+++ b/base_tier_validation/models/tier_review.py
@@ -153,10 +153,42 @@ class TierReview(models.Model):
         reviewer_field = self.env["res.users"]
         if self.reviewer_field_id:
             resource = self.env[self.model].browse(self.res_id)
-            reviewer_field = getattr(resource, self.reviewer_field_id.name, False)
-            if not reviewer_field or not reviewer_field._name == "res.users":
+            field_name = self.reviewer_field_id.name
+            no_field_on_model = field_name not in resource._fields
+            if no_field_on_model:
+                msg = self.env._(
+                    "There are no field %(field_name)s on the %(model_name)s model",
+                )
                 raise ValidationError(
-                    self.env._("There are no res.users in the selected field")
+                    msg % {"field_name": field_name, "model_name": resource._name}
+                )
+
+            reviewer_field = resource[field_name]
+            if not isinstance(reviewer_field, models.Model):
+                msg = self.env._(
+                    "Field %(field_name)s on %(model_name)s should be "
+                    "'res.users' but is %(actual_model_type)s"
+                )
+                raise ValidationError(
+                    msg
+                    % {
+                        "field_name": field_name,
+                        "model_name": resource._name,
+                        "actual_model_type": type(reviewer_field),
+                    }
+                )
+            if not reviewer_field._name == "res.users":
+                msg = self.env._(
+                    "Field %(field_name)s on %(model_name)s should be "
+                    "'res.users' but is %(actual_model_name)s"
+                )
+                raise ValidationError(
+                    msg
+                    % {
+                        "field_name": field_name,
+                        "model_name": resource._name,
+                        "actual_model_name": reviewer_field._name,
+                    }
                 )
         return reviewer_field
 

--- a/base_tier_validation/tests/test_tier_validation.py
+++ b/base_tier_validation/tests/test_tier_validation.py
@@ -1234,6 +1234,42 @@ class TierTierValidation(CommonTierValidation):
             self.test_user_3_multi_company.partner_id, followers.mapped("partner_id")
         )
 
+    def test_reviwer_wrong_field(self):
+        test_record = self.test_record.with_user(self.test_user_2)
+        # Force reviewer to be picked from resource[reviewer_field_id]
+        tier_definition = self.tier_definition
+        tier_definition.reviewer_id = False
+        tier_definition.reviewer_group_id = False
+        # If referenced field is not res.user, raise an exception
+        test_field = self.env["ir.model.fields"].search(
+            [("model", "=", "tier.validation.tester"), ("name", "=", "test_field")]
+        )
+        tier_definition.reviewer_field_id = test_field.id
+        regex = (
+            "Field test_field on tier.validation.tester should "
+            "be 'res.users' but is <class 'float'>"
+        )
+        # pylint: disable=pointless-statement
+        with self.assertRaisesRegex(ValidationError, regex):
+            review = test_record.request_validation()
+            review.reviewer_ids  # noqa: B018
+
+    def test_reviwer_field_empty(self):
+        test_record = self.test_record.with_user(self.test_user_2)
+        # Force reviewer to be picked from resource[reviewer_field_id]
+        tier_definition = self.tier_definition
+        tier_definition.reviewer_id = False
+        tier_definition.reviewer_group_id = False
+
+        # If reviewer field is empty, ok
+        user_field = self.env["ir.model.fields"].search(
+            [("model", "=", "tier.validation.tester"), ("name", "=", "user_id")]
+        )
+        tier_definition.reviewer_field_id = user_field.id
+        test_record.user_id = False
+        review = test_record.request_validation()
+        self.assertFalse(review.reviewer_ids)
+
 
 @tagged("at_install")
 class TierTierValidationView(CommonTierValidation):


### PR DESCRIPTION
Raises a misleading exception when reviewer field is correctly set, but is empty on the record.
Put this as draft / WIP as there's another exception raised once this is fixed that I need to tackle next.