### PR TITLE
[17.0][FIX] base_tier_validation: make ReviewsTable widget work with manual config

### DIFF
--- a/base_tier_validation/static/src/components/tier_review_widget/tier_review_widget.esm.js
+++ b/base_tier_validation/static/src/components/tier_review_widget/tier_review_widget.esm.js
@@ -35,6 +35,19 @@ ReviewsTable.template = "base_tier_validation.Collapse";
 
 export const reviewsTableComponent = {
     component: ReviewsTable,
+    supportedTypes: ["one2many"],
+    relatedFields: [
+        {name: "id", type: "integer"},
+        {name: "sequence", type: "integer"},
+        {name: "name", type: "char"},
+        {name: "display_status", type: "char"},
+        {name: "todo_by", type: "char"},
+        {name: "status", type: "char"},
+        {name: "reviewed_formated_date", type: "char"},
+        {name: "comment", type: "char"},
+        {name: "requested_by", type: "many2one", relation: "partner"},
+        {name: "done_by", type: "many2one", relation: "partner"},
+    ],
 };
 
 registry.category("fields").add("form.tier_validation", reviewsTableComponent);


### PR DESCRIPTION
When an Odoo model inherits from `tier.validation` but sets up `_tier_validation_manual_config = True` in the model class, adding `review_ids` in the model form view with `widget="tier_validation"` causes Owl errors on rendering when at least one review is linked to the model:

![2025-06-20_14-13](https://github.com/user-attachments/assets/102c4e8a-293a-4997-add0-4671ee017d42)

This fix adds the fields used in the `base_tier_validation.Collapse` widget template to the relevant component under the `relatedFields` key (which is what Odoo does with the Many2ManyTags widget, and where i got the idea to try this), which solves the issue while not changing the existing behavior for models using `_tier_validation_manual_config = False`.

I've made a small Odoo module that allows to quickly reproduce the issue since it asks for a bit of setup. It's available [here](https://github.com/MaxyMoos/base_tier_validation_test_module)