### PR TITLE
[16.0][FIX] base_tier_validation: add field attrs references

### DIFF
--- a/base_tier_validation/templates/tier_validation_templates.xml
+++ b/base_tier_validation/templates/tier_validation_templates.xml
@@ -2,6 +2,7 @@
 <odoo>
     <template id="tier_validation_buttons">
         <div>
+            <field name="validation_status" invisible="1" />
             <button
                 name="request_validation"
                 string="Request Validation"


### PR DESCRIPTION
since #1040, the request validation button is visible for records that have already validation request, because the new condition introduced there isn't added to the form by default (forms that have the field through other means won't suffer from this):

![image](https://github.com/user-attachments/assets/6a2433a6-e574-4a85-8d8e-ed319c3827e6)


You can check this on [runbot](http://oca-account-invoicing-16-0-d4443b512f89.runboat.odoo-community.org/web?debug=1#id=6&cids=1&menu_id=115&action=233&model=account.move&view_type=form) as long as the instance is alive.