### PR TITLE
[FIX] server_action_mass_edit: add onchange method for selection__ te…

### DIFF
--- a/server_action_mass_edit/tests/test_mass_editing.py
+++ b/server_action_mass_edit/tests/test_mass_editing.py
@@ -388,6 +388,21 @@ class TestMassEditing(common.TransactionCase):
         mass_edit_line_form.field_id = self.env.ref("base.field_res_users__country_id")
         self.assertFalse(mass_edit_line_form.widget_option)
 
+    def test_onchange_call(self):
+        """Onchange call does not error on dynamically added fields"""
+        self.env["mass.editing.wizard"].with_context(
+            active_ids=self.env.user.ids,
+            active_model=self.env.user._name,
+            server_action_id=self.mass_editing_user.id,
+        ).onchange(
+            values={},
+            field_names={},
+            fields_spec={
+                "selection__email": {},
+                "email": {},
+            },
+        )
+
     def test_onchange_model_id(self):
         """Test super call of `_onchange_model_id`"""
 

--- a/server_action_mass_edit/wizard/mass_editing_wizard.py
+++ b/server_action_mass_edit/wizard/mass_editing_wizard.py
@@ -69,6 +69,56 @@ class MassEditingWizard(models.TransientModel):
 
         return res
 
+    def onchange(self, values, field_names, fields_spec):
+        # Make sure the values passed to the super cover the dynamic fields.
+        # No onchanges are defined, but Odoo will call the onchange with empty
+        # values for all fields when opening the wizard form view.
+        first_call = not field_names
+        if first_call:
+            field_names = [fname for fname in values if fname != "id"]
+            missing_names = [fname for fname in fields_spec if fname not in values]
+            defaults = self.default_get(missing_names)
+            for field_name in missing_names:
+                values[field_name] = defaults.get(field_name, False)
+                if field_name in defaults:
+                    field_names.append(field_name)
+
+        server_action_id = self.env.context.get("server_action_id")
+        server_action = self.env["ir.actions.server"].sudo().browse(server_action_id)
+        if not server_action:
+            return super().onchange(values, field_names, fields_spec)
+        dynamic_fields = {}
+
+        for line in server_action.mapped("mass_edit_line_ids"):
+            values["selection__" + line.field_id.name] = "ignore"
+            values[line.field_id.name] = False
+
+            # Make sure there is an entry for the default value retrieved above.
+            dynamic_fields["selection__" + line.field_id.name] = fields.Selection(
+                [("ignore", _("Don't touch"))], default="ignore"
+            )
+            dynamic_fields[line.field_id.name] = fields.Text([()], default=False)
+
+        self._fields.update(dynamic_fields)
+
+        res = super().onchange(values, field_names, fields_spec)
+        if not res["value"]:
+            value = {key: value for key, value in values.items() if value is not False}
+            res["value"] = value
+
+        for field in dynamic_fields:
+            self._fields.pop(field)
+
+        view_temp = (
+            self.env["ir.ui.view"]
+            .sudo()
+            .search([("name", "=", "Temporary Mass Editing Wizard")], limit=1)
+        )
+        if view_temp:
+            view_temp.unlink()
+
+        return res
+
     @api.model
     def _prepare_fields(self, line, field, field_info):
         result = {}

--- a/server_action_mass_edit_onchange/wizard/mass_editing_wizard.py
+++ b/server_action_mass_edit_onchange/wizard/mass_editing_wizard.py
@@ -24,53 +24,6 @@ class MassEditingWizard(models.TransientModel):
         )
         return res
 
-    def onchange(self, values, field_names, fields_spec):
-        first_call = not field_names
-        if first_call:
-            field_names = [fname for fname in values if fname != "id"]
-            missing_names = [fname for fname in fields_spec if fname not in values]
-            defaults = self.default_get(missing_names)
-            for field_name in missing_names:
-                values[field_name] = defaults.get(field_name, False)
-                if field_name in defaults:
-                    field_names.append(field_name)
-
-        server_action_id = self.env.context.get("server_action_id")
-        server_action = self.env["ir.actions.server"].sudo().browse(server_action_id)
-        if not server_action:
-            return super().onchange(values, field_names, fields_spec)
-        dynamic_fields = {}
-
-        for line in server_action.mapped("mass_edit_line_ids"):
-            values["selection__" + line.field_id.name] = "ignore"
-            values[line.field_id.name] = False
-
-            dynamic_fields["selection__" + line.field_id.name] = fields.Selection(
-                [], default="ignore"
-            )
-
-            dynamic_fields[line.field_id.name] = fields.Text([()], default=False)
-
-        self._fields.update(dynamic_fields)
-
-        res = super().onchange(values, field_names, fields_spec)
-        if not res["value"]:
-            value = {key: value for key, value in values.items() if value is not False}
-            res["value"] = value
-
-        for field in dynamic_fields:
-            self._fields.pop(field)
-
-        view_temp = (
-            self.env["ir.ui.view"]
-            .sudo()
-            .search([("name", "=", "Temporary Mass Editing Wizard")], limit=1)
-        )
-        if view_temp:
-            view_temp.unlink()
-
-        return res
-
     def _exec_write(self, server_action, vals):
         active_ids = self.env.context.get("active_ids", [])
         model = self.env[server_action.model_id.model].with_context(mass_edit=True)


### PR DESCRIPTION
Fixes https://github.com/OCA/server-ux/issues/1095

```
File "/home/odoo/src/odoo/addons/web/models/models.py", line 883, in onchange
field = self._fields[field_name]
~~~~~~~~~~~~^^^^^^^^^^^^
KeyError: 'selection__scheduled_date'
```

When clicking on the action on the model Gear menu we had this
Put back the onchange from 17.0 + edits on line 94
