### PR TITLE
[RFC][18.0][IMP] base_tier_validation: cleanup rejected/validated fields, remove extraneous functions

### DIFF
--- a/base_tier_validation/README.rst
+++ b/base_tier_validation/README.rst
@@ -66,16 +66,16 @@ To configure this module, you need to:
 
 **Note:**
 
-- If check *Notify Reviewers on Creation*, all possible reviewers will
-  be notified by email when this definition is triggered.
-- If check *Notify reviewers on reaching pending* if you want to send a
-  notification when pending status is reached. This is usefull in a
-  approve by sequence scenario to only notify reviewers when it is their
-  turn in the sequence.
-- If check *Comment*, reviewers can comment after click Validate or
-  Reject.
-- If check *Approve by sequence*, reviewers is forced to review by
-  specified sequence.
+-  If check *Notify Reviewers on Creation*, all possible reviewers will
+   be notified by email when this definition is triggered.
+-  If check *Notify reviewers on reaching pending* if you want to send a
+   notification when pending status is reached. This is usefull in a
+   approve by sequence scenario to only notify reviewers when it is
+   their turn in the sequence.
+-  If check *Comment*, reviewers can comment after click Validate or
+   Reject.
+-  If check *Approve by sequence*, reviewers is forced to review by
+   specified sequence.
 
 To configure Tier Validation Exceptions, you need to:
 
@@ -90,14 +90,16 @@ To configure Tier Validation Exceptions, you need to:
 
 **Note:**
 
-- If you don't create any exception, the Validated record will be
-  readonly and cannot be modified.
-- If check *Write under Validation*, records will be able to be modified
-  only in the defined fields when the Validation process is ongoing.
-- If check *Write after Validation*, records will be able to be modified
-  only in the defined fields when the Validation process is finished.
-- If check *Write after Validation* and *Write under Validation*,
-  records will be able to be modified defined fields always.
+-  If you don't create any exception, the Validated record will be
+   readonly and cannot be modified.
+-  If check *Write under Validation*, records will be able to be
+   modified only in the defined fields when the Validation process is
+   ongoing.
+-  If check *Write after Validation*, records will be able to be
+   modified only in the defined fields when the Validation process is
+   finished.
+-  If check *Write after Validation* and *Write under Validation*,
+   records will be able to be modified defined fields always.
 
 Known issues / Roadmap
 ======================
@@ -105,25 +107,25 @@ Known issues / Roadmap
 This is the list of known issues for this module. Any proposal for
 improvement will be very valuable.
 
-- **Issue:**
+-  **Issue:**
 
-  When using approve_sequence option in any tier.definition there can be
-  inconsistencies in the systray notifications.
+   When using approve_sequence option in any tier.definition there can
+   be inconsistencies in the systray notifications.
 
-  **Description:**
+   **Description:**
 
-  Field can_review in tier.review is used to filter out, in the systray
-  notifications, the reviews a user can approve. This can_review field
-  is updated **in the database** in method review_user_count, this can
-  make it very inconsistent for databases with a lot of users and
-  recurring updates that can change the expected behavior.
+   Field can_review in tier.review is used to filter out, in the systray
+   notifications, the reviews a user can approve. This can_review field
+   is updated **in the database** in method review_user_count, this can
+   make it very inconsistent for databases with a lot of users and
+   recurring updates that can change the expected behavior.
 
-- **Migration to 15.0:**
+-  **Migration to 15.0:**
 
-  The parameter \_tier_validation_manual_config will become False, on
-  14.0, the default value is True, as the change is applied after the
-  migration. In order to use the new behavior we need to modify the
-  value on our expected model.
+   The parameter \_tier_validation_manual_config will become False, on
+   14.0, the default value is True, as the change is applied after the
+   migration. In order to use the new behavior we need to modify the
+   value on our expected model.
 
 Changelog
 =========
@@ -145,69 +147,69 @@ Migrated to Odoo 14.
 
 Fixes:
 
-- When using approve_sequence option in any tier.definition there can be
-  inconsistencies in the systray notifications
-- When using approve_sequence, still not approve only the needed
-  sequence, but also other sequence for the same approver
+-  When using approve_sequence option in any tier.definition there can
+   be inconsistencies in the systray notifications
+-  When using approve_sequence, still not approve only the needed
+   sequence, but also other sequence for the same approver
 
 12.0.3.3.1 (2019-12-02)
 -----------------------
 
 Fixes:
 
-- Show comment on Reviews Table.
-- Edit notification with approve_sequence.
+-  Show comment on Reviews Table.
+-  Edit notification with approve_sequence.
 
 12.0.3.3.0 (2019-11-27)
 -----------------------
 
 New features:
 
-- Add comment on Reviews Table.
-- Approve by sequence.
+-  Add comment on Reviews Table.
+-  Approve by sequence.
 
 12.0.3.2.1 (2019-11-26)
 -----------------------
 
 Fixes:
 
-- Remove message_subscribe_users
+-  Remove message_subscribe_users
 
 12.0.3.2.0 (2019-11-25)
 -----------------------
 
 New features:
 
-- Notify reviewers
+-  Notify reviewers
 
 12.0.3.1.0 (2019-07-08)
 -----------------------
 
 Fixes:
 
-- Singleton error
+-  Singleton error
 
 12.0.3.0.0 (2019-12-02)
 -----------------------
 
 Fixes:
 
-- Edit Reviews Table
+-  Edit Reviews Table
 
 12.0.2.1.0 (2019-05-29)
 -----------------------
 
 Fixes:
 
-- Edit drop-down style width and position
+-  Edit drop-down style width and position
 
 12.0.2.0.0 (2019-05-28)
 -----------------------
 
 New features:
 
-- Pass parameters as functions.
-- Add Systray.
+-  Pass parameters as functions.
+-  Add Systray.
 
 12.0.1.0.0 (2019-02-18)
 -----------------------
@@ -250,26 +252,26 @@ Authors
 Contributors
 ------------
 
-- Lois Rilo <lois.rilo@forgeflow.com>
-- Naglis Jonaitis <naglis@versada.eu>
-- Adrià Gil Sorribes <adria.gil@forgeflow.com>
-- Pimolnat Suntian <pimolnats@ecosoft.co.th>
-- Pedro Gonzalez <pedro.gonzalez@pesol.es>
-- Kitti U. <kittiu@ecosoft.co.th>
-- Saran Lim. <saranl@ecosoft.co.th>
-- Carlos Lopez <celm1990@gmail.com>
-- Javier Colmeiro <javier.colmeiro@braintec.com>
-- bosd
-- Evan Soh <evan.soh@omnisoftsolution.com>
-- Manuel Regidor <manuel.regidor@sygel.es>
-- Eduardo de Miguel <edu@moduon.team>
-- `XCG Consulting <https://xcg-consulting.fr>`__:
+-  Lois Rilo <lois.rilo@forgeflow.com>
+-  Naglis Jonaitis <naglis@versada.eu>
+-  Adrià Gil Sorribes <adria.gil@forgeflow.com>
+-  Pimolnat Suntian <pimolnats@ecosoft.co.th>
+-  Pedro Gonzalez <pedro.gonzalez@pesol.es>
+-  Kitti U. <kittiu@ecosoft.co.th>
+-  Saran Lim. <saranl@ecosoft.co.th>
+-  Carlos Lopez <celm1990@gmail.com>
+-  Javier Colmeiro <javier.colmeiro@braintec.com>
+-  bosd
+-  Evan Soh <evan.soh@omnisoftsolution.com>
+-  Manuel Regidor <manuel.regidor@sygel.es>
+-  Eduardo de Miguel <edu@moduon.team>
+-  `XCG Consulting <https://xcg-consulting.fr>`__:
 
-  - Houzéfa Abbasbhay
+   -  Houzéfa Abbasbhay
 
-- Stefan Rijnhart <stefan@opener.amsterdam>
-- Kevin Khao <kevinkhao@gmail.com>
-- Do Anh Duy <duyda@trobz.com>
+-  Stefan Rijnhart <stefan@opener.amsterdam>
+-  Kevin Khao <kevinkhao@gmail.com>
+-  Do Anh Duy <duyda@trobz.com>
 
 Other credits
 -------------

--- a/base_tier_validation/__manifest__.py
+++ b/base_tier_validation/__manifest__.py
@@ -3,7 +3,7 @@
 {
     "name": "Base Tier Validation",
     "summary": "Implement a validation process based on tiers.",
-    "version": "18.0.1.1.3",
+    "version": "18.0.1.1.4",
     "development_status": "Mature",
     "maintainers": ["LoisRForgeFlow"],
     "category": "Tools",

--- a/base_tier_validation/models/res_users.py
+++ b/base_tier_validation/models/res_users.py
@@ -29,7 +29,7 @@ class Users(models.Model):
             if tier_review and hasattr(Model, "can_review"):
                 records_domain = [
                     ("id", "in", tier_review.mapped("res_id")),
-                    ("rejected", "=", False),
+                    ("validation_status", "!=", "rejected"),
                     ("can_review", "=", True),
                 ]
                 records = (

--- a/base_tier_validation/models/tier_validation.py
+++ b/base_tier_validation/models/tier_validation.py
@@ -43,8 +43,6 @@ class TierValidation(models.AbstractModel):
         domain=lambda self: [("model", "=", self._name)],
         auto_join=True,
     )
-    validated_message = fields.Html(compute="_compute_validated_rejected")
-    rejected_message = fields.Html(compute="_compute_validated_rejected")
     need_validation = fields.Boolean(compute="_compute_need_validation")
     validation_status = fields.Selection(
         selection=[
@@ -141,36 +139,6 @@ class TierValidation(models.AbstractModel):
             ]
         )
         return [("id", model_operator, list(set(reviews.mapped("res_id"))))]
-
-    def _get_to_validate_message_name(self):
-        return self._description
-
-    def _get_to_validate_message(self):
-        return f"""<i class="fa fa-info-circle"></i> {self.env._(
-            "This %s needs to be validated",
-            self._get_to_validate_message_name()
-        )}"""
-
-    def _get_validated_message(self):
-        msg = f"""<i class="fa fa-thumbs-up"></i> {self.env._(
-            "Operation has been <b>validated</b>!"
-        )}"""
-        return self.validated and msg or ""
-
-    def _get_rejected_message(self):
-        msg = f"""<i class="fa fa-thumbs-down"></i> {self.env._(
-            "Operation has been <b>rejected</b>."
-        )}"""
-        return self.rejected and msg or ""
-
-    def _get_to_validate_message_name(self):
-        return self._description
-
-    def _get_to_validate_message(self):
-        return f"""<i class="fa fa-info-circle"></i> {self.env._(
-            "This %s needs to be validated",
-            self._get_to_validate_message_name()
-        )}"""
 
     @api.depends("review_ids", "review_ids.status")
     def _compute_validation_status(self):

--- a/base_tier_validation/models/tier_validation.py
+++ b/base_tier_validation/models/tier_validation.py
@@ -16,6 +16,9 @@ BASE_EXCEPTION_FIELDS = [
     "message_follower_ids",
     "access_token",
     "message_main_attachment_id",
+    "validation_status",
+    "validated_message",
+    "rejected_message",
 ]
 
 
@@ -40,19 +43,9 @@ class TierValidation(models.AbstractModel):
         domain=lambda self: [("model", "=", self._name)],
         auto_join=True,
     )
-    to_validate_message = fields.Html(compute="_compute_validated_rejected")
-    # TODO: Delete in v17 in favor of validation_status field
-    validated = fields.Boolean(
-        compute="_compute_validated_rejected", search="_search_validated"
-    )
     validated_message = fields.Html(compute="_compute_validated_rejected")
-    need_validation = fields.Boolean(compute="_compute_need_validation")
-    # TODO: Delete in v17 in favor of validation_status field
-    rejected = fields.Boolean(
-        compute="_compute_validated_rejected", search="_search_rejected"
-    )
     rejected_message = fields.Html(compute="_compute_validated_rejected")
-    # Informative field (used in purchase_tier_validation), will be reliable as of v17
+    need_validation = fields.Boolean(compute="_compute_need_validation")
     validation_status = fields.Selection(
         selection=[
             ("no", "Without validation"),
@@ -63,6 +56,8 @@ class TierValidation(models.AbstractModel):
         ],
         default="no",
         compute="_compute_validation_status",
+        compute_sudo=True,
+        store=True,
     )
     reviewer_ids = fields.Many2many(
         string="Reviewers",
@@ -116,7 +111,7 @@ class TierValidation(models.AbstractModel):
             ("review_ids.reviewer_ids", "=", self.env.user.id),
             ("review_ids.status", "in", ["pending", "waiting"]),
             ("review_ids.can_review", "=", True),
-            ("rejected", "=", False),
+            ("validation_status", "!=", "rejected"),
         ]
         if "active" in self._fields:
             domain.append(("active", "in", [True, False]))
@@ -129,30 +124,6 @@ class TierValidation(models.AbstractModel):
             rec.reviewer_ids = rec.review_ids.filtered(
                 lambda r: r.status in ("waiting", "pending")
             ).mapped("reviewer_ids")
-
-    @api.model
-    def _search_validated(self, operator, value):
-        assert operator in ("=", "!="), "Invalid domain operator"
-        assert value in (True, False), "Invalid domain value"
-        pos = self.search([(self._state_field, "in", self._state_from)]).filtered(
-            lambda r: r.validated
-        )
-        if value:
-            return [("id", "in", pos.ids)]
-        else:
-            return [("id", "not in", pos.ids)]
-
-    @api.model
-    def _search_rejected(self, operator, value):
-        assert operator in ("=", "!="), "Invalid domain operator"
-        assert value in (True, False), "Invalid domain value"
-        pos = self.search([(self._state_field, "in", self._state_from)]).filtered(
-            lambda r: r.rejected
-        )
-        if value:
-            return [("id", "in", pos.ids)]
-        else:
-            return [("id", "not in", pos.ids)]
 
     @api.model
     def _search_reviewer_ids(self, operator, value):
@@ -192,29 +163,33 @@ class TierValidation(models.AbstractModel):
         )}"""
         return self.rejected and msg or ""
 
-    def _compute_validated_rejected(self):
-        for rec in self:
-            rec.validated = self._calc_reviews_validated(rec.review_ids)
-            rec.validated_message = rec._get_validated_message()
-            rec.rejected = self._calc_reviews_rejected(rec.review_ids)
-            rec.rejected_message = rec._get_rejected_message()
-            rec.to_validate_message = rec._get_to_validate_message()
+    def _get_to_validate_message_name(self):
+        return self._description
 
+    def _get_to_validate_message(self):
+        return f"""<i class="fa fa-info-circle"></i> {self.env._(
+            "This %s needs to be validated",
+            self._get_to_validate_message_name()
+        )}"""
+
+    @api.depends("review_ids", "review_ids.status")
     def _compute_validation_status(self):
         for item in self:
-            if item.validated and not item.rejected:
+            validated = self._calc_reviews_validated(item.review_ids)
+            rejected = self._calc_reviews_rejected(item.review_ids)
+            if validated and not rejected:
                 item.validation_status = "validated"
-            elif not item.validated and item.rejected:
+            elif not validated and rejected:
                 item.validation_status = "rejected"
             elif (
-                not item.validated
-                and not item.rejected
+                not validated
+                and not rejected
                 and any(item.review_ids.filtered(lambda x: x.status == "pending"))
             ):
                 item.validation_status = "pending"
             elif (
-                not item.validated
-                and not item.rejected
+                not validated
+                and not rejected
                 and any(item.review_ids.filtered(lambda x: x.status == "waiting"))
             ):
                 item.validation_status = "waiting"
@@ -420,7 +395,7 @@ class TierValidation(models.AbstractModel):
                                 "\n - ".join(pending_reviews),
                             )
                         )
-                if rec.review_ids and not rec.validated:
+                if rec.review_ids and rec.validation_status != "validated":
                     raise ValidationError(
                         self.env._(
                             "A validation process is still open for at least "

--- a/base_tier_validation/static/description/index.html
+++ b/base_tier_validation/static/description/index.html
@@ -434,8 +434,8 @@ functionality.</li>
 be notified by email when this definition is triggered.</li>
 <li>If check <em>Notify reviewers on reaching pending</em> if you want to send a
 notification when pending status is reached. This is usefull in a
-approve by sequence scenario to only notify reviewers when it is their
-turn in the sequence.</li>
+approve by sequence scenario to only notify reviewers when it is
+their turn in the sequence.</li>
 <li>If check <em>Comment</em>, reviewers can comment after click Validate or
 Reject.</li>
 <li>If check <em>Approve by sequence</em>, reviewers is forced to review by
@@ -456,10 +456,12 @@ both.</li>
 <ul class="simple">
 <li>If you don’t create any exception, the Validated record will be
 readonly and cannot be modified.</li>
-<li>If check <em>Write under Validation</em>, records will be able to be modified
-only in the defined fields when the Validation process is ongoing.</li>
-<li>If check <em>Write after Validation</em>, records will be able to be modified
-only in the defined fields when the Validation process is finished.</li>
+<li>If check <em>Write under Validation</em>, records will be able to be
+modified only in the defined fields when the Validation process is
+ongoing.</li>
+<li>If check <em>Write after Validation</em>, records will be able to be
+modified only in the defined fields when the Validation process is
+finished.</li>
 <li>If check <em>Write after Validation</em> and <em>Write under Validation</em>,
 records will be able to be modified defined fields always.</li>
 </ul>
@@ -470,8 +472,8 @@ records will be able to be modified defined fields always.</li>
 improvement will be very valuable.</p>
 <ul>
 <li><p class="first"><strong>Issue:</strong></p>
-<p>When using approve_sequence option in any tier.definition there can be
-inconsistencies in the systray notifications.</p>
+<p>When using approve_sequence option in any tier.definition there can
+be inconsistencies in the systray notifications.</p>
 <p><strong>Description:</strong></p>
 <p>Field can_review in tier.review is used to filter out, in the systray
 notifications, the reviews a user can approve. This can_review field
@@ -503,8 +505,8 @@ to validate.</p>
 <h2><a class="toc-backref" href="#toc-entry-6">13.0.1.2.2 (2020-08-30)</a></h2>
 <p>Fixes:</p>
 <ul class="simple">
-<li>When using approve_sequence option in any tier.definition there can be
-inconsistencies in the systray notifications</li>
+<li>When using approve_sequence option in any tier.definition there can
+be inconsistencies in the systray notifications</li>
 <li>When using approve_sequence, still not approve only the needed
 sequence, but also other sequence for the same approver</li>
 </ul>

--- a/base_tier_validation/templates/tier_validation_templates.xml
+++ b/base_tier_validation/templates/tier_validation_templates.xml
@@ -5,7 +5,7 @@
             <button
                 name="request_validation"
                 string="Request Validation"
-                t-attf-invisible="not need_validation or rejected or hide_reviews"
+                t-attf-invisible="not need_validation or validation_status == 'rejected' or hide_reviews"
                 type="object"
             />
             <button
@@ -21,7 +21,7 @@
             <div
                 class="alert alert-warning mb-0"
                 role="alert"
-                t-attf-invisible="validated or hide_reviews or rejected or not review_ids"
+                t-attf-invisible="validation_status == 'validated' or hide_reviews or validation_status == 'rejected' or not review_ids"
             >
                 <p class="mb-1">
                 <i class="fa fa-lg fa-info-circle" />
@@ -49,7 +49,7 @@
             <div
                 class="alert alert-success mb-0"
                 role="alert"
-                t-attf-invisible="not validated or hide_reviews or not review_ids"
+                t-attf-invisible="validation_status != 'validated' or hide_reviews or not review_ids"
             >
                 <p class="mb-1">
                 <i class="fa fa-lg fa-thumbs-up" />
@@ -61,7 +61,7 @@
             <div
                 class="alert alert-danger mb-0"
                 role="alert"
-                t-attf-invisible="not rejected or hide_reviews or not review_ids"
+                t-attf-invisible="validation_status != 'rejected' or hide_reviews or not review_ids"
             >
                 <p class="mb-1">
                 <i class="fa fa-lg fa-thumbs-down" />

--- a/base_tier_validation/tests/test_tier_validation.py
+++ b/base_tier_validation/tests/test_tier_validation.py
@@ -37,7 +37,7 @@ class TierTierValidation(CommonTierValidation):
         record = self.test_record.with_user(self.test_user_1.id)
         record.invalidate_model()
         record.validate_tier()
-        self.assertTrue(record.validated)
+        self.assertEqual(record.validation_status, "validated")
 
     def test_04_request_validation_rejected(self):
         """Request validation, rejection and reset."""
@@ -48,7 +48,7 @@ class TierTierValidation(CommonTierValidation):
         record.invalidate_model()
         record.reject_tier()
         self.assertTrue(record.review_ids)
-        self.assertTrue(record.rejected)
+        self.assertEqual(record.validation_status, "rejected")
         record.restart_validation()
         self.assertFalse(record.review_ids)
 
@@ -88,7 +88,7 @@ class TierTierValidation(CommonTierValidation):
         self.test_record.with_user(self.test_user_2.id).request_validation()
         self.test_record.invalidate_model()
         res = self.test_model.with_user(self.test_user_1.id).search(
-            [("validated", "=", False)]
+            [("validation_status", "!=", "validated")]
         )
         self.assertTrue(res)
 
@@ -97,7 +97,7 @@ class TierTierValidation(CommonTierValidation):
         self.test_record.with_user(self.test_user_2.id).request_validation()
         self.test_record.invalidate_model()
         res = self.test_model.with_user(self.test_user_1.id).search(
-            [("rejected", "=", False)]
+            [("validation_status", "!=", "rejected")]
         )
         self.assertTrue(res)
 
@@ -966,7 +966,7 @@ class TierTierValidation(CommonTierValidation):
         record.invalidate_model()
         record.validate_tier()
         record.action_confirm()
-        self.assertTrue(record.validated)
+        self.assertEqual(record.validation_status, "validated")
         # Unable to write test_validation_field after validation
         with self.assertRaises(ValidationError):
             # Simulate there are fields, but not test_validation_field

--- a/base_tier_validation_forward/tests/test_tier_validation.py
+++ b/base_tier_validation_forward/tests/test_tier_validation.py
@@ -64,4 +64,4 @@ class TierTierValidation(CommonTierValidation):
         wizard.comment = "Forward tier is reviewed"
         wiz = wizard.save()
         wiz.add_comment()
-        self.assertTrue(record.validated)
+        self.assertEqual(record.validation_status, "validated")


### PR DESCRIPTION
This PR is split into 3 commits:
1. Fix performance issues. _search_validated_rejected kills performance when there are many records and can cause server crashes when there is a high number of account.move records
- remove fields rejected and validated
- uses validation_status instead, as intended in the comments
- makes the following fields stored: validation_status, validated_message, rejected_message
- the business logic is kept intact

2. Cleanup the message builder functions
- remove fields validated_message, rejected_message 
- remove associated functions
They are used nowhere in the base module. This module is already heavy, messaging functionality should be in its own module.

3. fix test on base_tier_validation_forward (minor)