### PR TITLE
[18.0][IMP] base_tier_validation: deprecate rejected/validated fields (for performance)

### DIFF
--- a/base_tier_validation/README.rst
+++ b/base_tier_validation/README.rst
@@ -70,16 +70,16 @@ To configure this module, you need to:
 
 **Note:**
 
-- If check *Notify Reviewers on Creation*, all possible reviewers will
-  be notified by email when this definition is triggered.
-- If check *Notify reviewers on reaching pending* if you want to send a
-  notification when pending status is reached. This is usefull in a
-  approve by sequence scenario to only notify reviewers when it is their
-  turn in the sequence.
-- If check *Comment*, reviewers can comment after click Validate or
-  Reject.
-- If check *Approve by sequence*, reviewers is forced to review by
-  specified sequence.
+-  If check *Notify Reviewers on Creation*, all possible reviewers will
+   be notified by email when this definition is triggered.
+-  If check *Notify reviewers on reaching pending* if you want to send a
+   notification when pending status is reached. This is usefull in a
+   approve by sequence scenario to only notify reviewers when it is
+   their turn in the sequence.
+-  If check *Comment*, reviewers can comment after click Validate or
+   Reject.
+-  If check *Approve by sequence*, reviewers is forced to review by
+   specified sequence.
 
 To configure Tier Validation Exceptions, you need to:
 
@@ -94,14 +94,16 @@ To configure Tier Validation Exceptions, you need to:
 
 **Note:**
 
-- If you don't create any exception, the Validated record will be
-  readonly and cannot be modified.
-- If check *Write under Validation*, records will be able to be modified
-  only in the defined fields when the Validation process is ongoing.
-- If check *Write after Validation*, records will be able to be modified
-  only in the defined fields when the Validation process is finished.
-- If check *Write after Validation* and *Write under Validation*,
-  records will be able to be modified defined fields always.
+-  If you don't create any exception, the Validated record will be
+   readonly and cannot be modified.
+-  If check *Write under Validation*, records will be able to be
+   modified only in the defined fields when the Validation process is
+   ongoing.
+-  If check *Write after Validation*, records will be able to be
+   modified only in the defined fields when the Validation process is
+   finished.
+-  If check *Write after Validation* and *Write under Validation*,
+   records will be able to be modified defined fields always.
 
 Known issues / Roadmap
 ======================
@@ -109,25 +111,54 @@ Known issues / Roadmap
 This is the list of known issues for this module. Any proposal for
 improvement will be very valuable.
 
-- **Issue:**
+-  **Issue:**
 
-  When using approve_sequence option in any tier.definition there can be
-  inconsistencies in the systray notifications.
+   When using approve_sequence option in any tier.definition there can
+   be inconsistencies in the systray notifications.
 
-  **Description:**
+   **Description:**
 
-  Field can_review in tier.review is used to filter out, in the systray
-  notifications, the reviews a user can approve. This can_review field
-  is updated **in the database** in method review_user_count, this can
-  make it very inconsistent for databases with a lot of users and
-  recurring updates that can change the expected behavior.
+   Field can_review in tier.review is used to filter out, in the systray
+   notifications, the reviews a user can approve. This can_review field
+   is updated **in the database** in method review_user_count, this can
+   make it very inconsistent for databases with a lot of users and
+   recurring updates that can change the expected behavior.
 
-- **Migration to 15.0:**
+-  **Default \_tier_validation_manual_config parameter**
 
-  The parameter \_tier_validation_manual_config will become False, on
-  14.0, the default value is True, as the change is applied after the
-  migration. In order to use the new behavior we need to modify the
-  value on our expected model.
+   The parameter \_tier_validation_manual_config will become False, on
+   18.0, the default value is True, as the change is applied after the
+   migration. In order to use the new behavior we need to modify the
+   value on our expected model.
+
+-  **Extraneous functions** All functions:
+
+   \_get_to_validate_message_name
+
+   \_get_to_validate_message
+
+   \_get_validated_message
+
+   \_get_rejected_message
+
+   are related to message building should be moved into their own
+   module. This module is already heavy enough as it is
+
+-  **Obsolete fields:**
+
+   The fields "rejected" and "validated" are kept for compatibility
+   reasons and should be removed in 19.0
+
+-  **Usability and architecture**
+
+   Implement the good feedback listed here about usability
+   https://github.com/OCA/server-ux/pull/1097#pullrequestreview-2961078706
+
+-  **More cleanup**
+
+   There are too many computes on tier reviews as evidenced by the
+   remaining invalidate\_\* function calls in tests. It would be simpler
+   to manage if these functions were in their own standalone function
 
 Changelog
 =========
@@ -149,69 +180,69 @@ Migrated to Odoo 14.
 
 Fixes:
 
-- When using approve_sequence option in any tier.definition there can be
-  inconsistencies in the systray notifications
-- When using approve_sequence, still not approve only the needed
-  sequence, but also other sequence for the same approver
+-  When using approve_sequence option in any tier.definition there can
+   be inconsistencies in the systray notifications
+-  When using approve_sequence, still not approve only the needed
+   sequence, but also other sequence for the same approver
 
 12.0.3.3.1 (2019-12-02)
 -----------------------
 
 Fixes:
 
-- Show comment on Reviews Table.
-- Edit notification with approve_sequence.
+-  Show comment on Reviews Table.
+-  Edit notification with approve_sequence.
 
 12.0.3.3.0 (2019-11-27)
 -----------------------
 
 New features:
 
-- Add comment on Reviews Table.
-- Approve by sequence.
+-  Add comment on Reviews Table.
+-  Approve by sequence.
 
 12.0.3.2.1 (2019-11-26)
 -----------------------
 
 Fixes:
 
-- Remove message_subscribe_users
+-  Remove message_subscribe_users
 
 12.0.3.2.0 (2019-11-25)
 -----------------------
 
 New features:
 
-- Notify reviewers
+-  Notify reviewers
 
 12.0.3.1.0 (2019-07-08)
 -----------------------
 
 Fixes:
 
-- Singleton error
+-  Singleton error
 
 12.0.3.0.0 (2019-12-02)
 -----------------------
 
 Fixes:
 
-- Edit Reviews Table
+-  Edit Reviews Table
 
 12.0.2.1.0 (2019-05-29)
 -----------------------
 
 Fixes:
 
-- Edit drop-down style width and position
+-  Edit drop-down style width and position
 
 12.0.2.0.0 (2019-05-28)
 -----------------------
 
 New features:
 
-- Pass parameters as functions.
-- Add Systray.
+-  Pass parameters as functions.
+-  Add Systray.
 
 12.0.1.0.0 (2019-02-18)
 -----------------------
@@ -254,26 +285,26 @@ Authors
 Contributors
 ------------
 
-- Lois Rilo <lois.rilo@forgeflow.com>
-- Naglis Jonaitis <naglis@versada.eu>
-- Adrià Gil Sorribes <adria.gil@forgeflow.com>
-- Pimolnat Suntian <pimolnats@ecosoft.co.th>
-- Pedro Gonzalez <pedro.gonzalez@pesol.es>
-- Kitti U. <kittiu@ecosoft.co.th>
-- Saran Lim. <saranl@ecosoft.co.th>
-- Carlos Lopez <celm1990@gmail.com>
-- Javier Colmeiro <javier.colmeiro@braintec.com>
-- bosd
-- Evan Soh <evan.soh@omnisoftsolution.com>
-- Manuel Regidor <manuel.regidor@sygel.es>
-- Eduardo de Miguel <edu@moduon.team>
-- `XCG Consulting <https://xcg-consulting.fr>`__:
+-  Lois Rilo <lois.rilo@forgeflow.com>
+-  Naglis Jonaitis <naglis@versada.eu>
+-  Adrià Gil Sorribes <adria.gil@forgeflow.com>
+-  Pimolnat Suntian <pimolnats@ecosoft.co.th>
+-  Pedro Gonzalez <pedro.gonzalez@pesol.es>
+-  Kitti U. <kittiu@ecosoft.co.th>
+-  Saran Lim. <saranl@ecosoft.co.th>
+-  Carlos Lopez <celm1990@gmail.com>
+-  Javier Colmeiro <javier.colmeiro@braintec.com>
+-  bosd
+-  Evan Soh <evan.soh@omnisoftsolution.com>
+-  Manuel Regidor <manuel.regidor@sygel.es>
+-  Eduardo de Miguel <edu@moduon.team>
+-  `XCG Consulting <https://xcg-consulting.fr>`__:
 
-  - Houzéfa Abbasbhay
+   -  Houzéfa Abbasbhay
 
-- Stefan Rijnhart <stefan@opener.amsterdam>
-- Kevin Khao <kevinkhao@gmail.com>
-- Do Anh Duy <duyda@trobz.com>
+-  Stefan Rijnhart <stefan@opener.amsterdam>
+-  Kevin Khao <kevinkhao@gmail.com>
+-  Do Anh Duy <duyda@trobz.com>
 
 Other credits
 -------------

--- a/base_tier_validation/models/res_users.py
+++ b/base_tier_validation/models/res_users.py
@@ -29,7 +29,7 @@ class Users(models.Model):
             if tier_review and hasattr(Model, "can_review"):
                 records_domain = [
                     ("id", "in", tier_review.mapped("res_id")),
-                    ("rejected", "=", False),
+                    ("validation_status", "!=", "rejected"),
                     ("can_review", "=", True),
                 ]
                 records = (

--- a/base_tier_validation/models/tier_review.py
+++ b/base_tier_validation/models/tier_review.py
@@ -91,7 +91,7 @@ class TierReview(models.Model):
             reviewed_date_tz = reviewed_date_utc.astimezone(pytz.timezone(timezone))
             review.reviewed_formated_date = reviewed_date_tz.replace(tzinfo=None)
 
-    @api.depends("definition_id.approve_sequence")
+    @api.depends("definition_id.approve_sequence", "status")
     def _compute_can_review(self):
         reviews = self.filtered(lambda rev: rev.status in ["waiting", "pending"])
         if reviews:

--- a/base_tier_validation/models/tier_validation.py
+++ b/base_tier_validation/models/tier_validation.py
@@ -41,18 +41,17 @@ class TierValidation(models.AbstractModel):
         auto_join=True,
     )
     to_validate_message = fields.Html(compute="_compute_validated_rejected")
-    # TODO: Delete in v17 in favor of validation_status field
+    # TODO: delete in 19.0 migration in favor of validation_status field
     validated = fields.Boolean(
         compute="_compute_validated_rejected", search="_search_validated"
     )
     validated_message = fields.Html(compute="_compute_validated_rejected")
     need_validation = fields.Boolean(compute="_compute_need_validation")
-    # TODO: Delete in v17 in favor of validation_status field
+    # TODO: delete in 19.0 migration in favor of validation_status field
     rejected = fields.Boolean(
         compute="_compute_validated_rejected", search="_search_rejected"
     )
     rejected_message = fields.Html(compute="_compute_validated_rejected")
-    # Informative field (used in purchase_tier_validation), will be reliable as of v17
     validation_status = fields.Selection(
         selection=[
             ("no", "Without validation"),
@@ -63,6 +62,7 @@ class TierValidation(models.AbstractModel):
         ],
         default="no",
         compute="_compute_validation_status",
+        store=True,
     )
     reviewer_ids = fields.Many2many(
         string="Reviewers",
@@ -106,6 +106,14 @@ class TierValidation(models.AbstractModel):
                 sequences.append(my_sequence)
         return sequences
 
+    @api.depends_context("uid")
+    @api.depends(
+        "review_ids",
+        "review_ids.sequence",
+        "review_ids.approve_sequence",
+        "review_ids.status",
+        "reviewer_ids",
+    )
     def _compute_can_review(self):
         for rec in self:
             rec.can_review = rec._get_sequences_to_approve(self.env.user)
@@ -116,7 +124,7 @@ class TierValidation(models.AbstractModel):
             ("review_ids.reviewer_ids", "=", self.env.user.id),
             ("review_ids.status", "in", ["pending", "waiting"]),
             ("review_ids.can_review", "=", True),
-            ("rejected", "=", False),
+            ("validation_status", "!=", "rejected"),
         ]
         if "active" in self._fields:
             domain.append(("active", "in", [True, False]))
@@ -130,29 +138,21 @@ class TierValidation(models.AbstractModel):
                 lambda r: r.status in ("waiting", "pending")
             ).mapped("reviewer_ids")
 
+    # TODO: delete in 19.0 migration in favor of validation_status field
     @api.model
     def _search_validated(self, operator, value):
         assert operator in ("=", "!="), "Invalid domain operator"
         assert value in (True, False), "Invalid domain value"
-        pos = self.search([(self._state_field, "in", self._state_from)]).filtered(
-            lambda r: r.validated
-        )
-        if value:
-            return [("id", "in", pos.ids)]
-        else:
-            return [("id", "not in", pos.ids)]
+        operator_equal = (operator == "=" and value) or (operator == "!=" and not value)
+        return [("validation_status", operator_equal and "=" or "!=", "validated")]
 
+    # TODO: delete in 19.0 migration in favor of validation_status field
     @api.model
     def _search_rejected(self, operator, value):
         assert operator in ("=", "!="), "Invalid domain operator"
         assert value in (True, False), "Invalid domain value"
-        pos = self.search([(self._state_field, "in", self._state_from)]).filtered(
-            lambda r: r.rejected
-        )
-        if value:
-            return [("id", "in", pos.ids)]
-        else:
-            return [("id", "not in", pos.ids)]
+        operator_equal = (operator == "=" and value) or (operator == "!=" and not value)
+        return [("validation_status", operator_equal and "=" or "!=", "rejected")]
 
     @api.model
     def _search_reviewer_ids(self, operator, value):
@@ -171,6 +171,8 @@ class TierValidation(models.AbstractModel):
         )
         return [("id", model_operator, list(set(reviews.mapped("res_id"))))]
 
+    # TODO move all the following own message-builder module
+    # START
     def _get_to_validate_message_name(self):
         return self._description
 
@@ -192,31 +194,31 @@ class TierValidation(models.AbstractModel):
         )}"""
         return self.rejected and msg or ""
 
+    # END
+
+    # TODO: delete in 19.0 migration in favor of validation_status field
+    @api.depends("validation_status")
     def _compute_validated_rejected(self):
         for rec in self:
-            rec.validated = self._calc_reviews_validated(rec.review_ids)
-            rec.validated_message = rec._get_validated_message()
-            rec.rejected = self._calc_reviews_rejected(rec.review_ids)
-            rec.rejected_message = rec._get_rejected_message()
-            rec.to_validate_message = rec._get_to_validate_message()
+            for field in ("validated", "rejected"):
+                rec[field] = rec.validation_status == field
 
+    @api.model
+    def _get_validation_status_dependencies(self):
+        return ["review_ids", "review_ids.status"]
+
+    @api.depends(lambda self: self._get_validation_status_dependencies())
     def _compute_validation_status(self):
         for item in self:
-            if item.validated and not item.rejected:
+            validated = self._calc_reviews_validated(item.review_ids)
+            rejected = self._calc_reviews_rejected(item.review_ids)
+            if validated and not rejected:
                 item.validation_status = "validated"
-            elif not item.validated and item.rejected:
+            elif rejected:
                 item.validation_status = "rejected"
-            elif (
-                not item.validated
-                and not item.rejected
-                and any(item.review_ids.filtered(lambda x: x.status == "pending"))
-            ):
+            elif any(item.review_ids.filtered(lambda x: x.status == "pending")):
                 item.validation_status = "pending"
-            elif (
-                not item.validated
-                and not item.rejected
-                and any(item.review_ids.filtered(lambda x: x.status == "waiting"))
-            ):
+            elif any(item.review_ids.filtered(lambda x: x.status == "waiting")):
                 item.validation_status = "waiting"
             else:
                 item.validation_status = "no"
@@ -420,7 +422,7 @@ class TierValidation(models.AbstractModel):
                                 "\n - ".join(pending_reviews),
                             )
                         )
-                if rec.review_ids and not rec.validated:
+                if rec.review_ids and rec.validation_status != "validated":
                     raise ValidationError(
                         self.env._(
                             "A validation process is still open for at least "

--- a/base_tier_validation/readme/ROADMAP.md
+++ b/base_tier_validation/readme/ROADMAP.md
@@ -14,9 +14,38 @@ improvement will be very valuable.
   make it very inconsistent for databases with a lot of users and
   recurring updates that can change the expected behavior.
 
-- **Migration to 15.0:**
+- **Default _tier_validation_manual_config parameter**
 
   The parameter \_tier_validation_manual_config will become False, on
-  14.0, the default value is True, as the change is applied after the
+  18.0, the default value is True, as the change is applied after the
   migration. In order to use the new behavior we need to modify the
   value on our expected model.
+
+- **Extraneous functions**
+  All functions:
+
+  _get_to_validate_message_name
+
+  _get_to_validate_message
+
+  _get_validated_message
+
+  _get_rejected_message
+
+  are related to message building should be moved into their own module. This module is
+    already heavy enough as it is
+
+- **Obsolete fields:**
+
+  The fields "rejected" and "validated" are kept for compatibility reasons and should be
+  removed in 19.0
+
+- **Usability and architecture**
+
+  Implement the good feedback listed here about usability
+  https://github.com/OCA/server-ux/pull/1097#pullrequestreview-2961078706
+
+- **More cleanup**
+
+  There are too many computes on tier reviews as evidenced by the remaining invalidate_* function calls in tests.
+  It would be simpler to manage if these functions were in their own standalone function

--- a/base_tier_validation/static/description/index.html
+++ b/base_tier_validation/static/description/index.html
@@ -439,8 +439,8 @@ functionality.</li>
 be notified by email when this definition is triggered.</li>
 <li>If check <em>Notify reviewers on reaching pending</em> if you want to send a
 notification when pending status is reached. This is usefull in a
-approve by sequence scenario to only notify reviewers when it is their
-turn in the sequence.</li>
+approve by sequence scenario to only notify reviewers when it is
+their turn in the sequence.</li>
 <li>If check <em>Comment</em>, reviewers can comment after click Validate or
 Reject.</li>
 <li>If check <em>Approve by sequence</em>, reviewers is forced to review by
@@ -461,10 +461,12 @@ both.</li>
 <ul class="simple">
 <li>If you don’t create any exception, the Validated record will be
 readonly and cannot be modified.</li>
-<li>If check <em>Write under Validation</em>, records will be able to be modified
-only in the defined fields when the Validation process is ongoing.</li>
-<li>If check <em>Write after Validation</em>, records will be able to be modified
-only in the defined fields when the Validation process is finished.</li>
+<li>If check <em>Write under Validation</em>, records will be able to be
+modified only in the defined fields when the Validation process is
+ongoing.</li>
+<li>If check <em>Write after Validation</em>, records will be able to be
+modified only in the defined fields when the Validation process is
+finished.</li>
 <li>If check <em>Write after Validation</em> and <em>Write under Validation</em>,
 records will be able to be modified defined fields always.</li>
 </ul>
@@ -475,8 +477,8 @@ records will be able to be modified defined fields always.</li>
 improvement will be very valuable.</p>
 <ul>
 <li><p class="first"><strong>Issue:</strong></p>
-<p>When using approve_sequence option in any tier.definition there can be
-inconsistencies in the systray notifications.</p>
+<p>When using approve_sequence option in any tier.definition there can
+be inconsistencies in the systray notifications.</p>
 <p><strong>Description:</strong></p>
 <p>Field can_review in tier.review is used to filter out, in the systray
 notifications, the reviews a user can approve. This can_review field
@@ -484,11 +486,32 @@ is updated <strong>in the database</strong> in method review_user_count, this ca
 make it very inconsistent for databases with a lot of users and
 recurring updates that can change the expected behavior.</p>
 </li>
-<li><p class="first"><strong>Migration to 15.0:</strong></p>
+<li><p class="first"><strong>Default _tier_validation_manual_config parameter</strong></p>
 <p>The parameter _tier_validation_manual_config will become False, on
-14.0, the default value is True, as the change is applied after the
+18.0, the default value is True, as the change is applied after the
 migration. In order to use the new behavior we need to modify the
 value on our expected model.</p>
+</li>
+<li><p class="first"><strong>Extraneous functions</strong> All functions:</p>
+<p>_get_to_validate_message_name</p>
+<p>_get_to_validate_message</p>
+<p>_get_validated_message</p>
+<p>_get_rejected_message</p>
+<p>are related to message building should be moved into their own
+module. This module is already heavy enough as it is</p>
+</li>
+<li><p class="first"><strong>Obsolete fields:</strong></p>
+<p>The fields “rejected” and “validated” are kept for compatibility
+reasons and should be removed in 19.0</p>
+</li>
+<li><p class="first"><strong>Usability and architecture</strong></p>
+<p>Implement the good feedback listed here about usability
+<a class="reference external" href="https://github.com/OCA/server-ux/pull/1097#pullrequestreview-2961078706">https://github.com/OCA/server-ux/pull/1097#pullrequestreview-2961078706</a></p>
+</li>
+<li><p class="first"><strong>More cleanup</strong></p>
+<p>There are too many computes on tier reviews as evidenced by the
+remaining invalidate_* function calls in tests. It would be simpler
+to manage if these functions were in their own standalone function</p>
 </li>
 </ul>
 </div>
@@ -508,8 +531,8 @@ to validate.</p>
 <h3><a class="toc-backref" href="#toc-entry-6">13.0.1.2.2 (2020-08-30)</a></h3>
 <p>Fixes:</p>
 <ul class="simple">
-<li>When using approve_sequence option in any tier.definition there can be
-inconsistencies in the systray notifications</li>
+<li>When using approve_sequence option in any tier.definition there can
+be inconsistencies in the systray notifications</li>
 <li>When using approve_sequence, still not approve only the needed
 sequence, but also other sequence for the same approver</li>
 </ul>

--- a/base_tier_validation/templates/tier_validation_templates.xml
+++ b/base_tier_validation/templates/tier_validation_templates.xml
@@ -6,7 +6,7 @@
             <button
                 name="request_validation"
                 string="Request Validation"
-                t-attf-invisible="not need_validation or rejected or hide_reviews"
+                t-attf-invisible="not need_validation or validation_status == 'rejected' or hide_reviews"
                 type="object"
             />
             <button
@@ -22,7 +22,7 @@
             <div
                 class="alert alert-warning mb-0"
                 role="alert"
-                t-attf-invisible="validated or hide_reviews or rejected or not review_ids"
+                t-attf-invisible="validation_status == 'validated' or hide_reviews or validation_status == 'rejected' or not review_ids"
             >
                 <p class="mb-1">
                 <i class="fa fa-lg fa-info-circle" />
@@ -50,7 +50,7 @@
             <div
                 class="alert alert-success mb-0"
                 role="alert"
-                t-attf-invisible="not validated or hide_reviews or not review_ids"
+                t-attf-invisible="validation_status != 'validated' or hide_reviews or not review_ids"
             >
                 <p class="mb-1">
                 <i class="fa fa-lg fa-thumbs-up" />
@@ -62,7 +62,7 @@
             <div
                 class="alert alert-danger mb-0"
                 role="alert"
-                t-attf-invisible="not rejected or hide_reviews or not review_ids"
+                t-attf-invisible="validation_status != 'rejected' or hide_reviews or not review_ids"
             >
                 <p class="mb-1">
                 <i class="fa fa-lg fa-thumbs-down" />

--- a/base_tier_validation/tests/test_tier_validation.py
+++ b/base_tier_validation/tests/test_tier_validation.py
@@ -35,9 +35,8 @@ class TierTierValidation(CommonTierValidation):
         reviews = self.test_record.with_user(self.test_user_2.id).request_validation()
         self.assertTrue(reviews)
         record = self.test_record.with_user(self.test_user_1.id)
-        record.invalidate_model()
         record.validate_tier()
-        self.assertTrue(record.validated)
+        self.assertEqual(record.validation_status, "validated")
 
     def test_04_request_validation_rejected(self):
         """Request validation, rejection and reset."""
@@ -45,10 +44,9 @@ class TierTierValidation(CommonTierValidation):
         reviews = self.test_record.with_user(self.test_user_2.id).request_validation()
         self.assertTrue(reviews)
         record = self.test_record.with_user(self.test_user_1.id)
-        record.invalidate_model()
         record.reject_tier()
         self.assertTrue(record.review_ids)
-        self.assertTrue(record.rejected)
+        self.assertEqual(record.validation_status, "rejected")
         record.restart_validation()
         self.assertFalse(record.review_ids)
 
@@ -58,7 +56,6 @@ class TierTierValidation(CommonTierValidation):
         reviews = self.test_record.with_user(self.test_user_2.id).request_validation()
         self.assertTrue(reviews)
         record = self.test_record.with_user(self.test_user_1.id)
-        record.invalidate_model()
         with self.assertRaises(ValidationError):
             record.write({"test_field": 0.5})
 
@@ -68,7 +65,6 @@ class TierTierValidation(CommonTierValidation):
         reviews = self.test_record.with_user(self.test_user_2.id).request_validation()
         self.assertTrue(reviews)
         record = self.test_record.with_user(self.test_user_1.id)
-        record.invalidate_model()
         with self.assertRaises(ValidationError):
             record.action_confirm()
 
@@ -77,29 +73,40 @@ class TierTierValidation(CommonTierValidation):
         reviews = self.test_record.with_user(self.test_user_2.id).request_validation()
         self.assertTrue(reviews)
         record = self.test_record.with_user(self.test_user_1.id)
-        record.invalidate_model()
-        record.invalidate_recordset()
         self.assertIn(self.test_user_1, record.reviewer_ids)
         res = self.test_model.search([("reviewer_ids", "in", self.test_user_1.id)])
         self.assertTrue(res)
 
-    def test_08_search_validated(self):
-        """Test for the validated search method."""
-        self.test_record.with_user(self.test_user_2.id).request_validation()
-        self.test_record.invalidate_model()
-        res = self.test_model.with_user(self.test_user_1.id).search(
-            [("validated", "=", False)]
+    def test_08_search_compute_validated_rejected(self):
+        """
+        TODO in v19: remove these deprecated fields
+        Test for fields validated/rejected compute and search methods
+        """
+        self.test_record.validation_status = "validated"
+        self.assertTrue(self.test_record.validated)
+        self.assertTrue(
+            self.env["tier.validation.tester"].search(
+                [("id", "=", self.test_record.id), ("validated", "=", True)]
+            )
         )
-        self.assertTrue(res)
-
-    def test_09_search_rejected(self):
-        """Test for the rejected search method."""
-        self.test_record.with_user(self.test_user_2.id).request_validation()
-        self.test_record.invalidate_model()
-        res = self.test_model.with_user(self.test_user_1.id).search(
-            [("rejected", "=", False)]
+        self.test_record.validation_status = "rejected"
+        self.assertTrue(self.test_record.rejected)
+        self.assertTrue(
+            self.env["tier.validation.tester"].search(
+                [("id", "=", self.test_record.id), ("rejected", "=", True)]
+            )
         )
-        self.assertTrue(res)
+        self.test_record.validation_status = "no"
+        self.assertFalse(
+            self.env["tier.validation.tester"].search(
+                [
+                    ("id", "=", self.test_record.id),
+                    "|",
+                    ("rejected", "=", True),
+                    ("validated", "=", True),
+                ]
+            )
+        )
 
     def test_10_systray_counter(self):
         # Create new test record
@@ -135,10 +142,14 @@ class TierTierValidation(CommonTierValidation):
         self.test_record_2.with_user(self.test_user_2.id).request_validation()
         # Get review user count as systray icon would do and check count value
         docs = self.test_user_1.with_user(self.test_user_1).review_user_count()
+        self.assertEqual(len(docs), 2)
         for doc in docs:
-            if doc.get("name") == "tier.validation.tester2":
+            self.assertIn(
+                doc.get("name"), ("Tier Validation Tester", "Tier Validation Tester 2")
+            )
+            if doc.get("name") == "Tier Validation Tester 2":
                 self.assertEqual(doc.get("pending_count"), 1)
-            else:
+            elif doc.get("name") == "Tier Validation Tester":
                 self.assertEqual(doc.get("pending_count"), 2)
 
     def test_11_add_comment(self):
@@ -158,7 +169,6 @@ class TierTierValidation(CommonTierValidation):
         review = test_record.with_user(self.test_user_2.id).request_validation()
         self.assertTrue(review)
         record = test_record.with_user(self.test_user_1.id)
-        record.invalidate_model()
         review.invalidate_model()
         res = record.validate_tier()
         ctx = res.get("context")
@@ -194,7 +204,6 @@ class TierTierValidation(CommonTierValidation):
         review = test_record.with_user(self.test_user_2.id).request_validation()
         self.assertTrue(review)
         record = test_record.with_user(self.test_user_1.id)
-        record.invalidate_model()
         review.invalidate_model()
         res = record.reject_tier()  # Rejection
         ctx = res.get("context")
@@ -250,10 +259,8 @@ class TierTierValidation(CommonTierValidation):
             self.assertEqual(doc.get("pending_count"), 0)
 
         record1 = test_record.with_user(self.test_user_1.id)
-        record1.invalidate_model()
         self.assertTrue(record1.can_review)
         record2 = test_record.with_user(self.test_user_2.id)
-        record2.invalidate_model()
         self.assertFalse(record2.can_review)
         # User 1 validates the record, 2 review should be approved.
         self.assertFalse(any(r.status == "approved" for r in record1.review_ids))
@@ -432,7 +439,6 @@ class TierTierValidation(CommonTierValidation):
         # Request validation
         review = test_record.with_user(self.test_user_2).request_validation()
         self.assertTrue(review)
-        self.env.invalidate_all()
         self.assertTrue(test_record.review_ids)
         # Used by front-end
         count = self.test_user_1.with_user(self.test_user_1).review_user_count()
@@ -460,7 +466,6 @@ class TierTierValidation(CommonTierValidation):
         )
         test_record3.with_user(self.test_user_2).request_validation()
         record1 = test_record3.with_user(self.test_user_1)
-        record1.invalidate_model()
         self.assertTrue(record1.can_review)
         self.assertTrue(
             self.test_user_1.with_user(self.test_user_1).review_user_count()
@@ -470,7 +475,6 @@ class TierTierValidation(CommonTierValidation):
         )
         # user 1 reject first tier
         record1.reject_tier()
-        record1.invalidate_model()
         self.assertFalse(record1.can_review)
         # both user 1 and 2 has nothing left in tray
         self.assertFalse(
@@ -539,7 +543,6 @@ class TierTierValidation(CommonTierValidation):
         self.assertTrue(review_2.done_by.id is False)
         self.assertTrue(review_2.reviewed_date is False)
         record = test_record.with_user(self.test_user_1.id)
-        record.invalidate_model()
         record.validate_tier()
         self.assertTrue(review_1.status == "approved")
         self.assertFalse(review_1.reviewed_date is False)
@@ -628,7 +631,6 @@ class TierTierValidation(CommonTierValidation):
         )
         test_record_1 = self.test_model.create({"test_field": 1})
         test_record_1.request_validation()
-        test_record_1.invalidate_model()
         record = test_record_1.with_user(self.test_user_2.id)
         notifications_no_1 = len(
             self.env["mail.notification"].search(
@@ -647,7 +649,6 @@ class TierTierValidation(CommonTierValidation):
         tier_definition.write({"notify_on_accepted": False})
         test_record_2 = self.test_model.create({"test_field": 1})
         test_record_2.request_validation()
-        test_record_2.invalidate_model()
         test_record_2.with_user(self.test_user_2.id)
         notifications_no_1 = len(
             self.env["mail.notification"].search(
@@ -683,7 +684,6 @@ class TierTierValidation(CommonTierValidation):
         )
         test_record_1 = self.test_model.create({"test_field": 1})
         test_record_1.request_validation()
-        test_record_1.invalidate_model()
         record = test_record_1.with_user(self.test_user_2.id)
         notifications_no_1 = len(
             self.env["mail.notification"].search(
@@ -702,7 +702,6 @@ class TierTierValidation(CommonTierValidation):
         tier_definition.write({"notify_on_rejected": False})
         test_record_2 = self.test_model.create({"test_field": 1})
         test_record_2.request_validation()
-        test_record_2.invalidate_model()
         test_record_2.with_user(self.test_user_2.id)
 
         notifications_no_1 = len(
@@ -739,7 +738,6 @@ class TierTierValidation(CommonTierValidation):
         )
         test_record_1 = self.test_model.create({"test_field": 1})
         test_record_1.request_validation()
-        test_record_1.invalidate_model()
         record = test_record_1.with_user(self.test_user_2.id)
         notifications_no_1 = len(
             self.env["mail.notification"].search(
@@ -801,7 +799,6 @@ class TierTierValidation(CommonTierValidation):
             )
         )
         test_record.request_validation()
-        test_record.invalidate_model()
         notifications_no_2 = len(
             self.env["mail.notification"].search(
                 [("res_partner_id", "=", self.test_user_1.partner_id.id)]
@@ -882,7 +879,6 @@ class TierTierValidation(CommonTierValidation):
             )
         )
         test_record.request_validation()
-        test_record.invalidate_model()
         notifications_no_2 = len(
             self.env["mail.notification"].search(
                 [("res_partner_id", "=", self.test_user_1.partner_id.id)]
@@ -946,7 +942,6 @@ class TierTierValidation(CommonTierValidation):
         self.assertFalse(self.test_record.review_ids)
         reviews = self.test_record.with_user(self.test_user_2.id).request_validation()
         self.assertTrue(reviews)
-        self.test_record.invalidate_model()
         self.assertTrue(self.test_record.review_ids)
         # Unable to write test_validation_field under validation
         with self.assertRaises(ValidationError):
@@ -963,10 +958,9 @@ class TierTierValidation(CommonTierValidation):
         self.assertEqual(self.test_record.test_validation_field, 2)
         # Validate record
         record = self.test_record.with_user(self.test_user_1.id)
-        record.invalidate_model()
         record.validate_tier()
         record.action_confirm()
-        self.assertTrue(record.validated)
+        self.assertEqual(record.validation_status, "validated")
         # Unable to write test_validation_field after validation
         with self.assertRaises(ValidationError):
             # Simulate there are fields, but not test_validation_field
@@ -1012,12 +1006,10 @@ class TierTierValidation(CommonTierValidation):
         self.test_record_computed.action_cancel()
         self.test_record_computed.flush_recordset()
         self.assertFalse(self.test_record_computed.review_ids)
-        self.test_record_computed.invalidate_recordset()
 
     def test_29_allow_write_for_reviewers(self):
         reviews = self.test_record.with_user(self.test_user_2.id).request_validation()
         record = self.test_record.with_user(self.test_user_1.id)
-        record.invalidate_recordset()
         with self.assertRaises(ValidationError):
             record.with_user(self.test_user_1.id).write({"test_field": 0.3})
         reviews.definition_id.with_user(self.test_user_1.id).write(
@@ -1049,7 +1041,6 @@ class TierTierValidation(CommonTierValidation):
         reviews = self.test_record_2.with_user(
             self.test_user_3_multi_company.id
         ).request_validation()
-        self.test_record_2.invalidate_recordset()
 
         self.assertEqual(len(reviews), 1)
 
@@ -1077,7 +1068,6 @@ class TierTierValidation(CommonTierValidation):
         reviews = self.test_record_2.with_user(
             self.test_user_3_multi_company.id
         ).request_validation()
-        self.test_record_2.invalidate_recordset()
 
         self.assertEqual(len(reviews), 2)
 


### PR DESCRIPTION
This PR fixes performance issues and clarifies the dependencies. 

- store validation_status to allow performant search on records in validation
- _search_validated_rejected kills performance when there are many records and can cause server crashes when there is a high number of account.move records -> replace by search on validation status
- stop using fields rejected and validated and keep them for compatibility, use validation_status instead, as intended in the comments
- update roadmap 
- future improvements in usability