### PR TITLE
[15.0]FIX] base_export_manager: add sudo call to models without explicit access

### DIFF
--- a/base_export_manager/models/ir_exports_line.py
+++ b/base_export_manager/models/ir_exports_line.py
@@ -61,7 +61,7 @@ class IrExportsLine(models.Model):
     @api.depends("field1_id")
     def _compute_model2_id(self):
         """Get the related model for the second field."""
-        IrModel = self.env["ir.model"]
+        IrModel = self.env["ir.model"].sudo()
         for one in self:
             one.model2_id = (
                 one.field1_id.ttype
@@ -72,7 +72,7 @@ class IrExportsLine(models.Model):
     @api.depends("field2_id")
     def _compute_model3_id(self):
         """Get the related model for the third field."""
-        IrModel = self.env["ir.model"]
+        IrModel = self.env["ir.model"].sudo()
         for one in self:
             one.model3_id = (
                 one.field2_id.ttype
@@ -83,7 +83,7 @@ class IrExportsLine(models.Model):
     @api.depends("field3_id")
     def _compute_model4_id(self):
         """Get the related model for the third field."""
-        IrModel = self.env["ir.model"]
+        IrModel = self.env["ir.model"].sudo()
         for one in self:
             one.model4_id = (
                 one.field3_id.ttype
@@ -177,8 +177,10 @@ class IrExportsLine(models.Model):
         :param str name:
             Technical name of the field, like ``child_ids``.
         """
-        field = self.env["ir.model.fields"].search(
-            [("name", "=", name), ("model_id", "=", model.id)]
+        field = (
+            self.env["ir.model.fields"]
+            .sudo()
+            .search([("name", "=", name), ("model_id", "=", model.id)])
         )
         if not field.exists():
             raise exceptions.ValidationError(

--- a/base_export_manager/models/ir_exports_line.py
+++ b/base_export_manager/models/ir_exports_line.py
@@ -46,7 +46,7 @@ class IrExportsLine(models.Model):
         "ir.model", "Fourth model", compute="_compute_model4_id", compute_sudo=True
     )
     sequence = fields.Integer()
-    label = fields.Char(compute="_compute_label")
+    label = fields.Char(compute="_compute_label", compute_sudo=True)
 
     @api.depends("field1_id", "field2_id", "field3_id", "field4_id")
     def _compute_name(self):

--- a/base_export_manager/tests/test_ir_exports.py
+++ b/base_export_manager/tests/test_ir_exports.py
@@ -1,11 +1,23 @@
 # Copyright 2015-2018 Tecnativa - Jairo Llopis
+# Copyright 2025 Tecnativa - Víctor Martínez
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from odoo.exceptions import ValidationError
-from odoo.tests.common import TransactionCase
+from odoo.tests import new_test_user
+from odoo.tests.common import TransactionCase, users
 
 
 class TestIrExportsCase(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        new_test_user(
+            cls.env,
+            login="test-user",
+            groups="base.group_user,base.group_allow_export",
+        )
+
+    @users("test-user")
     def test_create_with_basic_data(self):
         """Emulate creation from original form.
 


### PR DESCRIPTION
Changes done:
- [x] add sudo call to models without explicit access (Backport from https://github.com/OCA/server-ux/commit/2fe05a068e8ce4625c38f032699e84b90e8ff4ac).
- [x] Add compute_sudo=True to `label` field to prevent access error
- [x] Improve test with basic test-user

Please @pedrobaeza and  @carlosdauden can you review it?

@Tecnativa TT56933