### PR TITLE
[17.0][FIX] base_tier_validation: Proper notifications on reviews

### DIFF
--- a/base_tier_validation/data/mail_data.xml
+++ b/base_tier_validation/data/mail_data.xml
@@ -6,7 +6,7 @@
         forcecreate="1"
     >
         <field name="name">Tier Validation Requested</field>
-        <field name="default" eval="True" />
+        <field name="default" eval="False" />
         <field name="internal" eval="True" />
         <field name="hidden" eval="True" />
     </record>
@@ -16,7 +16,7 @@
         forcecreate="1"
     >
         <field name="name">Tier Validation Accepted Notification</field>
-        <field name="default" eval="True" />
+        <field name="default" eval="False" />
         <field name="internal" eval="True" />
         <field name="hidden" eval="True" />
     </record>
@@ -26,7 +26,7 @@
         forcecreate="1"
     >
         <field name="name">Tier Validation Rejected Notification</field>
-        <field name="default" eval="True" />
+        <field name="default" eval="False" />
         <field name="internal" eval="True" />
         <field name="hidden" eval="True" />
     </record>
@@ -36,7 +36,7 @@
         forcecreate="1"
     >
         <field name="name">Tier Validation Restarted</field>
-        <field name="default" eval="True" />
+        <field name="default" eval="False" />
         <field name="internal" eval="True" />
         <field name="hidden" eval="True" />
     </record>

--- a/base_tier_validation/models/tier_validation.py
+++ b/base_tier_validation/models/tier_validation.py
@@ -542,13 +542,30 @@ class TierValidation(models.AbstractModel):
         reviews_to_notify = user_reviews.filtered(
             lambda r: r.definition_id.notify_on_accepted
         )
+        # We need to notify all pending users if there is approve sequence
+        if tier_reviews and any(review.approve_sequence for review in tier_reviews):
+            reviews_to_notify = self.review_ids.filtered(
+                lambda r: r.status in ("waiting", "pending")
+                and r.definition_id.notify_on_accepted
+            )
+            # If there are approve sequence, only the following should be
+            # considered to notify
+            if reviews_to_notify and any(
+                review.approve_sequence for review in reviews_to_notify
+            ):
+                reviews_to_notify = reviews_to_notify.filtered(
+                    lambda x: x.approve_sequence
+                )[0]
         if reviews_to_notify:
             subscribe = "message_subscribe"
             if hasattr(self, subscribe):
                 getattr(self, subscribe)(
                     partner_ids=reviews_to_notify.mapped("reviewer_ids")
                     .mapped("partner_id")
-                    .ids
+                    .ids,
+                    subtype_ids=self.env.ref(
+                        self._get_accepted_notification_subtype()
+                    ).ids,
                 )
             for review in reviews_to_notify:
                 rec = self.env[review.model].browse(review.res_id)
@@ -664,13 +681,29 @@ class TierValidation(models.AbstractModel):
         reviews_to_notify = user_reviews.filtered(
             lambda r: r.definition_id.notify_on_rejected
         )
+        # We need to notify all pending users if there is approve sequence
+        if tier_reviews and any(review.approve_sequence for review in tier_reviews):
+            reviews_to_notify = self.review_ids.filtered(
+                lambda r: r.status == "pending" and r.definition_id.notify_on_rejected
+            )
+            # If there are approve sequence, only the following should be
+            # considered to notify
+            if reviews_to_notify and any(
+                review.approve_sequence for review in reviews_to_notify
+            ):
+                reviews_to_notify = reviews_to_notify.filtered(
+                    lambda x: x.approve_sequence
+                )[0]
         if reviews_to_notify:
             subscribe = "message_subscribe"
             if hasattr(self, subscribe):
                 getattr(self, subscribe)(
                     partner_ids=reviews_to_notify.mapped("reviewer_ids")
                     .mapped("partner_id")
-                    .ids
+                    .ids,
+                    subtype_ids=self.env.ref(
+                        self._get_rejected_notification_subtype()
+                    ).ids,
                 )
             for review in reviews_to_notify:
                 rec = self.env[review.model].browse(review.res_id)
@@ -697,7 +730,10 @@ class TierValidation(models.AbstractModel):
                 # Subscribe reviewers and notify
                 if len(users_to_notify) > 0:
                     getattr(rec, subscribe)(
-                        partner_ids=users_to_notify.mapped("partner_id").ids
+                        partner_ids=users_to_notify.mapped("partner_id").ids,
+                        subtype_ids=self.env.ref(
+                            self._get_requested_notification_subtype()
+                        ).ids,
                     )
                     getattr(rec, post)(
                         subtype_xmlid=self._get_requested_notification_subtype(),
@@ -788,7 +824,12 @@ class TierValidation(models.AbstractModel):
                     lambda r: r.definition_id.notify_on_restarted
                 )
                 if hasattr(self, subscribe):
-                    getattr(self, subscribe)(partner_ids=partners_to_notify_ids)
+                    getattr(self, subscribe)(
+                        partner_ids=partners_to_notify_ids,
+                        subtype_ids=self.env.ref(
+                            self._get_restarted_notification_subtype()
+                        ).ids,
+                    )
                 rec._notify_restarted_review()
 
     @api.model

--- a/base_tier_validation/tests/__init__.py
+++ b/base_tier_validation/tests/__init__.py
@@ -1,5 +1,4 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
-from . import common
 from . import test_tier_validation
 from . import test_tier_validation_reminder


### PR DESCRIPTION
FWP from 16.0: https://github.com/OCA/server-ux/pull/1083

Proper notifications on reviews

Changes done:
- The subtypes should not be defined as default=True to avoid that a follower receives notifications of everything (even if he/she doesn't really need it).
- When adding followers they are added to the corresponding subtype so that the notification arrives to whom it corresponds.
- Improve the code so that the reviews to notify are the "following ones according to the sequence".

@Tecnativa TT56354