### PR TITLE
[18.0][FIX] base_tier_validation: Proper notifications on reviews

### DIFF
--- a/base_tier_validation/data/mail_data.xml
+++ b/base_tier_validation/data/mail_data.xml
@@ -6,7 +6,7 @@
         forcecreate="1"
     >
         <field name="name">Tier Validation Requested</field>
-        <field name="default" eval="True" />
+        <field name="default" eval="False" />
         <field name="internal" eval="True" />
         <field name="hidden" eval="True" />
     </record>
@@ -16,7 +16,7 @@
         forcecreate="1"
     >
         <field name="name">Tier Validation Accepted Notification</field>
-        <field name="default" eval="True" />
+        <field name="default" eval="False" />
         <field name="internal" eval="True" />
         <field name="hidden" eval="True" />
     </record>
@@ -26,7 +26,7 @@
         forcecreate="1"
     >
         <field name="name">Tier Validation Rejected Notification</field>
-        <field name="default" eval="True" />
+        <field name="default" eval="False" />
         <field name="internal" eval="True" />
         <field name="hidden" eval="True" />
     </record>
@@ -36,7 +36,7 @@
         forcecreate="1"
     >
         <field name="name">Tier Validation Restarted</field>
-        <field name="default" eval="True" />
+        <field name="default" eval="False" />
         <field name="internal" eval="True" />
         <field name="hidden" eval="True" />
     </record>

--- a/base_tier_validation/tests/__init__.py
+++ b/base_tier_validation/tests/__init__.py
@@ -1,5 +1,4 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
-from . import common
 from . import test_tier_validation
 from . import test_tier_validation_reminder


### PR DESCRIPTION
FWP from 17.0: https://github.com/OCA/server-ux/pull/1111

Proper notifications on reviews

Changes done:
- The subtypes should not be defined as default=True to avoid that a follower receives notifications of everything (even if he/she doesn't really need it).
- When adding followers they are added to the corresponding subtype so that the notification arrives to whom it corresponds.
- Improve the code so that the reviews to notify are the "following ones according to the sequence".

@Tecnativa TT56354