### PR TITLE
[17.0]FIX] base_export_manager: add sudo call to models without explicit access

### DIFF
--- a/base_export_manager/models/ir_exports_line.py
+++ b/base_export_manager/models/ir_exports_line.py
@@ -46,7 +46,7 @@ class IrExportsLine(models.Model):
         "ir.model", "Fourth model", compute="_compute_model4_id", compute_sudo=True
     )
     sequence = fields.Integer()
-    label = fields.Char(compute="_compute_label")
+    label = fields.Char(compute="_compute_label", compute_sudo=True)
 
     @api.depends("field1_id", "field2_id", "field3_id", "field4_id")
     def _compute_name(self):

--- a/base_export_manager/tests/test_ir_exports.py
+++ b/base_export_manager/tests/test_ir_exports.py
@@ -1,11 +1,25 @@
 # Copyright 2015-2018 Tecnativa - Jairo Llopis
+# Copyright 2025 Tecnativa - Víctor Martínez
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from odoo.exceptions import ValidationError
-from odoo.tests.common import TransactionCase
+from odoo.tests import new_test_user
+from odoo.tests.common import users
+
+from odoo.addons.base.tests.common import BaseCommon
 
 
-class TestIrExportsCase(TransactionCase):
+class TestIrExportsCase(BaseCommon):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        new_test_user(
+            cls.env,
+            login="test-user",
+            groups="base.group_user,base.group_allow_export",
+        )
+
+    @users("test-user")
     def test_create_with_basic_data(self):
         """Emulate creation from original form.
 


### PR DESCRIPTION
FWP from 16.0: https://github.com/OCA/server-ux/pull/1113

Changes done:
- [x] Add compute_sudo=True to `label` field to prevent access error
- [x] Improve test with basic test-user

Please @pedrobaeza and  @carlosdauden can you review it?

@Tecnativa TT56933