### PR TITLE
[18.0][FIX] base_tier_validation: make ReviewsTable widget work with manual config

### DIFF
--- a/base_tier_validation/static/src/components/tier_review_widget/tier_review_widget.esm.js
+++ b/base_tier_validation/static/src/components/tier_review_widget/tier_review_widget.esm.js
@@ -35,6 +35,19 @@ ReviewsTable.template = "base_tier_validation.Collapse";
 
 export const reviewsTableComponent = {
     component: ReviewsTable,
+    supportedTypes: ["one2many"],
+    relatedFields: [
+        {name: "id", type: "integer"},
+        {name: "sequence", type: "integer"},
+        {name: "name", type: "char"},
+        {name: "display_status", type: "char"},
+        {name: "todo_by", type: "char"},
+        {name: "status", type: "char"},
+        {name: "reviewed_formated_date", type: "char"},
+        {name: "comment", type: "char"},
+        {name: "requested_by", type: "many2one", relation: "partner"},
+        {name: "done_by", type: "many2one", relation: "partner"},
+    ],
 };
 
 registry.category("fields").add("form.tier_validation", reviewsTableComponent);


### PR DESCRIPTION
Forward-port of #1093 , since the original issue can be reproduced in v18 too.