### PR TITLE
[17.0][IMP] base_tier_validation: add support for custom actions in TierReviewMenu

### DIFF
--- a/base_tier_validation/models/__init__.py
+++ b/base_tier_validation/models/__init__.py
@@ -6,3 +6,4 @@ from . import tier_review
 from . import tier_validation
 from . import res_users
 from . import res_config_settings
+from . import base

--- a/base_tier_validation/models/base.py
+++ b/base_tier_validation/models/base.py
@@ -1,0 +1,20 @@
+from odoo import api, models
+
+
+class Base(models.AbstractModel):
+    _inherit = "base"
+
+    @api.model
+    def get_tier_review_action(self):
+        """
+        To be overridden for custom per-model action customization
+        e.g. in `account.move` model class:
+
+        @api.model
+        def get_tier_review_action(self)
+            action = self.env["ir.actions.actions"]._for_xml_id(
+                "account.action_move_journal_line"
+            )
+            return action
+        """
+        return False

--- a/base_tier_validation/static/src/components/tier_review_menu/tier_review_menu.esm.js
+++ b/base_tier_validation/static/src/components/tier_review_menu/tier_review_menu.esm.js
@@ -29,7 +29,8 @@ export class TierReviewMenu extends Component {
     onBeforeOpen() {
         this.fetchSystrayReviewer();
     }
-    availableViews() {
+    // eslint-disable-next-line no-unused-vars
+    availableViews(group) {
         return [
             [false, "kanban"],
             [false, "list"],
@@ -37,7 +38,14 @@ export class TierReviewMenu extends Component {
             [false, "activity"],
         ];
     }
-    openReviewGroup(group) {
+    async getCustomAction(group) {
+        if (group.model) {
+            const action = await this.orm.call(group.model, "get_tier_review_action");
+            return action || false;
+        }
+        return false;
+    }
+    async openReviewGroup(group) {
         document.body.click();
         // Hack to close dropdown
         const context = {};
@@ -45,22 +53,37 @@ export class TierReviewMenu extends Component {
         if (group.active_field) {
             domain.push(["active", "in", [true, false]]);
         }
-        const views = this.availableViews();
 
-        this.action.doAction(
-            {
-                context,
-                domain,
-                name: group.name,
-                res_model: group.model,
-                search_view_id: [false],
-                type: "ir.actions.act_window",
-                views,
-            },
-            {
-                clearBreadcrumbs: true,
-            }
-        );
+        const action = await this.getCustomAction(group);
+        if (action) {
+            this.action.doAction(
+                {
+                    ...action,
+                    context,
+                    domain,
+                },
+                {
+                    clearBreadcrumbs: true,
+                }
+            );
+        } else {
+            const views = this.availableViews(group);
+
+            this.action.doAction(
+                {
+                    context,
+                    domain,
+                    name: group.name,
+                    res_model: group.model,
+                    search_view_id: [false],
+                    type: "ir.actions.act_window",
+                    views,
+                },
+                {
+                    clearBreadcrumbs: true,
+                }
+            );
+        }
     }
 }
 


### PR DESCRIPTION
This commit adds the possibility for modules inheriting from `base_tier_validation` to customize the `ir.actions.act_window` to run when a user clicks on the TierReviewMenu entries.

For example, the current behavior when using `account_move_tier_validation` is to use the default views for `account.move`, which leads users to a Kanban view of the Moves by default, and the Tree/List view has no "Partner" column.
With this PR, adding a small JS module such as:
```js
/* @odoo-module */
import { patch } from "@web/core/utils/patch";
import { TierReviewMenu } from "@base_tier_validation/components/tier_review_menu/tier_review_menu.esm";


patch(TierReviewMenu.prototype, {
    async getCustomAction(group) {
        if (group.model === 'account.move') {
            const action = 'account.action_move_journal_line';
            return this.action.loadAction(action);
        }
        return super.getCustomAction(group);
    }
});
```

would then open the classic "Journal Entries" default views, showing the "Partner" column in the tree view, etc...

Of course, the default behavior of this addition is to fallback on the current approach.
Also, we now pass the `group` variable to the `getAvailableViews` call so this can be customized too.