### PR TITLE
[16.0][FIX+IMP] base_tier_validation: base_tier_validation_waiting compatibiity

### DIFF
--- a/base_tier_validation/migrations/16.0.3.1.0/pre-migration.py
+++ b/base_tier_validation/migrations/16.0.3.1.0/pre-migration.py
@@ -102,11 +102,21 @@ def migrate(env, version):
                 env.cr,
                 f"""
                 UPDATE {table_name} SET validation_status = 'pending'
-                WHERE validated = false
-                AND coalesce(rejected, false) = false AND id IN (
+                WHERE validation_status = 'no' AND id IN (
                     SELECT DISTINCT(tr.res_id)
                     FROM tier_review AS tr
                     WHERE tr.model = '{model_name}' AND tr.status = 'pending'
+                )
+                """,
+            )
+            openupgrade.logged_query(
+                env.cr,
+                f"""
+                UPDATE {table_name} SET validation_status = 'waiting'
+                WHERE validation_status = 'no' AND id IN (
+                    SELECT DISTINCT(tr.res_id)
+                    FROM tier_review AS tr
+                    WHERE tr.model = '{model_name}' AND tr.status = 'waiting'
                 )
                 """,
             )

--- a/base_tier_validation/models/tier_validation.py
+++ b/base_tier_validation/models/tier_validation.py
@@ -42,9 +42,17 @@ class TierValidation(models.AbstractModel):
         domain=lambda self: [("model", "=", self._name)],
         auto_join=True,
     )
+    # TODO: Delete in v19 in favor of validation_status field
+    validated = fields.Boolean(
+        compute="_compute_validated_rejected", search="_search_validated"
+    )
     to_validate_message = fields.Html(compute="_compute_to_validate_message")
     validated_message = fields.Html(compute="_compute_validated_message")
     need_validation = fields.Boolean(compute="_compute_need_validation")
+    # TODO: Delete in v19 in favor of validation_status field
+    rejected = fields.Boolean(
+        compute="_compute_validated_rejected", search="_search_rejected"
+    )
     rejected_message = fields.Html(compute="_compute_rejected_message")
     validation_status = fields.Selection(
         selection=[
@@ -121,6 +129,22 @@ class TierValidation(models.AbstractModel):
                 lambda r: r.status == "pending"
             ).mapped("reviewer_ids")
 
+    # TODO: delete in 19.0 migration in favor of validation_status field
+    @api.model
+    def _search_validated(self, operator, value):
+        assert operator in ("=", "!="), "Invalid domain operator"
+        assert value in (True, False), "Invalid domain value"
+        operator_equal = (operator == "=" and value) or (operator == "!=" and not value)
+        return [("validation_status", operator_equal and "=" or "!=", "validated")]
+
+    # TODO: delete in 19.0 migration in favor of validation_status field
+    @api.model
+    def _search_rejected(self, operator, value):
+        assert operator in ("=", "!="), "Invalid domain operator"
+        assert value in (True, False), "Invalid domain value"
+        operator_equal = (operator == "=" and value) or (operator == "!=" and not value)
+        return [("validation_status", operator_equal and "=" or "!=", "rejected")]
+
     @api.model
     def _search_reviewer_ids(self, operator, value):
         model_operator = "in"
@@ -160,6 +184,13 @@ class TierValidation(models.AbstractModel):
             """Operation has been <b>rejected</b>."""
         )
         return self.validation_status == "rejected" and msg or ""
+
+    # TODO: delete in 19.0 migration in favor of validation_status field
+    @api.depends("validation_status")
+    def _compute_validated_rejected(self):
+        for rec in self:
+            for field in ("validated", "rejected"):
+                rec[field] = rec.validation_status == field
 
     @api.depends("validation_status")
     def _compute_to_validate_message(self):
@@ -228,18 +259,6 @@ class TierValidation(models.AbstractModel):
             if valid_tiers and rec.review_ids.definition_id:
                 if len(valid_tiers) != len(rec.review_ids.definition_id):
                     rec.is_reevaluation_required = True
-
-    @api.model
-    def _calc_reviews_validated(self, reviews):
-        """Override for different validation policy."""
-        if not reviews:
-            return False
-        return not any([s != "approved" for s in reviews.mapped("status")])
-
-    @api.model
-    def _calc_reviews_rejected(self, reviews):
-        """Override for different rejection policy."""
-        return any([s == "rejected" for s in reviews.mapped("status")])
 
     def _compute_need_validation(self):
         for rec in self:

--- a/base_tier_validation/models/tier_validation.py
+++ b/base_tier_validation/models/tier_validation.py
@@ -190,20 +190,13 @@ class TierValidation(models.AbstractModel):
         rejected_states = self._rejected_states()
         for item in self:
             reviews = item.review_ids
-            any_approved = any(reviews.filtered(lambda x: x.status in validated_states))
             any_rejected = any(reviews.filtered(lambda x: x.status in rejected_states))
             any_pending = any(reviews.filtered(lambda x: x.status == "pending"))
-            if (
-                reviews
-                and not any(
-                    reviews.filtered(lambda x: x.status not in validated_states)
-                )
-                and not any_rejected
-            ):
+            if reviews and all(x.status in validated_states for x in reviews):
                 item.validation_status = "validated"
-            elif reviews and not any_approved and any_rejected:
+            elif any_rejected:
                 item.validation_status = "rejected"
-            elif reviews and not any_approved and not any_rejected and any_pending:
+            elif any_pending:
                 item.validation_status = "pending"
             else:
                 item.validation_status = "no"

--- a/base_tier_validation_waiting/models/tier_validation.py
+++ b/base_tier_validation_waiting/models/tier_validation.py
@@ -7,6 +7,11 @@ from odoo import fields, models
 class TierValidation(models.AbstractModel):
     _inherit = "tier.validation"
 
+    validation_status = fields.Selection(
+        selection_add=[("waiting", "Waiting")],
+        ondelete={"waiting": "set default"},
+    )
+
     def _notify_review_available(self, tier_reviews):
         """method to notify when reaching pending"""
         subscribe = "message_subscribe"
@@ -50,4 +55,12 @@ class TierValidation(models.AbstractModel):
         self.ensure_one()
         self._validate_tier_waiting_reviews(tiers)
         res = super(TierValidation, self)._validate_tier(tiers)
+        return res
+
+    def _compute_validation_status(self):
+        res = super()._compute_validation_status()
+        for item in self.filtered(lambda tv: tv.validation_status == "no"):
+            any_waiting = any(item.review_ids.filtered(lambda x: x.status == "waiting"))
+            if any_waiting:
+                item.validation_status = "waiting"
         return res


### PR DESCRIPTION
Changes done:
- [x] [OU-IMP+OU-FIX]: base_tier_validation: Change/improve the migration script as discussed in https://github.com/OCA/server-ux/pull/1136#discussion_r2251063342 + compatibiity with `base_tier_validation_waiting`.
- [x] base_tier_validation_waiting: Compatibility with validation_status=waiting (similar to what already happens in 17.0).
- [x] `base_tier_validation`: Misc changes: https://github.com/OCA/server-ux/pull/1136#discussion_r2250810533 + https://github.com/OCA/server-ux/pull/1136#discussion_r2251067906 + https://github.com/OCA/server-ux/pull/1136#discussion_r2251075645 + https://github.com/OCA/server-ux/pull/1136#discussion_r2251085195
- [x] `base_tier_validation`: The validated and rejected fields are restored. Related to https://github.com/OCA/server-ux/pull/1136#issuecomment-3151284585

Please @pedrobaeza can you review it?

@Tecnativa