### PR TITLE
[18.0][FIX] base_tier_validation: Prevent errors in migration script

### DIFF
--- a/base_tier_validation/migrations/18.0.2.1.0/pre-migration.py
+++ b/base_tier_validation/migrations/18.0.2.1.0/pre-migration.py
@@ -5,7 +5,10 @@ from openupgradelib import openupgrade
 
 
 @openupgrade.migrate()
-def migrate(env, version):
+def migrate(cr, version):
+    # Workaround to execute the migration script without errors
+    # see https://github.com/odoo/odoo/blob/2a839ef1ed09c36f27ce7536ca3052d9f65ceed9/odoo/modules/migration.py#L252-L256
+    env = cr
     env.cr.execute(
         """
         SELECT imf.model


### PR DESCRIPTION
Odoo in V18 raises an error if the signature of the function is not strictly (cr, version). See: https://github.com/odoo/odoo/blob/2a839ef1ed09c36f27ce7536ca3052d9f65ceed9/odoo/modules/migration.py#L252-L256

This solves the error reported in: https://github.com/OCA/server-ux/pull/1138#pullrequestreview-3094480036

@Tecnativa @pedrobaeza @victoralmau @StefanRijnhart could you please review this?