### PR TITLE
[18.0][IMP] base_tier_validation: Duplicate t-key error when multiple reviewers have same sequence

### DIFF
--- a/base_tier_validation/static/src/components/tier_review_widget/tier_review_widget.xml
+++ b/base_tier_validation/static/src/components/tier_review_widget/tier_review_widget.xml
@@ -47,7 +47,7 @@
                                 <t
                                     t-foreach="_getReviewData()"
                                     t-as="review"
-                                    t-key="review.sequence"
+                                    t-key="review.id"
                                 >
                                     <t
                                         t-if="review.status == 'waiting'"


### PR DESCRIPTION
In server we noticed one BUG and we have already made issue on OCA
:- https://github.com/OCA/server-ux/issues/1144

- When a record has multiple reviewers assigned with the same sequence, opening the form view in debug mode raises an Owl client error due to duplicate keys in a t-foreach loop.

- Affected versions: 18.0

	- Steps to reproduce the behavior:
	- Create a record that requires tier validation.
	- Add two or more reviewers with the same sequence number.
	- Open that record in form view.
	- Activate debug/developer mode.
	- The error appears immediately.

As per lot of testing this seems perfect fix for this issue at the moment so I applied this in new branch.