### PR TITLE
[FIX] base_tier_validation: comment support approve_sequence_bypass

### DIFF
--- a/base_tier_validation/models/tier_validation.py
+++ b/base_tier_validation/models/tier_validation.py
@@ -578,6 +578,14 @@ class TierValidation(models.AbstractModel):
             for review in reviews_to_notify:
                 rec = self.env[review.model].browse(review.res_id)
                 rec._notify_accepted_reviews()
+        else:
+            post = "message_post"
+            if hasattr(self, post):
+                getattr(self.sudo(), post)(
+                    subtype_xmlid="mail.mt_note",
+                    body=self._notify_accepted_reviews_body(),
+                    message_type="comment",
+                )
 
     def _get_requested_notification_subtype(self):
         return "base_tier_validation.mt_tier_validation_requested"
@@ -605,7 +613,7 @@ class TierValidation(models.AbstractModel):
             lambda r: (self.env.user in r.reviewer_ids) and r.comment
         )
         if has_comment:
-            comment = has_comment.mapped("comment")[0]
+            comment = has_comment.mapped("comment")[-1]
             return self.env._("A review was accepted. (%s)", comment)
         return self.env._("A review was accepted")
 
@@ -659,7 +667,7 @@ class TierValidation(models.AbstractModel):
             lambda r: (self.env.user in r.reviewer_ids) and r.comment
         )
         if has_comment:
-            comment = has_comment.mapped("comment")[0]
+            comment = has_comment.mapped("comment")[-1]
             return self.env._(
                 "A review was rejected by %(user)s. (%(comment)s)",
                 user=self.env.user.name,
@@ -721,6 +729,14 @@ class TierValidation(models.AbstractModel):
             for review in reviews_to_notify:
                 rec = self.env[review.model].browse(review.res_id)
                 rec._notify_rejected_review()
+        else:
+            post = "message_post"
+            if hasattr(self, post):
+                getattr(self.sudo(), post)(
+                    subtype_xmlid="mail.mt_note",
+                    body=self._notify_rejected_review_body(),
+                    message_type="comment",
+                )
 
     def _notify_created_review_body(self):
         return self.env._(
@@ -753,6 +769,14 @@ class TierValidation(models.AbstractModel):
                         subtype_xmlid=self._get_requested_notification_subtype(),
                         body=rec._notify_created_review_body(),
                     )
+                else:
+                    post = "message_post"
+                    if hasattr(rec, post):
+                        getattr(rec.sudo(), post)(
+                            subtype_xmlid="mail.mt_note",
+                            body=rec._notify_created_review_body(),
+                            message_type="comment",
+                        )
 
     def _prepare_tier_review_vals(self, definition, sequence):
         return {
@@ -846,6 +870,14 @@ class TierValidation(models.AbstractModel):
                         ).ids,
                     )
                 rec._notify_restarted_review()
+            else:
+                post = "message_post"
+                if hasattr(self, post):
+                    getattr(self.sudo(), post)(
+                        subtype_xmlid="mail.mt_note",
+                        body=self._notify_restarted_review_body(),
+                        message_type="comment",
+                    )
 
     @api.model
     def _update_counter(self, review_counter):

--- a/base_tier_validation/models/tier_validation.py
+++ b/base_tier_validation/models/tier_validation.py
@@ -635,7 +635,11 @@ class TierValidation(models.AbstractModel):
         )
         if self.has_comment:
             user_reviews = reviews.filtered(
-                lambda r: r.status == "pending" and (self.env.user in r.reviewer_ids)
+                lambda r: (
+                    r.status == "pending"
+                    or (r.approve_sequence_bypass and r.status != "approved")
+                )
+                and (self.env.user in r.reviewer_ids)
             )
             return self._add_comment("validate", user_reviews)
         self._validate_tier(reviews)

--- a/base_tier_validation/wizard/comment_wizard.py
+++ b/base_tier_validation/wizard/comment_wizard.py
@@ -17,7 +17,10 @@ class CommentWizard(models.TransientModel):
     def add_comment(self):
         self.ensure_one()
         rec = self.env[self.res_model].browse(self.res_id)
-        self.review_ids.write({"comment": self.comment})
+        # Write only comment on last review and not on all
+        self.review_ids.sorted(lambda x: x.sequence)[-1].write(
+            {"comment": self.comment}
+        )
         if self.validate_reject == "validate":
             rec._validate_tier(self.review_ids)
         if self.validate_reject == "reject":


### PR DESCRIPTION
- the comment will only be added to last review and remove repetition

Improve https://github.com/OCA/server-ux/pull/975
Fix https://github.com/OCA/server-ux/pull/802
Fix https://github.com/OCA/server-ux/pull/803
Fix https://github.com/OCA/server-ux/pull/699

This code was ignoring approve_sequence_bypass