### PR TITLE
[18.0][IMP] base_cancel_confirm: add cancel_by and cancel_date

### DIFF
--- a/base_cancel_confirm/model/base_cancel_confirm.py
+++ b/base_cancel_confirm/model/base_cancel_confirm.py
@@ -26,6 +26,11 @@ class BaseCancelConfirm(models.AbstractModel):
         copy=False,
         help="An optional cancel reason",
     )
+    cancel_by = fields.Many2one(
+        comodel_name="res.users",
+        copy=False,
+    )
+    cancel_date = fields.Date(copy=False)
 
     def _cancel_confirm_disabled(self):
         key = f"{self._name}.cancel_confirm_disable"
@@ -50,7 +55,12 @@ class BaseCancelConfirm(models.AbstractModel):
         return action
 
     def _get_value_clear_cancel(self):
-        return {"cancel_confirm": False, "cancel_reason": False}
+        return {
+            "cancel_confirm": False,
+            "cancel_reason": False,
+            "cancel_by": False,
+            "cancel_date": False,
+        }
 
     def clear_cancel_confirm_data(self):
         self.write(self._get_value_clear_cancel())

--- a/base_cancel_confirm/views/cancel_confirm_template.xml
+++ b/base_cancel_confirm/views/cancel_confirm_template.xml
@@ -4,6 +4,8 @@
         <div>
             <group colspan="4" invisible="not cancel_reason">
                 <field name="cancel_confirm" invisible="1" />
+                <field name="cancel_by" readonly="1" />
+                <field name="cancel_date" readonly="1" />
                 <field name="cancel_reason" readonly="1" />
             </group>
         </div>

--- a/base_cancel_confirm/wizard/cancel_confirm.py
+++ b/base_cancel_confirm/wizard/cancel_confirm.py
@@ -23,7 +23,13 @@ class CancelConfirm(models.TransientModel):
         dict_update = {"cancel_confirm": True}
         # Cancel Reason
         if self.has_cancel_reason in ["optional", "required"]:
-            dict_update.update({"cancel_reason": self.cancel_reason})
+            dict_update.update(
+                {
+                    "cancel_reason": self.cancel_reason,
+                    "cancel_by": self.env.user,
+                    "cancel_date": fields.Date.context_today(self),
+                }
+            )
         return dict_update
 
     def confirm_cancel(self):


### PR DESCRIPTION
This PR implement `base_cancel_confirm` to add `cancel_by` and `cancel_date`


Depend On:
- [x] https://github.com/OCA/server-ux/pull/1169