### PR TITLE
[17.0][FIX] base_substate: Open Archived Record Error.

### DIFF
--- a/base_substate/views/base_substate_views.xml
+++ b/base_substate/views/base_substate_views.xml
@@ -19,14 +19,12 @@
         <field name="arch" type="xml">
             <form string="Base Substate" name="base_substate">
                 <sheet>
-                    <div class="oe_button_box" name="button_box">
-                        <widget
-                            name="web_ribbon"
-                            title="Archived"
-                            bg_color="bg-danger"
-                            invisible="active"
-                        />
-                    </div>
+                    <widget
+                        name="web_ribbon"
+                        title="Archived"
+                        bg_color="bg-danger"
+                        invisible="active"
+                    />
                     <div class="oe_title">
                         <label for="name" class="oe_edit_only" />
                         <h1>


### PR DESCRIPTION
Go to Base Substate 
-Set a custom filter to Active is not set
-Click on record, error occurs here, detailed error below

<img width="2811" height="1319" alt="image" src="https://github.com/user-attachments/assets/24993a79-91d1-4136-9d54-e3d76279d438" />

UncaughtPromiseError > OwlError
Uncaught Promise > Cannot find the definition of component "Widget"
OwlError: Cannot find the definition of component "Widget"
    Error: Cannot find the definition of component "Widget"
        at http://localhost:1750/web/assets/21095d2/web.assets_web.min.js:1581:33
        at FormController.slot1 (eval at compile (http://localhost:1750/web/assets/21095d2/web.assets_web.min.js:1540:421), <anonymous>:12:12)
        at callSlot (http://localhost:1750/web/assets/21095d2/web.assets_web.min.js:1132:25)
        at ButtonBox.template (eval at compile (http://localhost:1750/web/assets/21095d2/web.assets_web.min.js:1540:421), <anonymous>:53:45)
        at node.renderFn (http://localhost:1750/web/assets/21095d2/web.assets_web.min.js:1080:210)
        at Fiber._render (http://localhost:1750/web/assets/21095d2/web.assets_web.min.js:962:96)
        at Fiber.render (http://localhost:1750/web/assets/21095d2/web.assets_web.min.js:961:6)
        at ComponentNode.initiateRender (http://localhost:1750/web/assets/21095d2/web.assets_web.min.js:1031:47)