### PR TITLE
[18.0][FIX] base_cancel_confirm: format attrs invisible

### DIFF
--- a/base_cancel_confirm/views/cancel_confirm_template.xml
+++ b/base_cancel_confirm/views/cancel_confirm_template.xml
@@ -2,7 +2,7 @@
 <odoo>
     <template id="cancel_reason_template">
         <div>
-            <group colspan="4" attrs="{'invisible':[('cancel_reason', '=', False)]}">
+            <group colspan="4" invisible="not cancel_reason">
                 <field name="cancel_confirm" invisible="1" />
                 <field name="cancel_reason" readonly="1" />
             </group>


### PR DESCRIPTION
Change `attrs` to `invisible`