### PR TITLE
[18.0][FIX] base_tier_validation: prevent error when trying to access review_ids in a one2many

### DIFF
--- a/base_tier_validation/static/src/components/tier_review_widget/tier_review_widget.esm.js
+++ b/base_tier_validation/static/src/components/tier_review_widget/tier_review_widget.esm.js
@@ -12,7 +12,7 @@ export class ReviewsTable extends Component {
     }
 
     _getReviewData() {
-        const records = this.env.model.root.data.review_ids.records;
+        const records = this.props.record.data.review_ids.records;
         return records.map((record) => record.data);
     }
 


### PR DESCRIPTION
When the validations are in a model that is inside another model(some custom module), after the reviews are approved, trying to open the one2many raises an error. This commit ensures that the value is taken from the correct record instead of env.model.root, which represents the main model and not the model that inherits tier.validation.

<img width="1041" height="334" alt="image" src="https://github.com/user-attachments/assets/fddc87c0-4a29-4d42-8237-e77219f9da71" />

@pedrobaeza could you review this please?