### PR TITLE
[18.0][FIX] base_substate: fix window action view violation during migration

### DIFF
--- a/base_substate/migrations/18.0.1.0.0/pre-migration.py
+++ b/base_substate/migrations/18.0.1.0.0/pre-migration.py
@@ -1,0 +1,25 @@
+# Copyright 2025 Opener B.V. (<http://opener.amsterdam>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+
+def migrate(cr, version):
+    """Prevent violation of act_window_view_unique_mode_per_action.
+
+    Violation was triggered after rename of ir.actions.act_window.view in XML.
+    """
+    cr.execute(
+        """
+        update ir_model_data
+        set name = 'act_open_base_substate_type_view_list'
+        where name = 'act_open_base_substate_type_view_tree'
+             and module = 'base_substate';
+        update ir_model_data
+        set name = 'act_open_target_state_value_view_list'
+        where name = 'act_open_target_state_value_view_tree'
+             and module = 'base_substate';
+        update ir_model_data
+        set name = 'act_open_base_substate_view_list'
+        where name = 'act_open_base_substate_view_tree'
+             and module = 'base_substate';
+        """
+    )


### PR DESCRIPTION
Fixes
```
psycopg2.errors.UniqueViolation: duplicate key value violates unique constraint "act_window_view_unique_mode_per_action"
DETAIL:  Key (act_window_id, view_mode)=(755, list) already exists.

odoo.tools.convert.ParseError: while parsing /home/odoo/odoo18/src/server-ux/base_substate/views/base_substate_type_views.xml:67, somewhere inside
<record id="act_open_base_substate_type_view_list" model="ir.actions.act_window.view">
        <field name="act_window_id" ref="act_open_base_substate_type_view"/>
        <field name="sequence" eval="10"/>
        <field name="view_mode">list</field>
        <field name="view_id" ref="base_substate_type_view_list"/>
    </record>
```
after updating the module on a database that was migrated using Odoo's enterprise upgrade service.