### PR TITLE
[17.0][IMP] base_optional_quick_create: allow_quick_create context flag

### DIFF
--- a/base_optional_quick_create/models/ir_model.py
+++ b/base_optional_quick_create/models/ir_model.py
@@ -63,6 +63,8 @@ class IrModel(models.Model):
         def _wrap_name_create():
             @api.model
             def wrapper(self, name):
+                if self.env.context.get("allow_quick_create"):
+                    return wrapper.origin(self, name)
                 raise UserError(
                     _(
                         "Can't create %(model)s with name %(name)s quickly.\n"

--- a/base_optional_quick_create/tests/test_quick_create.py
+++ b/base_optional_quick_create/tests/test_quick_create.py
@@ -4,16 +4,23 @@
 from odoo.exceptions import UserError
 from odoo.tests.common import TransactionCase
 
+from odoo.addons.base.tests.common import DISABLED_MAIL_CONTEXT
+
 
 class TestQuickCreate(TransactionCase):
-    def setUp(self, *args, **kwargs):
-        super().setUp()
-        model_model = self.env["ir.model"]
-        self.partner_model = model_model.search([("model", "=", "res.partner")])
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env = cls.env(context=dict(cls.env.context, **DISABLED_MAIL_CONTEXT))
+        cls.partner_model = cls.env["ir.model"].search([("model", "=", "res.partner")])
+
+    def tearDown(self):
+        super().tearDown()
+        self.partner_model.avoid_quick_create = False
 
     def test_quick_create(self):
-        partner_id = self.env["res.partner"].name_create("TEST partner")
-        self.assertEqual(bool(partner_id), True)
+        partner = self.env["res.partner"].name_create("TEST partner")
+        self.assertEqual(bool(partner), True)
 
         # Setting the flag, patches the method
         self.partner_model.avoid_quick_create = True
@@ -22,11 +29,10 @@ class TestQuickCreate(TransactionCase):
 
         # Unsetting the flag, unpatches the method
         self.partner_model.avoid_quick_create = False
-        partner_id = self.env["res.partner"].name_create("TEST partner")
-        self.assertEqual(bool(partner_id), True)
+        partner = self.env["res.partner"].name_create("TEST partner")
+        self.assertEqual(bool(partner), True)
 
         # New Model
-
         # Setting the flag, patches the method
         self.env["ir.model"].create(
             {"name": "Test Model", "model": "x_.test.model", "avoid_quick_create": True}
@@ -42,5 +48,36 @@ class TestQuickCreate(TransactionCase):
                 "avoid_quick_create": False,
             }
         )
-        test_id = self.env["x_.test.model.quick"].name_create("TEST Model")
-        self.assertEqual(bool(test_id), True)
+        test_quick = self.env["x_.test.model.quick"].name_create("TEST Model")
+        self.assertEqual(bool(test_quick), True)
+
+    def test_allow_quick_create(self):
+        # Setting the flag, patches the method
+        self.partner_model.avoid_quick_create = True
+        with self.assertRaises(UserError):
+            self.env["res.partner"].name_create("TEST allow_quick_create")
+
+        # With allow_quick_create context flag
+        partner = (
+            self.env["res.partner"]
+            .with_context(allow_quick_create=True)
+            .name_create("TEST allow_quick_create")
+        )
+        self.assertEqual(bool(partner), True)
+
+        # New Model
+        # Setting the flag, patches the method
+        self.env["ir.model"].create(
+            {
+                "name": "Test Model",
+                "model": "x_.test.model.allow",
+                "avoid_quick_create": True,
+            }
+        )
+        # With allow_quick_create context flag
+        test_allow = (
+            self.env["x_.test.model.allow"]
+            .with_context(allow_quick_create=True)
+            .name_create("TEST Model")
+        )
+        self.assertEqual(bool(test_allow), True)


### PR DESCRIPTION
Introduce an `allow_quick_create` context flag to bypass the restriction applied by models with `avoid_quick_create` enabled. This allows controlled quick creation of records in specific, legitimate cases.

For example, the method `mail.thread::_mail_find_partner_from_emails(emails, records=None, force_create=False, extra_domain=False)`, with `force_create` set to `True`, creates a new partner (if not found) by using `name_create`:
```
partner = self.env['res.partner'].browse(self.env['res.partner'].name_create(contact)[0])
```
cf. https://github.com/odoo/odoo/blob/35ed88e2e6f66147c4c1582761df1e53011b3643/addons/mail/models/mail_thread.py#L1971-L2039

When `avoid_quick_create` is enabled on the `res.partner` model, an unwanted `UserError` is raised.

With the new `allow_quick_create` context flag, such internal operations can safely bypass the restriction while keeping it enforced for regular user actions. 
This requires to extend core methods in order to inject that context flag.