### PR TITLE
[IMP][CL] Blacklist exeptions

### DIFF
--- a/base_tier_validation/__manifest__.py
+++ b/base_tier_validation/__manifest__.py
@@ -3,7 +3,7 @@
 {
     "name": "Base Tier Validation",
     "summary": "Implement a validation process based on tiers.",
-    "version": "18.0.3.1.0",
+    "version": "18.0.3.1.1",
     "development_status": "Mature",
     "maintainers": ["LoisRForgeFlow"],
     "category": "Tools",

--- a/base_tier_validation/models/tier_validation.py
+++ b/base_tier_validation/models/tier_validation.py
@@ -274,23 +274,37 @@ class TierValidation(models.AbstractModel):
         else:
             return self
 
-    @api.model
-    def _get_validation_exceptions(self, extra_domain=None, add_base_exceptions=True):
-        """Return Tier Validation Exception field names that matchs custom domain."""
+    def _get_exception_fields(self, is_black_list=False, extra_domain=False):
         exception_fields = (
             self.env["tier.validation.exception"]
             .sudo()
             .search(
                 [
                     ("model_name", "=", self._name),
-                    ("company_id", "in", [False] + self._get_company().ids),
+                    ("company_id", "in", [False] + self.env.company.ids),
+                    ("is_black_list", "=", is_black_list),
                     "|",
                     ("group_ids", "in", self.env.user.groups_id.ids),
                     ("group_ids", "=", False),
                     *(extra_domain or []),
                 ]
             )
-            .mapped("field_ids.name")
+        )
+        if is_black_list:
+            return set(
+                (
+                    exception_fields.valid_model_field_ids
+                    - exception_fields.mapped("field_ids")
+                ).mapped("name")
+            )
+        return set(exception_fields.mapped("field_ids.name"))
+
+    @api.model
+    def _get_validation_exceptions(self, extra_domain=None, add_base_exceptions=True):
+        """Return Tier Validation Exception field names that matchs custom domain."""
+        exception_fields = list(
+            self._get_exception_fields(extra_domain=extra_domain)
+            or self._get_exception_fields(is_black_list=True, extra_domain=extra_domain)
         )
         if add_base_exceptions:
             exception_fields += BASE_EXCEPTION_FIELDS

--- a/base_tier_validation/models/tier_validation_exception.py
+++ b/base_tier_validation/models/tier_validation_exception.py
@@ -59,6 +59,13 @@ class TierValidationException(models.Model):
         string="Groups",
         help="Allowed groups to use this Tier Validation Exception",
     )
+    is_black_list = fields.Boolean(
+        string="Use like Black List",
+        help="If this option is selected, this exception will act "
+        "as a blacklist, meaning that the selected fields will NOT "
+        "be allowed for the specified model, but editing will be "
+        "enabled for all others.",
+    )
 
     @api.depends("model_id")
     def _compute_valid_model_field_ids(self):

--- a/base_tier_validation/tests/test_tier_validation.py
+++ b/base_tier_validation/tests/test_tier_validation.py
@@ -947,6 +947,7 @@ class TierTierValidation(CommonTierValidation):
         # Able to write test_validation_field after validation
         with mock.patch.multiple(
             TV,
+            _get_exception_fields=mock.MagicMock(return_value=_tvf),
             _get_validation_exceptions=mock.MagicMock(return_value=_tvf),
             _get_after_validation_exceptions=mock.MagicMock(return_value=_rv),
         ):

--- a/base_tier_validation/views/tier_validation_exception_view.xml
+++ b/base_tier_validation/views/tier_validation_exception_view.xml
@@ -36,6 +36,7 @@
                                 name="model_id"
                                 options="{'no_create': True, 'no_open': True}"
                             />
+                            <field name="is_black_list" />
                             <field
                                 name="field_ids"
                                 widget="many2many_tags"


### PR DESCRIPTION
An improvement has been made to define an exception by simulating a blacklist, so that if more modules are installed or created, it will not be necessary to add new fields to the exceptions. This is because there are cases where most fields can be edited, but not the category or critical fields.

ATT: César León from Trescloud