### PR TITLE
[18.0][FIX] base_tier_validation_forward: fix multiple reviews in 'pending' after forward

### DIFF
--- a/base_tier_validation/models/tier_review.py
+++ b/base_tier_validation/models/tier_review.py
@@ -94,6 +94,14 @@ class TierReview(models.Model):
 
     @api.depends("definition_id.approve_sequence")
     def _compute_can_review(self):
+        """Update review status. Called manually from various review operations.
+
+        To defer recompute, use context key
+        `tier_validation_defer_compute_can_review`. Be sure to explicitely call
+        the method afterwards.
+        """
+        if self.env.context.get("tier_validation_defer_compute_can_review"):
+            return
         reviews = self.filtered(lambda rev: rev.status in ["waiting", "pending"])
         if reviews:
             # get minimum sequence of all to prevent jumps

--- a/base_tier_validation/models/tier_review.py
+++ b/base_tier_validation/models/tier_review.py
@@ -14,6 +14,7 @@ _logger = logging.getLogger(__name__)
 class TierReview(models.Model):
     _name = "tier.review"
     _description = "Tier Review"
+    _order = "sequence, id"
 
     name = fields.Char(related="definition_id.name")
     status = fields.Selection(

--- a/base_tier_validation_forward/models/tier_review.py
+++ b/base_tier_validation_forward/models/tier_review.py
@@ -5,7 +5,6 @@ from odoo import api, fields, models
 
 class TierReview(models.Model):
     _inherit = "tier.review"
-    _order = "sequence"
 
     # NOTE: Added translate=True because in the compute method we assign:
     #   rec.name = rec.definition_id.name

--- a/base_tier_validation_forward/tests/test_tier_validation.py
+++ b/base_tier_validation_forward/tests/test_tier_validation.py
@@ -1,7 +1,7 @@
 # Copyright 2018 ForgeFlow S.L.
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
 
-from odoo.tests import Form, tagged
+from odoo.tests import Form, new_test_user, tagged
 
 from odoo.addons.base_tier_validation.tests.common import CommonTierValidation
 
@@ -11,6 +11,7 @@ class TierTierValidation(CommonTierValidation):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+        cls.other_test_user = new_test_user(cls.env, name="Clarissa", login="forward")
 
     def test_01_forward_tier(self):
         # Create new test record
@@ -65,3 +66,143 @@ class TierTierValidation(CommonTierValidation):
         wiz = wizard.save()
         wiz.add_comment()
         self.assertEqual(record.validation_status, "validated")
+
+    def _test_forward_tier_multiple(self, has_comment=False):
+        """Run forwarding flow with or without comments"""
+        self.tier_def_obj.create(
+            {
+                "approve_sequence": True,
+                "definition_domain": "[('test_field', '>', 1.0)]",
+                "has_comment": has_comment,
+                "has_forward": True,
+                "model_id": self.tester_model.id,
+                "review_type": "individual",
+                "reviewer_id": self.test_user_1.id,
+                "sequence": 2,
+            }
+        )
+        self.tier_def_obj.create(
+            {
+                "approve_sequence": True,
+                "definition_domain": "[('test_field', '>', 1.0)]",
+                "has_comment": True,
+                "has_forward": True,
+                "model_id": self.tester_model.id,
+                "review_type": "individual",
+                "reviewer_id": self.test_user_2.id,
+                "sequence": 1,
+            }
+        )
+        # Create new test record
+        test_record = self.test_model.create({"test_field": 2.5})
+        test_record.with_user(self.test_user_2.id).request_validation()
+        self.env.invalidate_all()
+        self.assertRecordValues(
+            test_record.review_ids,
+            [
+                {
+                    "reviewer_id": self.test_user_1.id,
+                    "status": "pending",
+                },
+                {
+                    "reviewer_id": self.test_user_2.id,
+                    "status": "waiting",
+                },
+            ],
+        )
+        # Forward the first review
+        action = test_record.with_user(self.test_user_1).forward_tier()
+        self.env[action["res_model"]].with_user(self.test_user_1).with_context(
+            **action["context"]
+        ).create(
+            {
+                "forward_reviewer_id": self.other_test_user.id,
+                "forward_description": "Have a look",
+            }
+        ).add_forward()
+        # The forwarded review is now in status 'forwarded',
+        # The new review is in state 'pending',
+        # and the remaining review is in status 'waiting'.
+        self.assertRecordValues(
+            test_record.review_ids,
+            [
+                {
+                    "reviewer_id": self.test_user_1.id,
+                    "status": "forwarded",
+                },
+                {
+                    "reviewer_id": self.other_test_user.id,
+                    "status": "pending",
+                },
+                {
+                    "reviewer_id": self.test_user_2.id,
+                    "status": "waiting",
+                },
+            ],
+        )
+
+        action = test_record.with_user(self.other_test_user).validate_tier()
+        if action:
+            self.env[action["res_model"]].with_user(self.other_test_user).with_context(
+                **action["context"]
+            ).create(
+                {
+                    "comment": "Reviewed",
+                }
+            ).add_comment()
+
+        self.assertRecordValues(
+            test_record.review_ids,
+            [
+                {
+                    "reviewer_id": self.test_user_1.id,
+                    "status": "forwarded",
+                },
+                {
+                    "reviewer_id": self.other_test_user.id,
+                    "status": "approved",
+                },
+                {
+                    "reviewer_id": self.test_user_2.id,
+                    "status": "pending",
+                },
+            ],
+        )
+
+        action = test_record.with_user(self.test_user_2).validate_tier()
+        if action:
+            self.env[action["res_model"]].with_user(self.test_user_2).with_context(
+                **action["context"]
+            ).create(
+                {
+                    "comment": "Reviewed",
+                }
+            ).add_comment()
+
+        self.assertRecordValues(
+            test_record.review_ids,
+            [
+                {
+                    "reviewer_id": self.test_user_1.id,
+                    "status": "forwarded",
+                },
+                {
+                    "reviewer_id": self.other_test_user.id,
+                    "status": "approved",
+                },
+                {
+                    "reviewer_id": self.test_user_2.id,
+                    "status": "approved",
+                },
+            ],
+        )
+        self.assertEqual(test_record.validation_status, "validated")
+
+    def test_02_forward_tier_multiple_with_comment(self):
+        """Expected flow with forwards and comments"""
+        # Create tier definitions with a different sequence
+        self._test_forward_tier_multiple(has_comment=True)
+
+    def test_03_forward_tier_multiple_without_comment(self):
+        """Expected flow with forwards, but without comments"""
+        self._test_forward_tier_multiple(has_comment=False)

--- a/base_tier_validation_forward/wizard/forward_wizard.py
+++ b/base_tier_validation_forward/wizard/forward_wizard.py
@@ -35,15 +35,21 @@ class ValidationForwardWizard(models.TransientModel):
                 )
             }
         )
-        prev_comment.add_comment()
+        prev_comment.with_context(
+            tier_validation_defer_compute_can_review=True
+        ).add_comment()
         prev_reviews = prev_comment.review_ids
-        review = self.env["tier.review"].create(
-            {
-                "model": rec._name,
-                "res_id": rec.id,
-                "sequence": max(prev_reviews.mapped("sequence")) + 0.1,
-                "requested_by": self.env.uid,
-            }
+        review = (
+            self.env["tier.review"]
+            .with_context(tier_validation_defer_compute_can_review=True)
+            .create(
+                {
+                    "model": rec._name,
+                    "res_id": rec.id,
+                    "sequence": max(prev_reviews.mapped("sequence")),
+                    "requested_by": self.env.uid,
+                }
+            )
         )
         # Because following fields are readonly, we need to write after create
         review.write(


### PR DESCRIPTION
# How to reproduce:
    
* Create two reviews for the same model with different sequences and `Approve by
    sequence` enabled.
* Request validation on a record. Let the user of the first review forward the
    first validation.
   
# Desired result:

The new (forward) review is in state 'pending', and the remaining review is in state 'waiting'.
    
# Actual result:
    
Both the new (forward) review and the remaining review are in state 'pending'.
    
# Suggested solution:
    
`_compute_can_review` has to be deferred during the fowarding process. It was called explicitely afterwards already.
