### PR TITLE
[16.0][FIX] base_cancel_confirm: Fix missing fields in models dict

### DIFF
--- a/base_cancel_confirm/model/base_cancel_confirm.py
+++ b/base_cancel_confirm/model/base_cancel_confirm.py
@@ -71,8 +71,12 @@ class BaseCancelConfirm(models.AbstractModel):
                     node.addnext(new_element)
                 for model in new_models:
                     if model in all_models:
-                        continue
-                    all_models[model] = new_models[model]
+                        # Merge field names: existing fields (tuple) + new fields (set)
+                        all_models[model] = tuple(
+                            set(all_models[model]) | new_models[model]
+                        )
+                    else:
+                        all_models[model] = tuple(new_models[model])
             res["arch"] = etree.tostring(doc)
             res["models"] = frozendict(all_models)
         return res


### PR DESCRIPTION
Fixes #1190

When `base_cancel_confirm` injects fields into view XML, those fields must also be added to the models dictionary returned by `get_view()`.

**The bug:** Lines 72-77 skipped merging fields when the model already existed:
```python
if model in all_models:
    continue  # Bug: skips merging!
```

This caused JavaScript errors:
> Missing field string information for the field 'cancel_confirm' from the 'account.payment' model

**The fix:** Merge new fields with existing ones instead of skipping.

**Impact:** All models using `base.cancel.confirm` (account.payment, account.move, sale.order, purchase.order, etc.)

**Testing:** Verified with account.payment forms - no more JS errors.