### PR TITLE
[IMP] document_quick_access_folder_auto_classification: Add Python-OpenCV as backup check

### DIFF
--- a/document_quick_access_folder_auto_classification/tests/test_document_quick_access_auto_classification.py
+++ b/document_quick_access_folder_auto_classification/tests/test_document_quick_access_auto_classification.py
@@ -4,6 +4,11 @@
 import base64
 from unittest.mock import patch
 
+try:
+    import cv2
+except ImportError:
+    cv2 = None
+
 from odoo import tools
 from odoo.tools import mute_logger
 
@@ -207,6 +212,54 @@ class TestDocumentQuickAccessClassification(TransactionComponentRegistryCase):
         missing.invalidate_recordset()
         self.assertEqual(missing.edi_exchange_state, "input_processed")
         self.assertFalse(missing.model)
+
+    def test_no_ok_cv2_ok_multi(self):
+        if cv2 is None:
+            self.skipTest("OpenCV is not installed")
+        partners = self.env["res.partner"].create({"name": "Partner 1"})
+        partners |= self.env["res.partner"].create({"name": "Partner 2"})
+        partners |= self.env["res.partner"].create({"name": "Partner 3"})
+        partners |= self.env["res.partner"].create({"name": "Partner 4"})
+        self.test_no_ok_cv2_ok(partners)
+
+    @mute_logger("odoo.addons.queue_job.models.base")
+    def test_no_ok_cv2_ok(self, partners=False):
+        if cv2 is None:
+            self.skipTest("OpenCV is not installed")
+        if not partners:
+            partners = self.env["res.partner"].create({"name": "Partner"})
+        file = tools.file_open(
+            "addons/document_quick_access_folder_auto_classification/tests/test_file.pdf",
+            mode="rb",
+        ).read()
+        self.env["document.quick.access.rule"].create(
+            {
+                "model_id": self.model_id.id,
+                "name": "PARTNER",
+                "priority": 1,
+                "barcode_format": "standard",
+            }
+        )
+        code = [partner.get_quick_access_code() for partner in partners]
+        with patch.object(cv2.QRCodeDetector, "detectAndDecodeMulti") as ptch:
+            ptch.return_value = [True, code, [], []]
+            self.backend.create_record(
+                "document_quick_access",
+                {
+                    "exchange_filename": "test_file.pdf",
+                    "exchange_file": base64.b64encode(file),
+                    "edi_exchange_state": "input_received",
+                },
+            )
+            self.backend._cron_check_input_exchange_sync()
+            self.assertEqual(ptch.call_count, 1)
+        self.assertTrue(partners)
+        for partner in partners:
+            self.assertTrue(
+                self.env["ir.attachment"].search(
+                    [("res_model", "=", partner._name), ("res_id", "=", partner.id)]
+                )
+            )
 
     @mute_logger("odoo.addons.queue_job.models.base")
     def test_corrupted(self):

--- a/document_quick_access_folder_auto_classification/tests/test_document_quick_access_auto_classification.py
+++ b/document_quick_access_folder_auto_classification/tests/test_document_quick_access_auto_classification.py
@@ -58,7 +58,7 @@ class TestDocumentQuickAccessClassification(TransactionComponentRegistryCase):
         partners |= self.env["res.partner"].create({"name": "Partner 4"})
         self.test_ok_pdf(partners)
 
-    @mute_logger("odoo.addons.queue_job.models.base")
+    @mute_logger("odoo.addons.queue_job.utils")
     def test_ok_pdf(self, partners=False):
         """Assign automatically PDFs to their assigned place"""
         if not partners:
@@ -103,7 +103,7 @@ class TestDocumentQuickAccessClassification(TransactionComponentRegistryCase):
                 )
             )
 
-    @mute_logger("odoo.addons.queue_job.models.base")
+    @mute_logger("odoo.addons.queue_job.utils")
     def test_no_ok_assign(self):
         """Assign failed files"""
         file = tools.file_open(
@@ -159,7 +159,7 @@ class TestDocumentQuickAccessClassification(TransactionComponentRegistryCase):
         self.assertEqual(partner._name, action["res_model"])
         self.assertEqual(partner.id, action["res_id"])
 
-    @mute_logger("odoo.addons.queue_job.models.base")
+    @mute_logger("odoo.addons.queue_job.utils")
     def test_failure(self):
         """We will check that if a major exception raises all is handled"""
         file = tools.file_open(
@@ -182,7 +182,7 @@ class TestDocumentQuickAccessClassification(TransactionComponentRegistryCase):
                 )
                 self.backend._cron_check_input_exchange_sync()
 
-    @mute_logger("odoo.addons.queue_job.models.base")
+    @mute_logger("odoo.addons.queue_job.utils")
     def test_no_ok_reject(self):
         """We will check that we can manage and reject failed files"""
         file = tools.file_open(
@@ -222,7 +222,7 @@ class TestDocumentQuickAccessClassification(TransactionComponentRegistryCase):
         partners |= self.env["res.partner"].create({"name": "Partner 4"})
         self.test_no_ok_cv2_ok(partners)
 
-    @mute_logger("odoo.addons.queue_job.models.base")
+    @mute_logger("odoo.addons.queue_job.utils")
     def test_no_ok_cv2_ok(self, partners=False):
         if cv2 is None:
             self.skipTest("OpenCV is not installed")
@@ -261,7 +261,7 @@ class TestDocumentQuickAccessClassification(TransactionComponentRegistryCase):
                 )
             )
 
-    @mute_logger("odoo.addons.queue_job.models.base")
+    @mute_logger("odoo.addons.queue_job.utils")
     def test_corrupted(self):
         """We will check that corrupted files are stored also"""
         file = tools.file_open(

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,1 +1,4 @@
-odoo-test-helper
+odoo_test_helper
+numpy
+--prefer-binary
+opencv-python-headless


### PR DESCRIPTION
It was on 14, but it was not ported.

Also including a fix to remove warnings on logs.