### PR TITLE
[18.0][FIX] base tier validation: fix got duplacate key

### DIFF
--- a/base_tier_validation/static/src/components/tier_review_widget/tier_review_widget.xml
+++ b/base_tier_validation/static/src/components/tier_review_widget/tier_review_widget.xml
@@ -47,7 +47,7 @@
                                 <t
                                     t-foreach="_getReviewData()"
                                     t-as="review"
-                                    t-key="review.sequence"
+                                    t-key="review.id"
                                 >
                                     <t
                                         t-if="review.status == 'waiting'"


### PR DESCRIPTION
Issue: Got duplicate key in t-foreach
<img width="831" height="344" alt="image" src="https://github.com/user-attachments/assets/7ec626b7-8fbc-48da-bd4c-42fa19812ed2" />

Detail
- use id to key