### PR TITLE
[17.0] [FIX] Translated stored related field warning on `tier.review.name`.

### DIFF
--- a/base_tier_validation_forward/models/tier_review.py
+++ b/base_tier_validation_forward/models/tier_review.py
@@ -7,7 +7,12 @@ class TierReview(models.Model):
     _inherit = "tier.review"
     _order = "sequence"
 
-    name = fields.Char(compute="_compute_definition_data", store=True)
+    name = fields.Char(
+        compute="_compute_definition_data",
+        related=None,
+        store=True,
+        string="Description",
+    )
     status = fields.Selection(
         selection_add=[("forwarded", "Forwarded")],
     )


### PR DESCRIPTION
Proposal to fix `WARNING odoo.fields: Translated stored related field (tier.review.name) will not be computed correctly in all languages`.

The above warning is raised on every related field that is both stored and translatable. As the field inheritance in question makes a related field computed, this can be fixed by explicitly making the field _not_ related anymore.

Other proposals are welcome!