### PR TITLE
[18.0][IMP] base_tier_validation_forward: preserve add_comment return

### DIFF
--- a/base_tier_validation_forward/wizard/comment_wizard.py
+++ b/base_tier_validation_forward/wizard/comment_wizard.py
@@ -7,9 +7,9 @@ class CommentWizard(models.TransientModel):
     _inherit = "comment.wizard"
 
     def add_comment(self):
-        super().add_comment()
+        res = super().add_comment()
         rec = self.env[self.res_model].browse(self.res_id)
         if self.validate_reject == "forward":
             rec._forward_tier(self.review_ids)
         rec._update_counter({"review_created": True})
-        return self.review_ids
+        return res

--- a/base_tier_validation_forward/wizard/forward_wizard.py
+++ b/base_tier_validation_forward/wizard/forward_wizard.py
@@ -35,7 +35,8 @@ class ValidationForwardWizard(models.TransientModel):
                 )
             }
         )
-        prev_reviews = prev_comment.add_comment()
+        prev_comment.add_comment()
+        prev_reviews = prev_comment.review_ids
         review = self.env["tier.review"].create(
             {
                 "model": rec._name,


### PR DESCRIPTION
The override of **add_comment()** changed the method’s return type, breaking standard wizard chaining and causing incompatibilities with other modules.