### PR TITLE
[18.0][IMP] base_tier_validation: handle multiple validations in different states

### DIFF
--- a/base_tier_validation/models/tier_validation.py
+++ b/base_tier_validation/models/tier_validation.py
@@ -40,6 +40,10 @@ class TierValidation(models.AbstractModel):
         domain=lambda self: [("model", "=", self._name)],
         auto_join=True,
     )
+    current_review_ids = fields.Many2many(
+        comodel_name="tier.review",
+        compute="_compute_current_review_ids",
+    )
     # TODO: Delete in v19 in favor of validation_status field
     validated = fields.Boolean(
         compute="_compute_validated_rejected", search="_search_validated"
@@ -82,7 +86,7 @@ class TierValidation(models.AbstractModel):
 
     def _compute_has_comment(self):
         for rec in self:
-            has_comment = rec.review_ids.filtered(
+            has_comment = rec.current_review_ids.filtered(
                 lambda r: r.status in ("waiting", "pending")
                 and self.env.user in r.reviewer_ids
             ).mapped("has_comment")
@@ -105,6 +109,30 @@ class TierValidation(models.AbstractModel):
             if my_sequence <= min_sequence:
                 sequences.append(my_sequence)
         return sequences
+
+    def _get_valid_definitions(self):
+        self.ensure_one()
+        tiers = (
+            self.env["tier.definition"]
+            .with_context(active_test=True)
+            .search(
+                [
+                    ("model", "=", self._name),
+                    ("company_id", "in", [False] + self._get_company().ids),
+                ]
+            )
+        )
+        return [tier for tier in tiers if self.evaluate_tier(tier)]
+
+    def _get_current_reviews(self, tiers=None):
+        if tiers:
+            valid_tiers = tiers
+        else:
+            valid_tiers = self._get_valid_definitions()
+        valid_reviews = self.review_ids.filtered(
+            lambda r: r.definition_id in valid_tiers
+        )
+        return valid_reviews
 
     @api.depends_context("uid")
     @api.depends("review_ids.status")
@@ -131,6 +159,11 @@ class TierValidation(models.AbstractModel):
             rec.reviewer_ids = rec.review_ids.filtered(
                 lambda r: r.status in ("waiting", "pending")
             ).mapped("reviewer_ids")
+
+    @api.depends(lambda self: [self._state_field])
+    def _compute_current_review_ids(self):
+        for rec in self:
+            rec.current_review_ids = rec._get_current_reviews()
 
     # TODO: delete in 19.0 migration in favor of validation_status field
     @api.model
@@ -221,7 +254,7 @@ class TierValidation(models.AbstractModel):
         validated_states = self._validated_states()
         rejected_states = self._rejected_states()
         for item in self:
-            reviews = item.review_ids
+            reviews = item._get_current_reviews()
             any_rejected = any(reviews.filtered(lambda x: x.status in rejected_states))
             any_pending = any(reviews.filtered(lambda x: x.status == "pending"))
             any_waiting = any(item.review_ids.filtered(lambda x: x.status == "waiting"))
@@ -252,19 +285,10 @@ class TierValidation(models.AbstractModel):
             if isinstance(rec.id, models.NewId):
                 rec.need_validation = False
                 continue
-            tiers = (
-                self.env["tier.definition"]
-                .with_context(active_test=True)
-                .search(
-                    [
-                        ("model", "=", self._name),
-                        ("company_id", "in", [False] + rec._get_company().ids),
-                    ]
-                )
-            )
-            valid_tiers = any([rec.evaluate_tier(tier) for tier in tiers])
+            valid_tiers = rec._get_valid_definitions()
+            valid_reviews = rec._get_current_reviews(tiers=valid_tiers)
             rec.need_validation = (
-                not rec.review_ids and valid_tiers and rec._check_state_from_condition()
+                not valid_reviews and valid_tiers and rec._check_state_from_condition()
             )
 
     def evaluate_tier(self, tier):
@@ -325,7 +349,9 @@ class TierValidation(models.AbstractModel):
         or for reviewers for all fields, even when the record is under
         validation."""
         if (
-            all(self.review_ids.mapped("definition_id.allow_write_for_reviewer"))
+            all(
+                self.current_review_ids.mapped("definition_id.allow_write_for_reviewer")
+            )
             and self.env.user in self.reviewer_ids
         ):
             return True
@@ -427,7 +453,7 @@ class TierValidation(models.AbstractModel):
                                 "\n - ".join(pending_reviews),
                             )
                         )
-                if rec.review_ids and rec.validation_status != "validated":
+                if rec.current_review_ids and rec.validation_status != "validated":
                     raise ValidationError(
                         self.env._(
                             "A validation process is still open for at least "
@@ -439,7 +465,7 @@ class TierValidation(models.AbstractModel):
         for rec in self:
             # Write under validation
             if (
-                rec.review_ids
+                rec.current_review_ids
                 and rec._check_tier_state_transition(vals)
                 and not rec._check_allow_write_under_validation(vals)
                 and not rec._context.get("skip_validation_check")
@@ -644,14 +670,14 @@ class TierValidation(models.AbstractModel):
     def reject_tier(self):
         self.ensure_one()
         sequences = self._get_sequences_to_approve(self.env.user)
-        reviews = self.review_ids.filtered(lambda x: x.sequence in sequences)
+        reviews = self.current_review_ids.filtered(lambda x: x.sequence in sequences)
         if self.has_comment:
             return self._add_comment("reject", reviews)
         self._rejected_tier(reviews)
         self._update_counter({"review_deleted": True})
 
     def _notify_rejected_review_body(self):
-        has_comment = self.review_ids.filtered(
+        has_comment = self.current_review_ids.filtered(
             lambda r: (self.env.user in r.reviewer_ids) and r.comment
         )
         if has_comment:
@@ -674,7 +700,7 @@ class TierValidation(models.AbstractModel):
 
     def _rejected_tier(self, tiers=False):
         self.ensure_one()
-        tier_reviews = tiers or self.review_ids
+        tier_reviews = tiers or self.current_review_ids
         user_reviews = tier_reviews.filtered(
             lambda r: r.status in ("waiting", "pending")
             and self.env.user in r.reviewer_ids
@@ -771,23 +797,15 @@ class TierValidation(models.AbstractModel):
         return company_id
 
     def request_validation(self):
-        td_obj = self.env["tier.definition"]
         tr_obj = self.env["tier.review"]
         vals_list = []
         for rec in self:
             if rec._check_state_from_condition() and rec.need_validation:
-                tier_definitions = td_obj.search(
-                    [
-                        ("model", "=", self._name),
-                        ("company_id", "in", [False] + rec._get_company().ids),
-                    ],
-                    order="sequence desc",
-                )
-                sequence = 0
+                tier_definitions = self._get_valid_definitions()
+                sequence = len(rec.review_ids)
                 for td in tier_definitions:
-                    if rec.evaluate_tier(td):
-                        sequence += 1
-                        vals_list.append(rec._prepare_tier_review_vals(td, sequence))
+                    sequence += 1
+                    vals_list.append(rec._prepare_tier_review_vals(td, sequence))
         created_trs = tr_obj.create(vals_list)
         if any(self.mapped("can_review")):
             self._update_counter({"review_created": True})
@@ -816,7 +834,7 @@ class TierValidation(models.AbstractModel):
                     and True
                     or False
                 )
-                reviews_to_notify = rec.review_ids.filtered(
+                reviews_to_notify = rec.current_review_ids.filtered(
                     lambda r: r.definition_id.notify_on_restarted
                 )
                 if reviews_to_notify:
@@ -826,12 +844,12 @@ class TierValidation(models.AbstractModel):
                         .ids
                     )
                 can_review = rec.can_review
-                rec.mapped("review_ids").unlink()
+                rec._get_current_reviews().unlink()
                 if to_update_counter and can_review:
                     self._update_counter({"review_deleted": True})
             if partners_to_notify_ids:
                 subscribe = "message_subscribe"
-                reviews_to_notify = rec.review_ids.filtered(
+                reviews_to_notify = rec.current_review_ids.filtered(
                     lambda r: r.definition_id.notify_on_restarted
                 )
                 if hasattr(self, subscribe):

--- a/base_tier_validation/templates/tier_validation_templates.xml
+++ b/base_tier_validation/templates/tier_validation_templates.xml
@@ -12,7 +12,7 @@
             <button
                 name="restart_validation"
                 string="Restart Validation"
-                invisible="not review_ids or hide_reviews"
+                invisible="not current_review_ids or hide_reviews"
                 type="object"
             />
         </div>
@@ -22,7 +22,7 @@
             <div
                 class="alert alert-warning mb-0"
                 role="alert"
-                t-attf-invisible="validation_status == 'validated' or hide_reviews or validation_status == 'rejected' or not review_ids"
+                t-attf-invisible="validation_status == 'validated' or hide_reviews or validation_status == 'rejected' or not current_review_ids"
             >
                 <p class="mb-1">
                 <i class="fa fa-lg fa-info-circle" />

--- a/base_tier_validation/tests/common.py
+++ b/base_tier_validation/tests/common.py
@@ -19,6 +19,7 @@ class CommonTierValidation(BaseCommon):
             TierValidationTester,
             TierValidationTester2,
             TierValidationTesterComputed,
+            TierValidationTesterMultipleStates,
         )
 
         self.loader.update_registry(
@@ -26,6 +27,7 @@ class CommonTierValidation(BaseCommon):
                 TierValidationTester,
                 TierValidationTester2,
                 TierValidationTesterComputed,
+                TierValidationTesterMultipleStates,
                 TierDefinition,
             )
         )
@@ -33,6 +35,9 @@ class CommonTierValidation(BaseCommon):
         self.test_model = self.env[TierValidationTester._name]
         self.test_model_2 = self.env[TierValidationTester2._name]
         self.test_model_computed = self.env[TierValidationTesterComputed._name]
+        self.test_model_multiple_states = self.env[
+            TierValidationTesterMultipleStates._name
+        ]
 
         self.tester_model = self.env["ir.model"].search(
             [("model", "=", "tier.validation.tester")]
@@ -43,6 +48,9 @@ class CommonTierValidation(BaseCommon):
         self.tester_model_computed = self.env["ir.model"].search(
             [("model", "=", "tier.validation.tester.computed")]
         )
+        self.tester_model_multiple_states = self.env["ir.model"].search(
+            [("model", "=", "tier.validation.tester.multiple.states")]
+        )
         # Create a multi-company
         self.main_company = self.env.ref("base.main_company")
         self.other_company = self.env["res.company"].create({"name": "My Company"})
@@ -51,6 +59,7 @@ class CommonTierValidation(BaseCommon):
             self.tester_model,
             self.tester_model_2,
             self.tester_model_computed,
+            self.tester_model_multiple_states,
         )
         for model in models:
             # Access record:
@@ -115,7 +124,9 @@ class CommonTierValidation(BaseCommon):
         self.test_record = self.test_model.create({"test_field": 1.0})
         self.test_record_2 = self.test_model_2.create({"test_field": 1.0})
         self.test_record_computed = self.test_model_computed.create({"test_field": 1.0})
-
+        self.test_record_multiple_states = self.test_model_multiple_states.create(
+            {"test_field": 1.0}
+        )
         self.tier_def_obj.create(
             {
                 "model_id": self.tester_model.id,
@@ -207,6 +218,33 @@ class CommonTierValidation(BaseCommon):
                 "sequence": 30,
                 "name": "Definition for test 30 - sequence - user 3 - other company",
                 "company_id": self.other_company.id,
+            }
+        )
+        # Create definitions for test 34
+        self.tier_def_obj.create(
+            {
+                "model_id": self.tester_model_multiple_states.id,
+                "review_type": "individual",
+                "reviewer_id": self.test_user_1.id,
+                "definition_domain": "[('state', '=', 'draft')]",
+                "approve_sequence": False,
+                "notify_on_pending": False,
+                "sequence": 30,
+                "name": "Definition for test 34 - draft to in_progress",
+                "company_id": self.main_company.id,
+            }
+        )
+        self.tier_def_obj.create(
+            {
+                "model_id": self.tester_model_multiple_states.id,
+                "review_type": "individual",
+                "reviewer_id": self.test_user_1.id,
+                "definition_domain": "[('state', '=', 'in_progress')]",
+                "approve_sequence": False,
+                "notify_on_pending": False,
+                "sequence": 30,
+                "name": "Definition for test 34 - in_progress to confirmed",
+                "company_id": self.main_company.id,
             }
         )
 

--- a/base_tier_validation/tests/test_tier_validation.py
+++ b/base_tier_validation/tests/test_tier_validation.py
@@ -1289,6 +1289,79 @@ class TierTierValidation(CommonTierValidation):
         # Review_ids should not be copied when duplicating a user
         self.assertFalse(new_user.review_ids.ids)
 
+    def test_35_test_tier_validation_multiple_reviews(self):
+        """Test that multiple reviews can be created and handled correctly"""
+        record = self.test_record_multiple_states
+        self.assertFalse(record.review_ids)
+        self.assertEqual(record.state, "draft")
+        self.assertEqual(record.validation_status, "no")
+
+        # User 2 request a validation to move from draft to in_progress
+        review = record.with_user(self.test_user_2.id).request_validation()
+        self.assertEqual(len(review), 1)
+        self.assertTrue(record.review_ids)
+        self.assertEqual(record.validation_status, "waiting")
+
+        # User 1 approve the review
+        record.with_user(self.test_user_1.id).validate_tier()
+        self.assertEqual(record.review_ids.status, "approved")
+        self.assertEqual(record.state, "draft")
+        self.assertEqual(record.validation_status, "validated")
+        record.invalidate_recordset()
+
+        # User 2 moves the record to in_progress
+        record.with_user(self.test_user_2.id).action_to_in_progress()
+        self.assertEqual(record.review_ids.status, "approved")
+        self.assertEqual(record.state, "in_progress")
+        record.invalidate_recordset()
+
+        # User 2 requests a new validation to move from in_progress to done
+        review = record.with_user(self.test_user_2.id).request_validation()
+        self.assertEqual(len(review), 1)
+        self.assertEqual(len(record.review_ids), 2)
+        self.assertEqual(record.validation_status, "waiting")
+
+        # User 1 rejects the review
+        record.with_user(self.test_user_1.id).reject_tier()
+        self.assertEqual(review.status, "rejected")
+        self.assertEqual(record.state, "in_progress")
+        self.assertEqual(record.validation_status, "rejected")
+        self.assertEqual(
+            len(record.review_ids.filtered(lambda r: r.status != "rejected")), 1
+        )
+        record.invalidate_recordset()
+
+        # User 2 restart and request the validation
+        record.with_user(self.test_user_2.id).restart_validation()
+        self.assertEqual(record.validation_status, "no")
+        record.with_user(self.test_user_2.id).request_validation()
+        self.assertEqual(record.validation_status, "waiting")
+        self.assertEqual(
+            len(record.review_ids.filtered(lambda r: r.status == "approved")), 1
+        )
+        self.assertEqual(
+            len(record.review_ids.filtered(lambda r: r.status == "waiting")), 1
+        )
+
+        # User 1 approves the review
+        record.with_user(self.test_user_1.id).validate_tier()
+        self.assertEqual(
+            len(record.review_ids.filtered(lambda r: r.status == "approved")), 2
+        )
+        self.assertEqual(record.state, "in_progress")
+        self.assertEqual(record.validation_status, "validated")
+        record.invalidate_recordset()
+
+        # User 2 moves the record to done
+        record.with_user(self.test_user_2.id).action_confirm()
+        self.assertEqual(record.state, "confirmed")
+        self.assertEqual(len(record.review_ids), 2)
+        self.assertEqual(
+            len(record.review_ids.filtered(lambda r: r.status == "approved")), 2
+        )
+        self.assertEqual(record.validation_status, "validated")
+        self.assertEqual(record.state, "confirmed")
+
 
 @tagged("at_install")
 class TierTierValidationView(CommonTierValidation):

--- a/base_tier_validation/tests/tier_validation_tester.py
+++ b/base_tier_validation/tests/tier_validation_tester.py
@@ -116,3 +116,33 @@ class TierDefinition(models.Model):
         res.append("tier.validation.tester2")
         res.append("tier.validation.tester.computed")
         return res
+
+
+class TierValidationTesterMultipleStates(models.Model):
+    _name = "tier.validation.tester.multiple.states"
+    _description = "Tier Validation Tester Multiple States"
+    _inherit = ["tier.validation"]
+    _tier_validation_manual_config = False
+
+    state = fields.Selection(
+        selection=[
+            ("draft", "Draft"),
+            ("in_progress", "In Progress"),
+            ("confirmed", "Confirmed"),
+            ("cancel", "Cancel"),
+        ],
+        default="draft",
+    )
+    _state_from = ["draft", "in_progress"]
+    _state_to = ["in_progress", "confirmed"]
+
+    test_field = fields.Float()
+    test_validation_field = fields.Float()
+    user_id = fields.Many2one(string="Assigned to:", comodel_name="res.users")
+    company_id = fields.Many2one(comodel_name="res.company")
+
+    def action_to_in_progress(self):
+        self.write({"state": "in_progress"})
+
+    def action_confirm(self):
+        self.write({"state": "confirmed"})

--- a/base_tier_validation_forward/models/tier_validation.py
+++ b/base_tier_validation_forward/models/tier_validation.py
@@ -8,6 +8,10 @@ class TierValidation(models.AbstractModel):
 
     can_forward = fields.Boolean(compute="_compute_can_forward")
 
+    def _get_current_reviews(self, tiers=None):
+        valid_reviews = super()._get_current_reviews(tiers=tiers)
+        return valid_reviews + self.review_ids.filtered(lambda r: not r.definition_id)
+
     def _compute_can_forward(self):
         for rec in self:
             if not rec.can_review:


### PR DESCRIPTION
This Pull Request enables the assignment of multiple tier definitions across different states. This allows us to validate reviews for a specific state without removing previous reviews. Also, when resetting validation, only the reviews corresponding to that specific state will be deleted.

Note: To achieve full functionality, the following two methods must be extended:

`_allow_to_remove_reviews()`
We override this method to prevent the system from automatically clear the existing reviews when performing the transition corresponding to the second validation step (specific state_from → state_to).



`_check_allow_write_after_validation()`
Standard behavior prevents writing to a record once it is validated. We override this to explicitly whitelist the transition defined for the second validation step, returning True. This ensures the specific state change is not blocked by the validation lock mechanisms.

Please note that this implementation is currently a workaround. While it works correctly now, a small refactor to base_tier_validation will be needed in the future to simplify the process and make it cleaner.