### PR TITLE
[18.0][FIX] base_search_custom_field_filter: Error when define filters with related fields

### DIFF
--- a/base_search_custom_field_filter/models/base.py
+++ b/base_search_custom_field_filter/models/base.py
@@ -7,7 +7,6 @@
 from lxml import etree
 
 from odoo import api, models
-from odoo.tools.translate import _
 
 
 class Base(models.AbstractModel):
@@ -34,9 +33,7 @@ class Base(models.AbstractModel):
         for custom_filter in custom_filters:
             node = False
             if custom_filter.position_after:
-                node = arch.xpath(
-                    _("//field[@name='%s']") % custom_filter.position_after
-                )
+                node = arch.xpath(f"//field[@name='{custom_filter.position_after}']")
             if not node:
                 node = arch.xpath("//field[last()]")
             if node:
@@ -65,7 +62,7 @@ class Base(models.AbstractModel):
         """Inject fake field definition for having custom filters available."""
         res = super().get_views(views, options)
         if self._name not in res["models"]:
-            res["models"][self._name] = {}
+            res["models"][self._name] = {"fields": {}}
         custom_filters = self.env["ir.ui.custom.field.filter"].search(
             [("model_name", "=", self._name)]
         )
@@ -78,9 +75,11 @@ class Base(models.AbstractModel):
             if not field:
                 continue
             field_name = custom_filter.expression
-            res["models"][self._name][field_name] = field.get_description(self.env)
+            res["models"][self._name]["fields"][field_name] = field.get_description(
+                self.env
+            )
             # Force these properties to prevent the field from appearing in the UI
-            res["models"][self._name][field_name]["selectable"] = False
-            res["models"][self._name][field_name]["sortable"] = False
-            res["models"][self._name][field_name]["store"] = False
+            res["models"][self._name]["fields"][field_name]["selectable"] = False
+            res["models"][self._name]["fields"][field_name]["sortable"] = False
+            res["models"][self._name]["fields"][field_name]["store"] = False
         return res

--- a/base_search_custom_field_filter/tests/test_filter.py
+++ b/base_search_custom_field_filter/tests/test_filter.py
@@ -104,8 +104,8 @@ class TestFilter(BaseCommon):
             }
         )
         res = self.env["res.partner"].get_views([], {})
-        self.assertIn("name", res["models"]["res.partner"])
-        self.assertFalse(res["models"]["res.partner"]["name"]["selectable"])
+        self.assertIn("name", res["models"]["res.partner"]["fields"])
+        self.assertFalse(res["models"]["res.partner"]["fields"]["name"]["selectable"])
 
     def test_06_invalid_related_field(self):
         with self.assertRaises(ValidationError):


### PR DESCRIPTION
Steps to reproduce the behavior:

1. Define a custom filter with . notation like partner_id.lang
2. Access to the model defined, to check if we can use this filter.

An error was thrown

With this changes the field is defined in the correct point and the error is not thrown.

ping @pedrobaeza @carlos-lopez-tecnativa @mariancuadranetkia

cc @Tecnativa 

This PR solves the Issue: https://github.com/OCA/server-ux/issues/1231