### PR TITLE
[17.0][IMP] base_tier_validation: remove codepath returning a single value where two are expected

### DIFF
--- a/base_tier_validation/models/tier_validation.py
+++ b/base_tier_validation/models/tier_validation.py
@@ -348,8 +348,6 @@ class TierValidation(models.AbstractModel):
         for val in vals:
             if val not in exceptions:
                 not_allowed_fields.append(val)
-        if not not_allowed_fields:
-            return []
 
         not_allowed_field_names, allowed_field_names = [], []
         for fld_name, fld_data in self.fields_get(


### PR DESCRIPTION
From the two existing calls made to it, `_get_fields_to_write_validation` is supposed to return a 2-tuple value, but there is a codepath in this method that returns a single (empty) list.

This codepath seems unreachable anyway, since the function call is only triggered when a `write` call is made with at least one non-allowed field (that is, if `_check_allow_write_under_validation()` or `_check_allow_write_after_validation()` return `False`)