### PR TITLE
[19.0][IMP] Update substates properly when state field is computed

### DIFF
--- a/base_substate/models/base_substate_mixin.py
+++ b/base_substate/models/base_substate_mixin.py
@@ -13,6 +13,8 @@ class BaseSubstateMixin(models.AbstractModel):
 
     @api.constrains("substate_id", _state_field)
     def check_substate_id_value(self):
+        if self.env.context.get("skip_substate_while_state_field_computation"):
+            return
         rec_states = dict(self._fields[self._state_field].selection)
         for rec in self:
             target_state = rec.substate_id.target_state_value_id.target_state_value
@@ -85,9 +87,12 @@ class BaseSubstateMixin(models.AbstractModel):
                     )
                 )
 
-    def _update_before_write_create(self, values):
+    def _get_state_field(self):
         substate_type = self._get_substate_type()
-        state_field = substate_type.target_state_field
+        return substate_type.target_state_field
+
+    def _update_before_write_create(self, values):
+        state_field = self._get_state_field()
         if values.get(state_field) and not values.get("substate_id"):
             state_val = values.get(state_field)
             values["substate_id"] = self._get_default_substate_id(state_val)
@@ -114,4 +119,22 @@ class BaseSubstateMixin(models.AbstractModel):
         for vals in vals_list:
             vals = self._update_before_write_create(vals)
         res = super().create(vals_list)
+        return res
+
+    def _compute_field_value(self, field):
+        # OVERRIDE: if ``_state_field`` is computed, it does not go through
+        # write method, so we need to set substate in _compute_field_value
+        state_field = self._get_state_field()
+        # Store former values for all records in the recordset
+        former_values = {rec.id: rec[state_field] for rec in self}
+        res = super(
+            BaseSubstateMixin,
+            self.with_context(skip_substate_while_state_field_computation=True),
+        )._compute_field_value(field)
+        # Update substate for records where state changed
+        if field.name == state_field:
+            for rec in self:
+                new_value = rec[state_field]
+                if former_values.get(rec.id) != new_value:
+                    rec.substate_id = rec._get_default_substate_id(new_value)
         return res

--- a/base_substate/tests/sale_test.py
+++ b/base_substate/tests/sale_test.py
@@ -24,6 +24,8 @@ class SaleTest(models.Model):
         string="Status",
         readonly=True,
         default="draft",
+        compute="_compute_state",
+        store=True,
     )
     active = fields.Boolean(default=True)
     partner_id = fields.Many2one("res.partner", string="Partner")
@@ -48,6 +50,12 @@ class SaleTest(models.Model):
     def button_cancel(self):
         self.write({"state": "cancel"})
 
+    @api.depends("line_ids.done")
+    def _compute_state(self):
+        for record in self:
+            if record.line_ids and all(record.mapped("line_ids.done")):
+                record.state = "done"
+
 
 class LineTest(models.Model):
     _name = "base.substate.test.sale.line"
@@ -61,3 +69,7 @@ class LineTest(models.Model):
     )
     qty = fields.Float()
     amount = fields.Float()
+    done = fields.Boolean(default=False)
+
+    def button_done(self):
+        self.done = True

--- a/base_substate/tests/test_base_substate.py
+++ b/base_substate/tests/test_base_substate.py
@@ -46,6 +46,15 @@ class TestBaseSubstate(CommonBaseSubstate):
                 "target_state_value": "sale",
             }
         )
+
+        cls.substate_val_done = cls.env["target.state.value"].create(
+            {
+                "name": "Done",
+                "base_substate_type_id": cls.sale_test_substate_type.id,
+                "target_state_value": "done",
+            }
+        )
+
         cls.substate_under_negotiation = cls.base_substate.create(
             {
                 "name": "Under negotiation",
@@ -87,6 +96,22 @@ class TestBaseSubstate(CommonBaseSubstate):
             }
         )
 
+        cls.substate_to_publish = cls.base_substate.create(
+            {
+                "name": "To publish",
+                "sequence": 5,
+                "target_state_value_id": cls.substate_val_done.id,
+            }
+        )
+
+        cls.substate_published = cls.base_substate.create(
+            {
+                "name": "Published",
+                "sequence": 6,
+                "target_state_value_id": cls.substate_val_done.id,
+            }
+        )
+
     def test_sale_order_substate(self):
         # Create a partner instead of using a potentially non-existent XML ID
         partner = self.env["res.partner"].create(
@@ -117,6 +142,16 @@ class TestBaseSubstate(CommonBaseSubstate):
         self.assertIn(
             self.mail_template.subject, so_test1.message_ids.mapped("subject")
         )
+        # Test that computation of sale order state change substate_id
+        so_test1.line_ids.button_done()
+        self.assertEqual(so_test1.state, "done")
+        self.assertEqual(so_test1.substate_id, self.substate_to_publish)
+        # If the state computation does not change its value,
+        # it should not change the substate
+        so_test1.substate_id = self.substate_published
+        so_test1.line_ids.button_done()  # Triggers the recomputation despite no change
+        self.assertEqual(so_test1.state, "done")
+        self.assertEqual(so_test1.substate_id, self.substate_published)
         # Test that substate_id is set to false if
         # there is not substate corresponding to state
         so_test1.button_cancel()


### PR DESCRIPTION
If the state field on which the substate is based is computed, its update does not goes through `write` or `create` methods. In that cas we need to take care of the substate in ``_compute_field_value``.

As an example, you can check [stock_picking_batch_substate](https://github.com/OCA/stock-logistics-workflow/pull/2244): the batch state is computed in some cases (all picking set to done or cancel).

Unit tests have been adapted to check this case.