### PR TITLE
[18.0][IMP] base_revision: Enhance message posting for new revisions with links

### DIFF
--- a/base_revision/models/base_revision.py
+++ b/base_revision/models/base_revision.py
@@ -113,9 +113,10 @@ class BaseRevision(models.AbstractModel):
             # Calling  Copy method
             copied_rec = rec.copy_revision_with_context()
             if hasattr(self, "message_post"):
-                msg = _("New revision created: %s") % copied_rec.name
-                copied_rec.message_post(body=msg)
-                rec.message_post(body=msg)
+                target_msg = _("New revision created from: %s", rec._get_html_link())
+                copied_rec.message_post(body=target_msg)
+                source_msg = _("New revision created: %s", copied_rec._get_html_link())
+                rec.message_post(body=source_msg)
             revision_ids.append(copied_rec.id)
         action = {
             "type": "ir.actions.act_window",


### PR DESCRIPTION
Before no link and in both (source/new) the same message:
<img width="321" height="71" alt="image" src="https://github.com/user-attachments/assets/2221e627-7e16-4c04-9065-79c65746e81e" />

Source:
<img width="1897" height="203" alt="image" src="https://github.com/user-attachments/assets/23ff1907-67a0-4122-a9ca-364d4b9203e2" />

New:
<img width="1870" height="163" alt="image" src="https://github.com/user-attachments/assets/f54a4b69-268d-4c5c-b95a-458681c8683c" />
