### PR TITLE
[18.0][IMP] date_range: Change where the mock has to be loaded

### DIFF
--- a/base_cancel_confirm/tests/test_cancel_confirm.py
+++ b/base_cancel_confirm/tests/test_cancel_confirm.py
@@ -8,27 +8,26 @@ from odoo.tests import Form, common, tagged
 
 @tagged("post_install", "-at_install")
 class TestCancelConfirm(common.TransactionCase):
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
+    def setUp(self):
+        super().setUp()
 
-        cls.loader = FakeModelLoader(cls.env, cls.__module__)
-        cls.loader.backup_registry()
+        self.loader = FakeModelLoader(self.env, self.__module__)
+        self.loader.backup_registry()
         from .cancel_confirm_tester import CancelConfirmTester
 
-        cls.loader.update_registry((CancelConfirmTester,))
-        cls.test_model = cls.env[CancelConfirmTester._name]
-        cls.tester_model = cls.env["ir.model"].search(
+        self.loader.update_registry((CancelConfirmTester,))
+        self.test_model = self.env[CancelConfirmTester._name]
+        self.tester_model = self.env["ir.model"].search(
             [("model", "=", "cancel.confirm.tester")]
         )
-        cls.env["ir.config_parameter"].create(
+        self.env["ir.config_parameter"].create(
             {"key": "cancel.confirm.tester.cancel_confirm_disable", "value": "False"}
         )
         # Access record:
-        cls.env["ir.model.access"].create(
+        self.env["ir.model.access"].create(
             {
                 "name": "access.cancel.confirm.tester",
-                "model_id": cls.tester_model.id,
+                "model_id": self.tester_model.id,
                 "perm_read": 1,
                 "perm_write": 1,
                 "perm_create": 1,
@@ -36,12 +35,11 @@ class TestCancelConfirm(common.TransactionCase):
             }
         )
 
-        cls.test_record = cls.test_model.create({"name": "DOC-001"})
+        self.test_record = self.test_model.create({"name": "DOC-001"})
 
-    @classmethod
-    def tearDownClass(cls):
-        cls.loader.restore_registry()
-        return super().tearDownClass()
+    def tearDown(self):
+        self.loader.restore_registry()
+        return super().tearDown()
 
     def test_01_cancel_confirm_tester(self):
         """Cancel a document, I expect cancel_reason.

--- a/base_optional_quick_create/tests/test_quick_create.py
+++ b/base_optional_quick_create/tests/test_quick_create.py
@@ -2,14 +2,36 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 from odoo.exceptions import UserError
-from odoo.tests.common import TransactionCase
+from odoo.tests.common import SETATTR_SOURCES, TransactionCase
+
+# Register ir_model.py as a known path in odoo.tests.common for patching methods
+SETATTR_SOURCES["_patch_method"] = tuple(
+    list(SETATTR_SOURCES.get("_patch_method", []))
+    + ["/base_optional_quick_create/models/ir_model.py"],
+)
+SETATTR_SOURCES["_revert_method"] = tuple(
+    list(SETATTR_SOURCES.get("_revert_method", []))
+    + ["/base_optional_quick_create/models/ir_model.py"],
+)
 
 
 class TestQuickCreate(TransactionCase):
     def setUp(self, *args, **kwargs):
         super().setUp()
+        self.patched_models = [
+            model._name
+            for model in self.env.registry.values()
+            if "name_create" in vars(model)
+        ]
         model_model = self.env["ir.model"]
         self.partner_model = model_model.search([("model", "=", "res.partner")])
+
+    def tearDown(self):
+        # Revert any patched method to avoid side effects on other tests
+        for model in self.env.registry.values():
+            if "name_create" in vars(model) and model._name not in self.patched_models:
+                delattr(model, "name_create")
+        return super().tearDown()
 
     def test_quick_create(self):
         partner_id = self.env["res.partner"].name_create("TEST partner")

--- a/base_revision/tests/test_base_revision.py
+++ b/base_revision/tests/test_base_revision.py
@@ -9,22 +9,20 @@ from odoo.tests import common
 
 
 class TestBaseRevision(common.TransactionCase):
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
+    def setUp(self):
+        super().setUp()
 
-        cls.loader = FakeModelLoader(cls.env, cls.__module__)
-        cls.loader.backup_registry()
+        self.loader = FakeModelLoader(self.env, self.__module__)
+        self.loader.backup_registry()
         from .base_revision_tester import BaseRevisionTester
 
-        cls.loader.update_registry((BaseRevisionTester,))
+        self.loader.update_registry((BaseRevisionTester,))
 
-        cls.revision_model = cls.env[BaseRevisionTester._name]
+        self.revision_model = self.env[BaseRevisionTester._name]
 
-    @classmethod
-    def tearDownClass(cls):
-        cls.loader.restore_registry()
-        return super().tearDownClass()
+    def tearDown(self):
+        self.loader.restore_registry()
+        return super().tearDown()
 
     def _create_tester(self, vals_list=None):
         if not vals_list:

--- a/base_substate/tests/common.py
+++ b/base_substate/tests/common.py
@@ -7,18 +7,17 @@ from odoo.addons.base.tests.common import BaseCommon
 
 
 class CommonBaseSubstate(BaseCommon):
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-        cls.loader = FakeModelLoader(cls.env, cls.__module__)
-        cls.loader.backup_registry()
+    def setUp(self):
+        super().setUp()
+        self.loader = FakeModelLoader(self.env, self.__module__)
+        self.loader.backup_registry()
         from .sale_test import (
             BaseSubstateType,
             LineTest,
             SaleTest,
         )
 
-        cls.loader.update_registry(
+        self.loader.update_registry(
             (
                 SaleTest,
                 LineTest,
@@ -26,10 +25,10 @@ class CommonBaseSubstate(BaseCommon):
             )
         )
 
-        cls.sale_test_model = cls.env[SaleTest._name]
-        cls.sale_line_test_model = cls.env[LineTest._name]
+        self.sale_test_model = self.env[SaleTest._name]
+        self.sale_line_test_model = self.env[LineTest._name]
 
-        models = cls.env["ir.model"].search(
+        models = self.env["ir.model"].search(
             [
                 (
                     "model",
@@ -40,7 +39,7 @@ class CommonBaseSubstate(BaseCommon):
         )
         for model in models:
             # Access record:
-            cls.env["ir.model.access"].create(
+            self.env["ir.model.access"].create(
                 {
                     "name": f"access {model.name}",
                     "model_id": model.id,
@@ -51,7 +50,6 @@ class CommonBaseSubstate(BaseCommon):
                 }
             )
 
-    @classmethod
-    def tearDownClass(cls):
-        cls.loader.restore_registry()
-        super().tearDownClass()
+    def tearDown(self):
+        self.loader.restore_registry()
+        super().tearDown()

--- a/base_substate/tests/test_base_substate.py
+++ b/base_substate/tests/test_base_substate.py
@@ -9,21 +9,20 @@ from .common import CommonBaseSubstate
 
 @tagged("post_install", "-at_install", "mi_tag")
 class TestBaseSubstate(CommonBaseSubstate):
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
+    def setUp(self):
+        super().setUp()
 
-        cls.substate_type = cls.env["base.substate.type"]
-        cls.base_substate = cls.env["base.substate"]
+        self.substate_type = self.env["base.substate.type"]
+        self.base_substate = self.env["base.substate"]
 
-        cls.mail_template = cls.env["mail.template"].create(
+        self.mail_template = self.env["mail.template"].create(
             {
                 "name": "Waiting for legal documents",
-                "model_id": cls.env["ir.model"]._get(cls.sale_test_model._name).id,
+                "model_id": self.env["ir.model"]._get(self.sale_test_model._name).id,
                 "subject": "Test Email Substate",
             }
         )
-        cls.sale_test_substate_type = cls.substate_type.create(
+        self.sale_test_substate_type = self.substate_type.create(
             {
                 "name": "Sale",
                 "model": "base.substate.test.sale",
@@ -31,59 +30,59 @@ class TestBaseSubstate(CommonBaseSubstate):
             }
         )
 
-        cls.substate_val_quotation = cls.env["target.state.value"].create(
+        self.substate_val_quotation = self.env["target.state.value"].create(
             {
                 "name": "Quotation",
-                "base_substate_type_id": cls.sale_test_substate_type.id,
+                "base_substate_type_id": self.sale_test_substate_type.id,
                 "target_state_value": "draft",
             }
         )
 
-        cls.substate_val_sale = cls.env["target.state.value"].create(
+        self.substate_val_sale = self.env["target.state.value"].create(
             {
                 "name": "Sale order",
-                "base_substate_type_id": cls.sale_test_substate_type.id,
+                "base_substate_type_id": self.sale_test_substate_type.id,
                 "target_state_value": "sale",
             }
         )
-        cls.substate_under_negotiation = cls.base_substate.create(
+        self.substate_under_negotiation = self.base_substate.create(
             {
                 "name": "Under negotiation",
                 "sequence": 1,
-                "target_state_value_id": cls.substate_val_quotation.id,
+                "target_state_value_id": self.substate_val_quotation.id,
             }
         )
 
-        cls.substate_won = cls.base_substate.create(
+        self.substate_won = self.base_substate.create(
             {
                 "name": "Won",
                 "sequence": 1,
-                "target_state_value_id": cls.substate_val_quotation.id,
+                "target_state_value_id": self.substate_val_quotation.id,
             }
         )
 
-        cls.substate_wait_docs = cls.base_substate.create(
+        self.substate_wait_docs = self.base_substate.create(
             {
                 "name": "Waiting for legal documents",
                 "sequence": 2,
-                "target_state_value_id": cls.substate_val_sale.id,
-                "mail_template_id": cls.mail_template.id,
+                "target_state_value_id": self.substate_val_sale.id,
+                "mail_template_id": self.mail_template.id,
             }
         )
 
-        cls.substate_valid_docs = cls.base_substate.create(
+        self.substate_valid_docs = self.base_substate.create(
             {
                 "name": "To validate legal documents",
                 "sequence": 3,
-                "target_state_value_id": cls.substate_val_sale.id,
+                "target_state_value_id": self.substate_val_sale.id,
             }
         )
 
-        cls.substate_in_delivering = cls.base_substate.create(
+        self.substate_in_delivering = self.base_substate.create(
             {
                 "name": "In delivering",
                 "sequence": 4,
-                "target_state_value_id": cls.substate_val_sale.id,
+                "target_state_value_id": self.substate_val_sale.id,
             }
         )
 

--- a/base_tier_validation/tests/common.py
+++ b/base_tier_validation/tests/common.py
@@ -10,11 +10,10 @@ from odoo.addons.base.tests.common import BaseCommon
 
 
 class CommonTierValidation(BaseCommon):
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-        cls.loader = FakeModelLoader(cls.env, cls.__module__)
-        cls.loader.backup_registry()
+    def setUp(self):
+        super().setUp()
+        self.loader = FakeModelLoader(self.env, self.__module__)
+        self.loader.backup_registry()
         from .tier_validation_tester import (
             TierDefinition,
             TierValidationTester,
@@ -22,7 +21,7 @@ class CommonTierValidation(BaseCommon):
             TierValidationTesterComputed,
         )
 
-        cls.loader.update_registry(
+        self.loader.update_registry(
             (
                 TierValidationTester,
                 TierValidationTester2,
@@ -31,31 +30,31 @@ class CommonTierValidation(BaseCommon):
             )
         )
 
-        cls.test_model = cls.env[TierValidationTester._name]
-        cls.test_model_2 = cls.env[TierValidationTester2._name]
-        cls.test_model_computed = cls.env[TierValidationTesterComputed._name]
+        self.test_model = self.env[TierValidationTester._name]
+        self.test_model_2 = self.env[TierValidationTester2._name]
+        self.test_model_computed = self.env[TierValidationTesterComputed._name]
 
-        cls.tester_model = cls.env["ir.model"].search(
+        self.tester_model = self.env["ir.model"].search(
             [("model", "=", "tier.validation.tester")]
         )
-        cls.tester_model_2 = cls.env["ir.model"].search(
+        self.tester_model_2 = self.env["ir.model"].search(
             [("model", "=", "tier.validation.tester2")]
         )
-        cls.tester_model_computed = cls.env["ir.model"].search(
+        self.tester_model_computed = self.env["ir.model"].search(
             [("model", "=", "tier.validation.tester.computed")]
         )
         # Create a multi-company
-        cls.main_company = cls.env.ref("base.main_company")
-        cls.other_company = cls.env["res.company"].create({"name": "My Company"})
+        self.main_company = self.env.ref("base.main_company")
+        self.other_company = self.env["res.company"].create({"name": "My Company"})
 
         models = (
-            cls.tester_model,
-            cls.tester_model_2,
-            cls.tester_model_computed,
+            self.tester_model,
+            self.tester_model_2,
+            self.tester_model_computed,
         )
         for model in models:
             # Access record:
-            cls.env["ir.model.access"].create(
+            self.env["ir.model.access"].create(
                 {
                     "name": f"access {model.name}",
                     "model_id": model.id,
@@ -67,7 +66,7 @@ class CommonTierValidation(BaseCommon):
             )
 
             # Define views to avoid automatic views with all fields.
-            cls.env["ir.ui.view"].create(
+            self.env["ir.ui.view"].create(
                 {
                     "model": model.model,
                     "name": f"Demo view for {model}",
@@ -84,44 +83,44 @@ class CommonTierValidation(BaseCommon):
             )
 
         # Create users:
-        cls.test_user_1 = new_test_user(
-            cls.env, name="John", login="test1", groups="base.group_system"
+        self.test_user_1 = new_test_user(
+            self.env, name="John", login="test1", groups="base.group_system"
         )
-        cls.test_user_2 = new_test_user(cls.env, name="Mike", login="test2")
-        cls.test_user_3_multi_company = new_test_user(
-            cls.env,
+        self.test_user_2 = new_test_user(self.env, name="Mike", login="test2")
+        self.test_user_3_multi_company = new_test_user(
+            self.env,
             name="Jane",
             login="test3",
-            company_ids=[Command.set([cls.main_company.id, cls.other_company.id])],
+            company_ids=[Command.set([self.main_company.id, self.other_company.id])],
         )
         # Create groups
-        cls.test_group = cls.env["res.groups"].create(
+        self.test_group = self.env["res.groups"].create(
             {
                 "name": "TestGroup",
-                "users": [(4, cls.test_user_1.id), (4, cls.test_user_2.id)],
+                "users": [(4, self.test_user_1.id), (4, self.test_user_2.id)],
             }
         )
         # Create tier definitions:
-        cls.tier_def_obj = cls.env["tier.definition"]
-        cls.tier_definition = cls.tier_def_obj.create(
+        self.tier_def_obj = self.env["tier.definition"]
+        self.tier_definition = self.tier_def_obj.create(
             {
-                "model_id": cls.tester_model.id,
+                "model_id": self.tester_model.id,
                 "review_type": "individual",
-                "reviewer_id": cls.test_user_1.id,
+                "reviewer_id": self.test_user_1.id,
                 "definition_domain": "[('test_field', '=', 1.0)]",
                 "sequence": 30,
             }
         )
 
-        cls.test_record = cls.test_model.create({"test_field": 1.0})
-        cls.test_record_2 = cls.test_model_2.create({"test_field": 1.0})
-        cls.test_record_computed = cls.test_model_computed.create({"test_field": 1.0})
+        self.test_record = self.test_model.create({"test_field": 1.0})
+        self.test_record_2 = self.test_model_2.create({"test_field": 1.0})
+        self.test_record_computed = self.test_model_computed.create({"test_field": 1.0})
 
-        cls.tier_def_obj.create(
+        self.tier_def_obj.create(
             {
-                "model_id": cls.tester_model.id,
+                "model_id": self.tester_model.id,
                 "review_type": "individual",
-                "reviewer_id": cls.test_user_1.id,
+                "reviewer_id": self.test_user_1.id,
                 "definition_domain": "[('test_field', '>', 3.0)]",
                 "approve_sequence": True,
                 "notify_on_pending": False,
@@ -129,11 +128,11 @@ class CommonTierValidation(BaseCommon):
                 "name": "Definition for test 19 - sequence - user 1",
             }
         )
-        cls.tier_def_obj.create(
+        self.tier_def_obj.create(
             {
-                "model_id": cls.tester_model.id,
+                "model_id": self.tester_model.id,
                 "review_type": "individual",
-                "reviewer_id": cls.test_user_2.id,
+                "reviewer_id": self.test_user_2.id,
                 "definition_domain": "[('test_field', '>', 3.0)]",
                 "approve_sequence": True,
                 "notify_on_pending": True,
@@ -142,11 +141,11 @@ class CommonTierValidation(BaseCommon):
             }
         )
         # Create definition for test 20
-        cls.tier_def_obj.create(
+        self.tier_def_obj.create(
             {
-                "model_id": cls.tester_model.id,
+                "model_id": self.tester_model.id,
                 "review_type": "individual",
-                "reviewer_id": cls.test_user_1.id,
+                "reviewer_id": self.test_user_1.id,
                 "definition_domain": "[('test_field', '=', 0.9)]",
                 "approve_sequence": False,
                 "notify_on_pending": True,
@@ -155,11 +154,11 @@ class CommonTierValidation(BaseCommon):
             }
         )
 
-        cls.tier_def_obj.create(
+        self.tier_def_obj.create(
             {
-                "model_id": cls.tester_model_computed.id,
+                "model_id": self.tester_model_computed.id,
                 "review_type": "individual",
-                "reviewer_id": cls.test_user_1.id,
+                "reviewer_id": self.test_user_1.id,
                 "definition_domain": "[]",
                 "approve_sequence": True,
                 "notify_on_pending": False,
@@ -170,48 +169,47 @@ class CommonTierValidation(BaseCommon):
 
         # Create definition for test 30, 31
         # Main company tier definition
-        cls.tier_def_obj.create(
+        self.tier_def_obj.create(
             {
-                "model_id": cls.tester_model_2.id,
+                "model_id": self.tester_model_2.id,
                 "review_type": "individual",
-                "reviewer_id": cls.test_user_1.id,
+                "reviewer_id": self.test_user_1.id,
                 "definition_domain": "[('test_field', '>=', 1.0)]",
                 "approve_sequence": True,
                 "notify_on_pending": False,
                 "sequence": 30,
                 "name": "Definition for test 30 - sequence - user 1 - main company",
-                "company_id": cls.main_company.id,
+                "company_id": self.main_company.id,
             }
         )
-        cls.tier_def_obj.create(
+        self.tier_def_obj.create(
             {
-                "model_id": cls.tester_model_2.id,
+                "model_id": self.tester_model_2.id,
                 "review_type": "individual",
-                "reviewer_id": cls.test_user_3_multi_company.id,
+                "reviewer_id": self.test_user_3_multi_company.id,
                 "definition_domain": "[('test_field', '>=', 1.0)]",
                 "approve_sequence": True,
                 "notify_on_pending": False,
                 "sequence": 20,
                 "name": "Definition for test 30 - sequence - user 3 - main company",
-                "company_id": cls.main_company.id,
+                "company_id": self.main_company.id,
             }
         )
         # Other company tier definition
-        cls.tier_def_obj.create(
+        self.tier_def_obj.create(
             {
-                "model_id": cls.tester_model_2.id,
+                "model_id": self.tester_model_2.id,
                 "review_type": "individual",
-                "reviewer_id": cls.test_user_3_multi_company.id,
+                "reviewer_id": self.test_user_3_multi_company.id,
                 "definition_domain": "[('test_field', '>=', 1.0)]",
                 "approve_sequence": True,
                 "notify_on_pending": False,
                 "sequence": 30,
                 "name": "Definition for test 30 - sequence - user 3 - other company",
-                "company_id": cls.other_company.id,
+                "company_id": self.other_company.id,
             }
         )
 
-    @classmethod
-    def tearDownClass(cls):
-        cls.loader.restore_registry()
-        super().tearDownClass()
+    def tearDown(self):
+        self.loader.restore_registry()
+        super().tearDown()

--- a/base_tier_validation_correction/tests/test_tier_validation.py
+++ b/base_tier_validation_correction/tests/test_tier_validation.py
@@ -9,15 +9,14 @@ from odoo.addons.base_tier_validation.tests.common import CommonTierValidation
 
 
 class TierTierValidation(CommonTierValidation):
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
+    def setUp(self):
+        super().setUp()
 
         from .tier_validation_tester import TierValidationTester
 
-        cls.loader.update_registry((TierValidationTester,))
+        self.loader.update_registry((TierValidationTester,))
 
-        cls.test_record.name = "test"
+        self.test_record.name = "test"
 
     def test_01_tier_correction(self):
         """With the document in validation,

--- a/base_tier_validation_formula/tests/test_tier_validation.py
+++ b/base_tier_validation_formula/tests/test_tier_validation.py
@@ -12,27 +12,26 @@ from odoo.addons.base.tests.common import BaseCommon
 # Use Base Common
 @tagged("post_install", "-at_install")
 class TierTierValidation(BaseCommon):
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-        cls.loader = FakeModelLoader(cls.env, cls.__module__)
-        cls.loader.backup_registry()
+    def setUp(self):
+        super().setUp()
+        self.loader = FakeModelLoader(self.env, self.__module__)
+        self.loader.backup_registry()
         from odoo.addons.base_tier_validation.tests.tier_validation_tester import (
             TierValidationTester,
         )
 
-        cls.loader.update_registry((TierValidationTester,))
-        cls.test_model = cls.env[TierValidationTester._name]
+        self.loader.update_registry((TierValidationTester,))
+        self.test_model = self.env[TierValidationTester._name]
 
-        cls.tester_model = cls.env["ir.model"].search(
+        self.tester_model = self.env["ir.model"].search(
             [("model", "=", "tier.validation.tester")]
         )
 
         # Access record:
-        cls.env["ir.model.access"].create(
+        self.env["ir.model.access"].create(
             {
                 "name": "access.tester",
-                "model_id": cls.tester_model.id,
+                "model_id": self.tester_model.id,
                 "perm_read": 1,
                 "perm_write": 1,
                 "perm_create": 1,
@@ -40,30 +39,29 @@ class TierTierValidation(BaseCommon):
             }
         )
 
-        cls.test_user_1 = cls.env.ref("base.user_admin")
-        cls.test_user_2 = cls.env.ref("base.user_demo")
+        self.test_user_1 = self.env.ref("base.user_admin")
+        self.test_user_2 = self.env.ref("base.user_demo")
         # Create users:
-        cls.test_user_3 = cls.env["res.users"].create(
+        self.test_user_3 = self.env["res.users"].create(
             {"name": "Mary", "login": "test3", "email": "mary@yourcompany.example.com"}
         )
 
         # Create tier definitions:
-        cls.tier_def_obj = cls.env["tier.definition"]
-        cls.tier_def_obj.create(
+        self.tier_def_obj = self.env["tier.definition"]
+        self.tier_def_obj.create(
             {
-                "model_id": cls.tester_model.id,
+                "model_id": self.tester_model.id,
                 "review_type": "individual",
-                "reviewer_id": cls.test_user_1.id,
+                "reviewer_id": self.test_user_1.id,
                 "definition_domain": "[('test_field', '>', 1.0)]",
             }
         )
 
-        cls.test_record = cls.test_model.create({"test_field": 2.5})
+        self.test_record = self.test_model.create({"test_field": 2.5})
 
-    @classmethod
-    def tearDownClass(cls):
-        cls.loader.restore_registry()
-        return super().tearDownClass()
+    def tearDown(self):
+        self.loader.restore_registry()
+        super().tearDown()
 
     def test_01_reviewer_from_python_expression(self):
         tier_definition = self.tier_def_obj.create(

--- a/base_tier_validation_server_action/tests/test_tier_validation.py
+++ b/base_tier_validation_server_action/tests/test_tier_validation.py
@@ -8,25 +8,24 @@ from odoo.tests.common import tagged
 
 @tagged("post_install", "-at_install")
 class TierTierValidation(common.TransactionCase):
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
+    def setUp(self):
+        super().setUp()
 
-        cls.loader = FakeModelLoader(cls.env, cls.__module__)
-        cls.loader.backup_registry()
+        self.loader = FakeModelLoader(self.env, self.__module__)
+        self.loader.backup_registry()
         from .tier_validation_tester import TierValidationTester
 
-        cls.loader.update_registry((TierValidationTester,))
-        cls.test_model = cls.env[TierValidationTester._name]
-        cls.tester_model = cls.env["ir.model"].search(
+        self.loader.update_registry((TierValidationTester,))
+        self.test_model = self.env[TierValidationTester._name]
+        self.tester_model = self.env["ir.model"].search(
             [("model", "=", "tier.validation.tester")]
         )
 
         # Access record:
-        cls.env["ir.model.access"].create(
+        self.env["ir.model.access"].create(
             {
                 "name": "access.tester",
-                "model_id": cls.tester_model.id,
+                "model_id": self.tester_model.id,
                 "perm_read": 1,
                 "perm_write": 1,
                 "perm_create": 1,
@@ -35,36 +34,35 @@ class TierTierValidation(common.TransactionCase):
         )
 
         # Create users:
-        cls.group_system = cls.env.ref("base.group_system")
-        group_ids = cls.group_system.ids
-        cls.test_user_1 = cls.env["res.users"].create(
+        self.group_system = self.env.ref("base.group_system")
+        group_ids = self.group_system.ids
+        self.test_user_1 = self.env["res.users"].create(
             {"name": "John", "login": "test1", "groups_id": [(6, 0, group_ids)]}
         )
-        cls.test_user_2 = cls.env["res.users"].create(
+        self.test_user_2 = self.env["res.users"].create(
             {"name": "Mike", "login": "test2"}
         )
-        cls.test_user_3 = cls.env["res.users"].create(
+        self.test_user_3 = self.env["res.users"].create(
             {"name": "John Wick", "login": "test3", "groups_id": [(6, 0, group_ids)]}
         )
 
         # Create tier definitions:
-        cls.tier_def_obj = cls.env["tier.definition"]
-        cls.tier_def_obj.create(
+        self.tier_def_obj = self.env["tier.definition"]
+        self.tier_def_obj.create(
             {
-                "model_id": cls.tester_model.id,
+                "model_id": self.tester_model.id,
                 "review_type": "individual",
-                "reviewer_id": cls.test_user_1.id,
+                "reviewer_id": self.test_user_1.id,
                 "definition_domain": "[('test_field', '>', 1.0)]",
                 "sequence": 30,
             }
         )
 
-        cls.test_record = cls.test_model.create({"test_field": 2.5})
+        self.test_record = self.test_model.create({"test_field": 2.5})
 
-    @classmethod
-    def tearDownClass(cls):
-        cls.loader.restore_registry()
-        super().tearDownClass()
+    def tearDown(self):
+        self.loader.restore_registry()
+        super().tearDown()
 
     def test_1_auto_validation(self):
         # Create new test record

--- a/date_range/tests/test_date_range_search_mixin.py
+++ b/date_range/tests/test_date_range_search_mixin.py
@@ -8,21 +8,20 @@ from odoo.tests.common import TransactionCase
 
 
 class TestDateRangeSearchMixin(TransactionCase):
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
+    def setUp(self):
+        super().setUp()
         # Load a test model using odoo_test_helper
-        cls.loader = FakeModelLoader(cls.env, cls.__module__)
-        cls.loader.backup_registry()
+        self.loader = FakeModelLoader(self.env, self.__module__)
+        self.loader.backup_registry()
         from .models import TestDateRangeSearchMixin
 
-        cls.loader.update_registry((TestDateRangeSearchMixin,))
+        self.loader.update_registry((TestDateRangeSearchMixin,))
 
-        cls.env.user.lang = "en_US"
-        rtype = cls.env["date.range.type"].create(
+        self.env.user.lang = "en_US"
+        rtype = self.env["date.range.type"].create(
             {"name": __name__, "company_id": False, "allow_overlap": False}
         )
-        cls.env["date.range.generator"].create(
+        self.env["date.range.generator"].create(
             {
                 "date_start": "1943-01-01",
                 "name_prefix": "1943-",
@@ -32,13 +31,12 @@ class TestDateRangeSearchMixin(TransactionCase):
                 "count": 4,
             }
         ).action_apply()
-        cls.ranges = cls.env["date.range"].search([("type_id", "=", rtype.id)])
-        cls.model = cls.env[TestDateRangeSearchMixin._name]
+        self.ranges = self.env["date.range"].search([("type_id", "=", rtype.id)])
+        self.model = self.env[TestDateRangeSearchMixin._name]
 
-    @classmethod
-    def tearDownClass(cls):
-        cls.loader.restore_registry()
-        return super().tearDownClass()
+    def tearDown(self):
+        self.loader.restore_registry()
+        return super().tearDown()
 
     def test_01_search_view(self):
         """The search field is injected in the model's search view"""

--- a/multi_step_wizard/tests/common.py
+++ b/multi_step_wizard/tests/common.py
@@ -7,16 +7,14 @@ from odoo.tests import common
 
 
 class CommonTestMultiStepWizard(common.TransactionCase):
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-        cls.loader = FakeModelLoader(cls.env, cls.__module__)
-        cls.loader.backup_registry()
+    def setUp(self):
+        super().setUp()
+        self.loader = FakeModelLoader(self.env, self.__module__)
+        self.loader.backup_registry()
         from .multi_step_wizard_test import MultiStepWizardTest
 
-        cls.loader.update_registry((MultiStepWizardTest,))
+        self.loader.update_registry((MultiStepWizardTest,))
 
-    @classmethod
-    def tearDownClass(cls):
-        cls.loader.restore_registry()
+    def tearDown(self):
+        self.loader.restore_registry()
         return super().tearDownClass()


### PR DESCRIPTION
With the changes introduced in https://github.com/odoo/odoo/commit/de056cc784a3bbe2575fd3c9e81ca62e73c362d4#diff-b37c7fd5520c97a29ddc59495779e7be61a66e15e85603928e27b3affb9dc31f, an error was occurring because the change validation on the model was being performed before tearDownClass was executed. Therefore, it has been modified so that the mock changes are applied in each test and cleaned up after each test. This way, the error will no longer appear and the test will run normally.

cc @Tecnativa

ping @pedrobaeza @carlos-lopez-tecnativa 