### PR TITLE
[18.0][FIX] base_tier_validation: use validation_status for readonly domain

### DIFF
--- a/base_tier_validation/models/tier_validation.py
+++ b/base_tier_validation/models/tier_validation.py
@@ -871,7 +871,7 @@ class TierValidation(models.AbstractModel):
         return new_node
 
     def _get_tier_validation_readonly_domain(self):
-        return "bool(review_ids)"
+        return "validation_status not in ('no', False)"
 
     @api.model
     def get_view(self, view_id=None, view_type="form", **options):


### PR DESCRIPTION
## Description

The `_get_tier_validation_readonly_domain` method currently returns `bool(review_ids)` which is injected as a readonly domain modifier on all form fields via `get_view()`.

In Odoo 18, the web client does not always include One2many fields like `review_ids` in the data spec during form re-renders (e.g. after a status change or button click), causing an OWL rendering error:

```
Name 'review_ids' is not defined
```

This happens for example when cancelling a sale order that has tier validation configured.

## Fix

Replace the readonly domain with `validation_status not in ('no', False)` which uses the stored computed `validation_status` Selection field instead. This field is always available in the form data spec and provides the same semantics: fields become readonly when a validation process is active (pending, approved, or rejected).

The `validation_status` field is already defined on the `tier.validation` mixin with values: `no`, `pending`, `approved`, `rejected`.