### PR TITLE
[18.0][IMP] base_tier_validation: new user should not have review_ids

### DIFF
--- a/base_tier_validation/models/res_users.py
+++ b/base_tier_validation/models/res_users.py
@@ -7,7 +7,9 @@ from odoo import api, fields, models, modules
 class Users(models.Model):
     _inherit = "res.users"
 
-    review_ids = fields.Many2many(string="Reviews", comodel_name="tier.review")
+    review_ids = fields.Many2many(
+        string="Reviews", comodel_name="tier.review", copy=False
+    )
 
     @api.model
     def review_user_count(self):

--- a/base_tier_validation/tests/test_tier_validation.py
+++ b/base_tier_validation/tests/test_tier_validation.py
@@ -1254,6 +1254,41 @@ class TierTierValidation(CommonTierValidation):
         ):
             test_record.request_validation()
 
+    def test_34_test_duplicate_new_user_should_not_have_review_ids(self):
+        """
+        This test ensures that when a user with review_ids is duplicated and
+        the new user does not get the same review_ids.
+        """
+        # Create new test record
+        test_record = self.test_model.create({"test_field": 2.5})
+        # Create tier definitions
+        self.tier_def_obj.create(
+            {
+                "model_id": self.tester_model.id,
+                "review_type": "individual",
+                "reviewer_id": self.test_user_2.id,
+                "definition_domain": "[('test_field', '>', 1.0)]",
+                "has_comment": True,
+            }
+        )
+
+        # Request validation
+        review = test_record.request_validation()
+        self.assertTrue(review)
+
+        # User Should have review_ids
+        self.assertTrue(self.test_user_2.review_ids.ids)
+        self.assertEqual(
+            self.test_user_2.review_ids.mapped("res_id"),
+            [test_record.id],
+        )
+
+        # Duplicate user
+        new_user = self.test_user_2.copy()
+
+        # Review_ids should not be copied when duplicating a user
+        self.assertFalse(new_user.review_ids.ids)
+
 
 @tagged("at_install")
 class TierTierValidationView(CommonTierValidation):


### PR DESCRIPTION
### Detail pull request
When duplicating a user that already has review_ids, the new user inherits the same review_ids because the field is copied by default.

This behavior is incorrect since review_ids represent pending review assignments for a specific user. Copying them to a duplicated user can lead to inconsistent review responsibilities.

**Step Error Case**
Test with module `partner_firstname` and `base_tier_validation` together.
1. Install `partner_firstname` and `base_tier_validation`, then create a Tier Definition.
<img width="1467" height="269" alt="SCR-20260315-pbuh" src="https://github.com/user-attachments/assets/45bcc700-5d1b-42f5-8b7c-7166824dc53f" />
<img width="1470" height="569" alt="SCR-20260315-pdkg" src="https://github.com/user-attachments/assets/7701d9ef-ac4c-48c3-9aaf-facabdab4635" />

2. Request validation on a document so or other that a reviewer is assigned.
<img width="1470" height="828" alt="SCR-20260315-pdnh" src="https://github.com/user-attachments/assets/46d554a8-99c7-4c4a-ac91-e42ceeb8bcb9" />

3. Duplicate the user who has pending reviews.
<img width="1470" height="831" alt="SCR-20260315-pdvu" src="https://github.com/user-attachments/assets/2bc2f334-b805-44a0-b2d1-e980ee3fbc09" />

**Solution**
Set copy=False on the review_ids field to prevent duplicated users from inheriting existing review records.



