### PR TITLE
[IMP] base_tier_validation: add configurable position for reviews widget

### DIFF
--- a/base_tier_validation/models/tier_validation.py
+++ b/base_tier_validation/models/tier_validation.py
@@ -27,6 +27,7 @@ class TierValidation(models.AbstractModel):
     _tier_validation_manual_config = True
     _tier_validation_state_field_is_computed = False
     _tier_validation_company_field = "company_id"
+    _tier_validation_reviews_position = "bottom"
 
     _state_field = "state"
     _state_from = ["draft"]
@@ -906,7 +907,10 @@ class TierValidation(models.AbstractModel):
                 new_node = self._add_tier_validation_reviews(node, params)
                 new_arch, new_models = View.postprocess_and_fields(new_node, self._name)
                 new_node = etree.fromstring(new_arch)
-                node.append(new_node)
+                if self._tier_validation_reviews_position == "bottom":
+                    node.append(new_node)
+                else:
+                    node.insert(0, new_node)
                 _merge_view_fields(all_models, new_models)
             excepted_fields = self._get_all_validation_exceptions()
             all_fields = self.fields_get(attributes=("readonly",))


### PR DESCRIPTION
Add `_tier_validation_reviews_position` class attribute to the `TierValidation` mixin to control whether the reviews widget is rendered at the top or bottom of the form sheet.

Default value is `"bottom"` to preserve existing behavior. Set `"top"` on any inheriting model to display reviews above all form fields, which improves usability on mobile views where scrolling to the bottom is less convenient.

Child models can now configure this per-model:

      _tier_validation_reviews_position = "top"

This feature was created to position the validation at the top, as when the record description contains a large amount of text, the validation area becomes hard to find. This option is configurable.