### PR TITLE
[18.0][FIX] base_tier_validation: remove codepath returning a single value where two are expected

### DIFF
--- a/base_tier_validation/models/tier_validation.py
+++ b/base_tier_validation/models/tier_validation.py
@@ -352,8 +352,6 @@ class TierValidation(models.AbstractModel):
         for val in vals:
             if val not in exceptions:
                 not_allowed_fields.append(val)
-        if not not_allowed_fields:
-            return []
 
         not_allowed_field_names, allowed_field_names = [], []
         for fld_name, fld_data in self.fields_get(


### PR DESCRIPTION
Forwarding #1233 to 18.0