### PR TITLE
[18.0][FIX] date_range: Tree editor mark 'date end' as end

### DIFF
--- a/date_range/static/src/js/tree_editor.esm.js
+++ b/date_range/static/src/js/tree_editor.esm.js
@@ -71,8 +71,8 @@ patch(TreeEditor.prototype, {
                         if (!selected) {
                             selected = dateRanges[0];
                             update([
-                                toDateTime(selected.date_end, fieldDef.type),
-                                toDateTime(selected.date_start, fieldDef.type, true),
+                                toDateTime(selected.date_end, fieldDef.type, true),
+                                toDateTime(selected.date_start, fieldDef.type),
                             ]);
                         }
 
@@ -81,8 +81,8 @@ patch(TreeEditor.prototype, {
                             update: (v) => {
                                 const range = dateRanges.find((r) => r.id === v);
                                 update([
-                                    toDateTime(range.date_end, fieldDef.type),
-                                    toDateTime(range.date_start, fieldDef.type, true),
+                                    toDateTime(range.date_end, fieldDef.type, true),
+                                    toDateTime(range.date_start, fieldDef.type),
                                 ]);
                             },
                             value: selected.id,
@@ -130,8 +130,8 @@ patch(TreeEditor.prototype, {
             }
             if (operator.includes("daterange") && dateRanges) {
                 node.value = [
-                    toDateTime(dateRanges[0].date_end, fieldDef.type),
-                    toDateTime(dateRanges[0].date_start, fieldDef.type, true),
+                    toDateTime(dateRanges[0].date_end, fieldDef.type, true),
+                    toDateTime(dateRanges[0].date_start, fieldDef.type),
                 ];
                 this.notifyChanges();
             }


### PR DESCRIPTION
Without this fix we skip two days (first and last) when using date range domains, because the first day was set to start at 23:59:59 and the last day to finish at 00:00:00.

Before:

<img width="1331" height="495" alt="image" src="https://github.com/user-attachments/assets/20c218e6-149b-464e-9eab-f43b6b545f05" />

After:

<img width="1331" height="495" alt="image" src="https://github.com/user-attachments/assets/d863b8d1-c2b6-4242-9d4d-386d3b33139d" />
