### PR TITLE
[FIX] base_tier_validation_forward: fix forward notification delivery

### DIFF
--- a/base_tier_validation_forward/models/tier_validation.py
+++ b/base_tier_validation_forward/models/tier_validation.py
@@ -26,7 +26,7 @@ class TierValidation(models.AbstractModel):
         return res
 
     def _get_forwarded_notification_subtype(self):
-        return "base_tier_validation.mt_tier_validation_forwarded"
+        return "base_tier_validation_forward.mt_tier_validation_forwarded"
 
     def forward_tier(self):
         self.ensure_one()

--- a/base_tier_validation_forward/tests/test_tier_validation.py
+++ b/base_tier_validation_forward/tests/test_tier_validation.py
@@ -206,3 +206,95 @@ class TierTierValidation(CommonTierValidation):
     def test_03_forward_tier_multiple_without_comment(self):
         """Expected flow with forwards, but without comments"""
         self._test_forward_tier_multiple(has_comment=False)
+
+    def test_04_forward_notification_subtype_xmlid(self):
+        """The forwarded notification subtype must reference the correct module."""
+        test_record = self.test_model.create({"test_field": 2.5})
+        expected = "base_tier_validation_forward.mt_tier_validation_forwarded"
+        self.assertEqual(test_record._get_forwarded_notification_subtype(), expected)
+        # Verify the xmlid resolves to an actual record
+        subtype = self.env.ref(expected)
+        self.assertEqual(subtype.name, "Tier Validation Forward Notification")
+
+    def test_05_forward_message_uses_correct_subtype(self):
+        """Forward must post a chatter message with the correct subtype."""
+        self.tier_def_obj.create(
+            {
+                "model_id": self.tester_model.id,
+                "review_type": "individual",
+                "reviewer_id": self.test_user_2.id,
+                "definition_domain": "[('test_field', '>', 1.0)]",
+                "approve_sequence": True,
+                "has_forward": True,
+            }
+        )
+        test_record = self.test_model.create({"test_field": 2.5})
+        test_record.with_user(self.test_user_2).request_validation()
+
+        # Forward from user_2 to other_test_user
+        action = test_record.with_user(self.test_user_2).forward_tier()
+        self.env[action["res_model"]].with_user(self.test_user_2).with_context(
+            **action["context"]
+        ).create(
+            {
+                "forward_reviewer_id": self.other_test_user.id,
+                "forward_description": "Please check",
+            }
+        ).add_forward()
+
+        # The forwarded notification must use the correct subtype
+        fwd_subtype = self.env.ref(
+            "base_tier_validation_forward.mt_tier_validation_forwarded"
+        )
+        fwd_msg = self.env["mail.message"].search(
+            [
+                ("model", "=", "tier.validation.tester"),
+                ("res_id", "=", test_record.id),
+                ("subtype_id", "=", fwd_subtype.id),
+            ],
+            limit=1,
+        )
+        self.assertTrue(
+            fwd_msg,
+            "Forward notification must use subtype "
+            "'base_tier_validation_forward.mt_tier_validation_forwarded', "
+            "not fall back to 'mail.mt_note'",
+        )
+
+    def test_06_forward_target_subscribed_as_follower(self):
+        """Forward target must be subscribed as follower of the record."""
+        self.tier_def_obj.create(
+            {
+                "model_id": self.tester_model.id,
+                "review_type": "individual",
+                "reviewer_id": self.test_user_2.id,
+                "definition_domain": "[('test_field', '>', 1.0)]",
+                "approve_sequence": True,
+                "has_forward": True,
+            }
+        )
+        test_record = self.test_model.create({"test_field": 2.5})
+        test_record.with_user(self.test_user_2).request_validation()
+
+        target_partner = self.other_test_user.partner_id
+        followers_before = test_record.message_follower_ids.mapped("partner_id")
+        self.assertNotIn(target_partner, followers_before)
+
+        action = test_record.with_user(self.test_user_2).forward_tier()
+        self.env[action["res_model"]].with_user(self.test_user_2).with_context(
+            **action["context"]
+        ).create(
+            {
+                "forward_reviewer_id": self.other_test_user.id,
+                "forward_description": "Please check",
+            }
+        ).add_forward()
+
+        test_record.invalidate_recordset()
+        followers_after = test_record.message_follower_ids.mapped("partner_id")
+        self.assertIn(
+            target_partner,
+            followers_after,
+            "Forward target must be subscribed as follower to receive "
+            "email notifications about the forwarded review",
+        )

--- a/base_tier_validation_forward/wizard/forward_wizard.py
+++ b/base_tier_validation_forward/wizard/forward_wizard.py
@@ -25,6 +25,17 @@ class ValidationForwardWizard(models.TransientModel):
         """Add extra step, with specific reviewer"""
         self.ensure_one()
         rec = self.env[self.res_model].browse(self.res_id)
+        # Subscribe the forward target as a follower so they receive
+        # email notifications about the forwarded review.
+        if hasattr(rec, "message_subscribe"):
+            fwd_subtype = self.env.ref(
+                "base_tier_validation_forward.mt_tier_validation_forwarded",
+                raise_if_not_found=False,
+            )
+            rec.message_subscribe(
+                partner_ids=self.forward_reviewer_id.partner_id.ids,
+                subtype_ids=fwd_subtype.ids if fwd_subtype else [],
+            )
         prev_comment = self.env["comment.wizard"].browse(
             self._context.get("comment_id")
         )


### PR DESCRIPTION
## Summary

Two bugs in `base_tier_validation_forward` prevent forwarded review notifications from reaching the target user:

**Bug 1 — Wrong `subtype_xmlid`:** `_get_forwarded_notification_subtype()` returns `"base_tier_validation.mt_tier_validation_forwarded"` but the `mail.message.subtype` record is defined in the `base_tier_validation_forward` module (see `data/mail_data.xml`). When `message_post()` cannot resolve the xmlid, it silently falls back to `mail.mt_note` — internal notes do **not** generate email notifications for followers.

**Bug 2 — Forward target not subscribed as follower:** The forward wizard `add_forward()` creates a `tier.review` for the target user but never calls `message_subscribe()`. Without being a follower of the record, the target user cannot receive email notifications even if the subtype were correct.

**Combined effect:** When a reviewer forwards their approval to another user, the target user is never notified by email. The forward "works" technically (the review record is created), but the target user has no way of knowing they need to act — unless they happen to be actively browsing the record's chatter.

## Changes

- **`models/tier_validation.py`**: Fix the module prefix in `_get_forwarded_notification_subtype()` from `base_tier_validation` → `base_tier_validation_forward`
- **`wizard/forward_wizard.py`**: Call `message_subscribe()` in `add_forward()` to subscribe the forward target as a follower with the forward notification subtype
- **`tests/test_tier_validation.py`**: Add 3 tests — subtype xmlid correctness, message subtype verification, follower subscription after forward