### PR TITLE
[18.0][IMP] base_tier_validation: increase review limit for reminder cron

### DIFF
--- a/base_tier_validation/models/tier_definition.py
+++ b/base_tier_validation/models/tier_definition.py
@@ -153,7 +153,7 @@ class TierDefinition(models.Model):
                 ("last_reminder_date", "=", False),
                 ("last_reminder_date", "<", review_date),
             ],
-            limit=1,
+            limit=50,
         )
 
     def _cron_send_review_reminder(self):

--- a/base_tier_validation/models/tier_review.py
+++ b/base_tier_validation/models/tier_review.py
@@ -192,16 +192,20 @@ class TierReview(models.Model):
         return self.env._("A review has been requested %s days ago.", delay)
 
     def _send_review_reminder(self):
-        record = self.env[self.model].browse(self.res_id)
-        # Only schedule activity if reviewer is a single user and model has activities
-        if len(self.reviewer_ids) == 1 and hasattr(record, "activity_ids"):
-            self._schedule_review_reminder_activity(record)
-        elif hasattr(record, "message_post"):
-            self._notify_review_reminder(record)
-        else:
-            msg = f"Could not send reminder for record {record}"
-            _logger.exception(msg)
-        self.last_reminder_date = fields.Datetime.now()
+        for rev in self:
+            record = self.env[rev.model].browse(rev.res_id)
+            if not record.exists():  # <-- skip orphaned reviews
+                continue
+            # Only schedule activity if reviewer is a single user and model
+            # has activities
+            if len(rev.reviewer_ids) == 1 and hasattr(record, "activity_ids"):
+                rev._schedule_review_reminder_activity(record)
+            elif hasattr(record, "message_post"):
+                rev._notify_review_reminder(record)
+            else:
+                msg = f"Could not send reminder for record {record}"
+                _logger.exception(msg)
+            rev.last_reminder_date = fields.Datetime.now()
 
     def _notify_review_reminder(self, record):
         record.message_post(


### PR DESCRIPTION
The search on pending reviews is currently limited to 1. If we have the case where a company has plenty of reviews, even if the cron runs every minute (the standard minimum in cron configuration), it takes a lot of time to browse all pending reviews. I suggest to increase the limit and adapt the called action to fit with a recordset.