### PR TITLE
[18.0][FIX] checklog-odoo.cfg: ignore Killing chrome descendants-or-self warning

### DIFF
--- a/checklog-odoo.cfg
+++ b/checklog-odoo.cfg
@@ -1,3 +1,4 @@
 [checklog-odoo]
 ignore=
     WARNING.* 0 failed, 0 error\(s\).*
+    WARNING .* Killing chrome descendants-or-self .*


### PR DESCRIPTION
Warning introduced in https://github.com/odoo/odoo/commit/d22e0b4e181de0940810b0f0a760bcfe288042a7. The previous warning apparently did not occur, as it was not featured in checklog-odoo.cfg.

```
2026-04-13 06:39:49,548 745 WARNING odoo odoo.addons.base_import_security_group.tests.test_base_import_security_group.TestImportSecurityGroup.test_access_demo: Killing chrome descendants-or-self of 761: 6 remaining
- chrome (zombie)
- chrome (zombie)
- chrome (zombie)
- chrome (zombie)
- chrome (zombie)
- chrome (zombie)
2026-04-13 06:40:08,196 745 WARNING odoo odoo.addons.base_import_security_group.tests.test_base_import_security_group.TestImportSecurityGroup.test_import_button: Killing chrome descendants-or-self of 881: 6 remaining
- chrome (zombie)
- chrome (zombie)
- chrome (zombie)
- chrome (zombie)
- chrome (zombie)
- chrome (zombie)
2026-04-13 06:40:26,898 745 WARNING odoo odoo.addons.base_import_security_group.tests.test_base_import_security_group.TestImportSecurityGroup.test_no_import_button: Killing chrome descendants-or-self of 1008: 6 remaining
- chrome (zombie)
- chrome (zombie)
- chrome (zombie)
- chrome (zombie)
- chrome (zombie)
- chrome (zombie)
```