### PR TITLE
[18.0][FIX] server_action_mass_edit: add onchange_helper dependency

### DIFF
--- a/server_action_mass_edit/__manifest__.py
+++ b/server_action_mass_edit/__manifest__.py
@@ -2,7 +2,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 {
     "name": "Mass Editing",
-    "version": "18.0.1.1.3",
+    "version": "18.0.1.1.4",
     "author": "Serpent Consulting Services Pvt. Ltd., "
     "Tecnativa, "
     "GRAP, "
@@ -14,6 +14,7 @@
     "summary": "Mass Editing",
     "depends": [
         "base",
+        "onchange_helper",
     ],
     "data": [
         "security/ir.model.access.csv",


### PR DESCRIPTION
Closes: #3368 (reported on OCA/server-tools, but module is in server-ux)

**Problem:**
Installing `server_action_mass_edit` alone and creating a mass editing rule for relational fields (like `categ_id`) crashes with `KeyError: 'selection__categ_id'`. The wizard's `fields_get()` and `onchange()` methods generate dynamic fields, but the underlying `onchange_helper` infrastructure is missing.

**Fix:**
Add `onchange_helper` to the `depends` list in `__manifest__.py`.

**Why not `server_action_mass_edit_onchange`:**
Adding `server_action_mass_edit_onchange` directly would create a circular dependency (`mass_edit` depends on `mass_edit_onchange` depends on `mass_edit`). `onchange_helper` is the common upstream dependency that breaks the cycle.