### PR TITLE
[18.0][IMP][BCKP] base_tier_validation: clearer notify_on_pending chatter body

### DIFF
--- a/base_tier_validation/models/tier_validation.py
+++ b/base_tier_validation/models/tier_validation.py
@@ -729,8 +729,34 @@ class TierValidation(models.AbstractModel):
             self.env.user.name,
         )
 
-    def _notify_requested_review_body(self):
-        return self.env._("A review has been requested by %s.", self.env.user.name)
+    def _notify_requested_review_body(self, tier_reviews=None):
+        """Chatter body for a tier reaching ``pending``.
+
+        Sources the requester from the review's ``requested_by`` rather
+        than ``env.user`` -- on second-and-later tier promotions
+        ``env.user`` is the previous-tier *approver*, which is the wrong
+        person to attribute the request to.
+
+        Names the assignee(s) in the body so the recipient sees at a
+        glance that the message is meant for them (chatter notifications
+        do not render the "Notified to" pill, so the body has to carry
+        that information itself). Reuses ``tier.review.todo_by`` so the
+        wording is consistent with the Reviews table and handles every
+        review type out of the box -- individual user, group, or field.
+        """
+        if tier_reviews:
+            requester = tier_reviews[:1].requested_by or self.env.user
+            assignees = ", ".join(
+                filter(None, tier_reviews.mapped("todo_by"))
+            ) or self.env._("the assigned reviewer")
+            return self.env._(
+                "Review pending for %(assignees)s, requested by %(requester)s.",
+                assignees=assignees,
+                requester=requester.display_name,
+            )
+        return self.env._(
+            "A review has been requested by %s.", self.env.user.display_name
+        )
 
     def _notify_review_requested(self, tier_reviews):
         """method to notify when tier validation is created"""
@@ -949,7 +975,7 @@ class TierValidation(models.AbstractModel):
                 )
                 rec.message_post(
                     subtype_xmlid=self._get_requested_notification_subtype(),
-                    body=rec._notify_requested_review_body(),
+                    body=rec._notify_requested_review_body(tier_reviews),
                 )
 
 

--- a/base_tier_validation/readme/HISTORY.md
+++ b/base_tier_validation/readme/HISTORY.md
@@ -1,3 +1,17 @@
+## 18.0.3.5.0 (2026-05-17)
+
+Improvements:
+
+- ``notify_on_pending`` chatter body now names the assignee(s) so the
+  recipient can tell at a glance that the message is for them. Reuses
+  ``tier.review.todo_by`` so every review type (individual user,
+  group, ``res.users`` / ``res.groups`` field) is handled uniformly.
+- ``notify_on_pending`` chatter body now attributes the request to
+  ``review.requested_by`` (the user who actually pressed *Request
+  Validation*) instead of ``env.user``. On second-and-later tier
+  promotions ``env.user`` is the previous-tier approver, which was the
+  wrong person to credit.
+
 ## 17.0.1.0.0 (2024-01-10)
 
 Migrated to Odoo 17.

--- a/base_tier_validation/tests/test_tier_validation.py
+++ b/base_tier_validation/tests/test_tier_validation.py
@@ -592,8 +592,12 @@ class TierTierValidation(CommonTierValidation):
         review_1._compute_can_review()
         self.assertTrue(review_1.status == "pending")
         msg2 = test_record2.message_ids[0].body
-        request = test_record2._notify_requested_review_body()
+        # The promotion body now carries the assignee + the original
+        # requester (sourced from ``review.requested_by``, not env.user).
+        request = test_record2._notify_requested_review_body(review_1)
         self.assertIn(request, msg2)
+        self.assertIn(review_1.todo_by, msg2)
+        self.assertIn(review_1.requested_by.display_name, msg2)
 
     def test_21_notify_on_create(self):
         # notify on create


### PR DESCRIPTION
Backport of OCA/tier-validation#22 to 18.0.

## Problem

The chatter message posted when a tier reaches ``pending`` (from
``_notify_review_available``) has two UX problems:

1. **Wrong attribution on later tiers.** ``self.env.user.name`` inside
   ``_notify_requested_review_body`` resolves to whichever user
   triggered the promotion. On second-and-later tiers that is the
   *approver* of the previous tier, not the person who pressed
   *Request Validation* -- so the message credits the wrong user.
2. **No way to tell who the message is for.** Chatter system
   notifications do not render the "Notified to" pill the way
   user-typed comments do. A recipient seeing *"A review has been
   requested by Administrator"* cannot tell whether it was meant for
   them.

## Fix

- Source the requester from ``review.requested_by`` (set once at
  ``request_validation`` time, never reassigned) so attribution is
  consistent across all tiers.
- Reuse the existing ``tier.review.todo_by`` field for the assignee
  label -- it already handles every review type (individual /
  ``res.users`` field, group, ``res.groups`` field) with the same
  abbreviation rules as the Reviews table.
- New wording: *"Review pending for Mike, requested by Administrator."*

Backwards-compatible: ``_notify_requested_review_body()`` still works
with no arguments and returns the previous short body for any
downstream overrider that calls it that way.

## Notes on backport scope

The upstream PR also extends ``test_19a_notify_on_pending_sequence_negative``,
which was introduced by its dependency OCA/tier-validation#21 and does
not exist on this branch (18.0's nearest equivalent,
``test_19_waiting_tier``, deliberately runs with ``notify_on_pending``
off). Only the ``test_20_no_sequence`` adaptation -- which asserts the
assignee and the original requester are present in the body -- has been
ported here.

## Test plan

- ``test_20_no_sequence`` updated to assert both the assignee
  (``review_1.todo_by``) and the original requester
  (``review_1.requested_by``) are present in the chatter body.