### PR TITLE
[16.0][FIX] server_action_mass_edit: stop poisoning the registry on onchange

### DIFF
--- a/server_action_mass_edit/__manifest__.py
+++ b/server_action_mass_edit/__manifest__.py
@@ -2,7 +2,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 {
     "name": "Mass Editing",
-    "version": "16.0.2.1.1",
+    "version": "16.0.2.1.2",
     "author": "Serpent Consulting Services Pvt. Ltd., "
     "Tecnativa, "
     "GRAP, "

--- a/server_action_mass_edit/tests/test_mass_editing.py
+++ b/server_action_mass_edit/tests/test_mass_editing.py
@@ -7,6 +7,7 @@ from ast import literal_eval
 
 import psycopg2
 
+from odoo import models
 from odoo.exceptions import UserError, ValidationError
 from odoo.tests import Form, common, new_test_user
 from odoo.tools.misc import mute_logger
@@ -438,6 +439,93 @@ class TestMassEditing(common.TransactionCase):
             ).create(vals)
         except Exception as e:
             self.assertEqual(type(e), UserError)
+
+    def test_onchange_dynamic_fields_are_bound_and_cleaned(self):
+        """Dynamic Selection fields injected in ``_fields`` during ``onchange``
+        must:
+
+        1. Be bound to their owner so ``model_name`` and ``name`` are
+           populated. Otherwise any later access to
+           ``registry._field_triggers`` (e.g. via ``_has_onchange`` triggered
+           by ``get_view`` on another model) resolves ``registry[None]`` and
+           raises ``KeyError: None``, which then surfaces as a random RPC
+           error in unrelated views.
+        2. Be removed from ``_fields`` once ``onchange`` returns, even when
+           ``super().onchange()`` raises. ``_fields`` is a class attribute
+           shared by every request handled by the worker, so a leaked Field
+           poisons the registry until the process is restarted.
+        """
+        wizard_model = self.MassEditingWizard
+        injected_field_names = [
+            "selection__" + line.field_id.name
+            for line in self.mass_editing_user.mass_edit_line_ids
+        ]
+        self.assertTrue(injected_field_names, "demo data should have lines")
+
+        # Happy path: capture the dynamic Field metadata while super() runs,
+        # then assert nothing is left behind afterwards.
+        original_onchange = models.Model.onchange
+        captured = {}
+
+        def inspecting_onchange(inst, values, field_name, field_onchange):
+            for fname in injected_field_names:
+                fld = inst._fields.get(fname)
+                captured[fname] = (
+                    fld.model_name if fld else None,
+                    fld.name if fld else None,
+                )
+            return {}
+
+        models.Model.onchange = inspecting_onchange
+        try:
+            wizard_model.with_context(
+                server_action_id=self.mass_editing_user.id,
+                active_ids=[],
+                original_active_ids=[],
+            ).onchange({}, [], {})
+        finally:
+            models.Model.onchange = original_onchange
+
+        for fname in injected_field_names:
+            model_name, name = captured[fname]
+            self.assertEqual(
+                model_name,
+                wizard_model._name,
+                "Dynamic field %s was injected with model_name=%r; "
+                "registry lookups will crash with KeyError: None."
+                % (fname, model_name),
+            )
+            self.assertEqual(name, fname)
+            self.assertNotIn(
+                fname,
+                wizard_model._fields,
+                "Dynamic field %s leaked into _fields after a successful "
+                "onchange call." % fname,
+            )
+
+        # Failure path: even when super().onchange() raises, dynamic fields
+        # must be cleaned up so the worker's _fields stays uncontaminated.
+        def failing_onchange(inst, values, field_name, field_onchange):
+            raise UserError("boom")  # pylint: disable=translation-required
+
+        models.Model.onchange = failing_onchange
+        try:
+            with self.assertRaises(UserError):
+                wizard_model.with_context(
+                    server_action_id=self.mass_editing_user.id,
+                    active_ids=[],
+                    original_active_ids=[],
+                ).onchange({}, [], {})
+        finally:
+            models.Model.onchange = original_onchange
+
+        for fname in injected_field_names:
+            self.assertNotIn(
+                fname,
+                wizard_model._fields,
+                "Dynamic field %s leaked into _fields after a failing "
+                "onchange call." % fname,
+            )
 
     def test_mass_edit_partner_sql_error(self):
         vals = {

--- a/server_action_mass_edit/wizard/mass_editing_wizard.py
+++ b/server_action_mass_edit/wizard/mass_editing_wizard.py
@@ -101,13 +101,24 @@ class MassEditingWizard(models.TransientModel):
             return super().onchange(values, field_name, field_onchange)
         dynamic_fields = {}
         for line in server_action.mapped("mass_edit_line_ids"):
-            dynamic_fields["selection__" + line.field_id.name] = fields.Selection(
-                [()], default="ignore"
-            )
+            fname = "selection__" + line.field_id.name
+            fld = fields.Selection([()], default="ignore")
+            # Bind the dynamic Field to its owner so ``model_name`` / ``name``
+            # are populated. Otherwise any later access to the registry's
+            # ``_field_triggers`` (e.g. via ``_has_onchange`` on another model)
+            # would resolve ``registry[None]`` and raise ``KeyError: None``,
+            # which then propagates as a random RPC error in unrelated views.
+            fld.__set_name__(type(self), fname)
+            dynamic_fields[fname] = fld
         self._fields.update(dynamic_fields)
-        res = super().onchange(values, field_name, field_onchange)
-        for field in dynamic_fields:
-            self._fields.pop(field)
+        try:
+            res = super().onchange(values, field_name, field_onchange)
+        finally:
+            # Always clean up: ``_fields`` is a class attribute shared by every
+            # request handled by the worker, so a leaked Field would poison
+            # the registry until the process is restarted.
+            for fname in dynamic_fields:
+                self._fields.pop(fname, None)
         return res
 
     @api.model


### PR DESCRIPTION
## Symptom

In production we have been seeing random `KeyError: None` traces every few minutes, fired from unrelated views (`bank_rec_widget`, `knowledge.article`, ...) and surfaced to the web client as `RPC_ERROR`:

```
File ".../odoo/models.py", line 6347, in _has_onchange
    for dep in self.pool.get_dependent_fields(field.base_field)
File ".../odoo/modules/registry.py", line 351, in get_dependent_fields
    if field not in self._field_triggers:
File ".../odoo/modules/registry.py", line 439, in _field_triggers
    dependencies = list(field.resolve_depends(self))
File ".../odoo/fields.py", line 775, in resolve_depends
    Model0 = registry[self.model_name]
File ".../odoo/modules/registry.py", line 186, in __getitem__
    return self.models[model_name]
KeyError: None
```

The trace never points at this module on the surface, but the only thing that has been planting `Field` instances with `model_name = None` into the registry is `MassEditingWizard.onchange`.

## Root cause

`MassEditingWizard.onchange` injects dynamic `Selection` fields by assigning them straight into `self._fields`:

```python
dynamic_fields["selection__" + line.field_id.name] = fields.Selection(
    [()], default="ignore"
)
self._fields.update(dynamic_fields)
```

These `Field` objects never go through `__set_name__`, so `model_name` and `name` stay at the default `None`. Any later access to `registry._field_triggers` — for example from `_has_onchange` while building a view for any other model — calls `field.resolve_depends(self)` → `registry[None]` → `KeyError: None`.

The `for field in dynamic_fields: self._fields.pop(field)` cleanup is also not wrapped in `try/finally`. If anything inside `super().onchange()` raises, the orphan `Field` instances are left in `mass.editing.wizard._fields` (a class-level dict, shared by every request on that worker). The worker stays poisoned for the rest of its lifetime: every request that touches `_field_triggers` then explodes randomly on completely unrelated views.

I could not find an open issue/PR covering this exact scenario in OCA/server-ux. PR #1203 deals with the view cache mechanism on 17.0+, which is unrelated.

## Fix

* Call `Field.__set_name__` on each dynamic field before inserting it into `_fields`, so `model_name` / `name` are populated and registry lookups resolve to `mass.editing.wizard` as expected.
* Wrap the `super().onchange()` call in `try/finally`, so the dynamic fields are always removed from `_fields` — even when the parent `onchange` raises.

## Regression test

`test_onchange_dynamic_fields_are_bound_and_cleaned` asserts both invariants:

1. While `super().onchange()` is running, each dynamic Field has `model_name == 'mass.editing.wizard'` (without the fix the test fails with `None != 'mass.editing.wizard': Dynamic field selection__bank_ids was injected with model_name=None`).
2. `_fields` is restored to its original state on both the success path and a failure path that forces `super().onchange()` to raise.

## Affected versions

The same pattern is present on 17.0, 18.0 and the 19.0 migration PRs. I will open companion PRs once this one is reviewed.