### PR TITLE
[18.0][IMP] base_tier_validation: default comment approve

### DIFF
--- a/base_tier_validation/models/tier_definition.py
+++ b/base_tier_validation/models/tier_definition.py
@@ -94,6 +94,10 @@ class TierDefinition(models.Model):
         "to this definition are restarted.",
     )
     has_comment = fields.Boolean(string="Comment", default=False)
+    comment_approve_default = fields.Char(
+        string="Approve Comment",
+        help="Default comment prefilled when approval comments are enabled.",
+    )
     notify_reminder_delay = fields.Integer(
         string="Send reminder message on pending reviews",
         help="Number of days after which a message must be posted to remind about "

--- a/base_tier_validation/models/tier_validation.py
+++ b/base_tier_validation/models/tier_validation.py
@@ -645,7 +645,11 @@ class TierValidation(models.AbstractModel):
             user_reviews = reviews.filtered(
                 lambda r: r.status == "pending" and (self.env.user in r.reviewer_ids)
             )
-            return self._add_comment("validate", user_reviews)
+            action = self._add_comment("validate", user_reviews)
+            action["context"]["default_comment"] = (
+                user_reviews[:1].definition_id.comment_approve_default or ""
+            )
+            return action
         self._validate_tier(reviews)
         self._update_counter({"review_deleted": True})
 

--- a/base_tier_validation/tests/test_tier_validation.py
+++ b/base_tier_validation/tests/test_tier_validation.py
@@ -128,13 +128,14 @@ class TierTierValidation(CommonTierValidation):
         # Create new test record
         test_record = self.test_model.create({"test_field": 2.5})
         # Create tier definitions
-        self.tier_def_obj.create(
+        tier_def = self.tier_def_obj.create(
             {
                 "model_id": self.tester_model.id,
                 "review_type": "individual",
                 "reviewer_id": self.test_user_1.id,
                 "definition_domain": "[('test_field', '>', 1.0)]",
                 "has_comment": True,
+                "comment_approve_default": "Approved",
             }
         )
         # Request validation
@@ -145,7 +146,19 @@ class TierTierValidation(CommonTierValidation):
         record = test_record.with_user(self.test_user_1.id)
         res = record.validate_tier()
         ctx = res.get("context")
+        # Default comment pre-filled from tier definition
+        self.assertEqual(ctx.get("default_comment"), "Approved")
         wizard = Form(self.env["comment.wizard"].with_context(**ctx))
+        self.assertEqual(wizard.comment, "Approved")
+
+        # Clear default approve comment
+        tier_def.write({"comment_approve_default": False})
+
+        res = record.validate_tier()
+        ctx = res.get("context")
+        self.assertEqual(ctx.get("default_comment"), "")
+        wizard = Form(self.env["comment.wizard"].with_context(**ctx))
+        self.assertEqual(wizard.comment, "")
         wizard.comment = "Test Comment"
         wiz = wizard.save()
         wiz.add_comment()

--- a/base_tier_validation/views/tier_definition_view.xml
+++ b/base_tier_validation/views/tier_definition_view.xml
@@ -114,6 +114,10 @@
                                     <field name="notify_on_rejected" />
                                     <field name="notify_on_restarted" />
                                     <field name="has_comment" />
+                                    <field
+                                        name="comment_approve_default"
+                                        invisible="not has_comment"
+                                    />
                                     <field name="notify_reminder_delay" />
                                 </group>
                             </group>


### PR DESCRIPTION
Currently, comments are required for both approval and rejection.

From a business perspective, rejection should usually include a reason, but approval often does not. By allowing a default approval comment, users can approve requests without entering a comment manually each time.

This PR adds config a default approval comment, which is automatically filled in the approval wizard.

<img width="1147" height="952" alt="Screenshot 2026-06-01 104619" src="https://github.com/user-attachments/assets/fe52c75c-a482-497f-b577-f2c6482a7623" />
<img width="2259" height="678" alt="Screenshot 2026-06-01 104657" src="https://github.com/user-attachments/assets/e86f2b6f-7b7d-4eff-bfba-a589c19c73af" />
