### PR TITLE
[18.0] [FIX] server_action_mass_edit: delete inactive views in tests

### DIFF
--- a/server_action_mass_edit/tests/test_mass_editing.py
+++ b/server_action_mass_edit/tests/test_mass_editing.py
@@ -155,7 +155,7 @@ class TestMassEditing(common.TransactionCase):
         )
 
         # test the code path where we extract an embedded tree for o2m fields
-        self.env["ir.ui.view"].search(
+        self.env["ir.ui.view"].with_context(active_test=False).search(
             [
                 ("model", "in", ("res.partner.bank", "res.partner", "res.users")),
                 ("id", "!=", self.env.ref("base.res_partner_view_form_private").id),


### PR DESCRIPTION
If a module deactivates a res partner view, then the test will fail, because the view will not be fetched by the search and this will cause a SQL error, because it is trying to remove the parent view before the inactive view is unlinked