### PR TITLE
[19.0][IMP] base_substate: cache substate type lookup to avoid a query per computed field

### DIFF
--- a/base_substate/__manifest__.py
+++ b/base_substate/__manifest__.py
@@ -3,7 +3,7 @@
 
 {
     "name": "Base Sub State",
-    "version": "19.0.1.0.1",
+    "version": "19.0.1.0.2",
     "category": "Tools",
     "author": "Akretion, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/server-ux",

--- a/base_substate/models/base_substate.py
+++ b/base_substate/models/base_substate.py
@@ -1,7 +1,7 @@
 # Copyright 2020 Akretion
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class BaseSubstateType(models.Model):
@@ -27,6 +27,24 @@ class BaseSubstateType(models.Model):
         help="Technical target state field name."
         ' Ex for sale order "state" for other "status" ... ',
     )
+
+    # base.substate.mixin._get_substate_type_id caches the type per model;
+    # clear that cache whenever the (model -> type) mapping can change.
+    @api.model_create_multi
+    def create(self, vals_list):
+        records = super().create(vals_list)
+        self.env.registry.clear_cache()
+        return records
+
+    def write(self, vals):
+        res = super().write(vals)
+        if "model" in vals:
+            self.env.registry.clear_cache()
+        return res
+
+    def unlink(self):
+        self.env.registry.clear_cache()
+        return super().unlink()
 
 
 class TargetStateValue(models.Model):

--- a/base_substate/models/base_substate_mixin.py
+++ b/base_substate/models/base_substate_mixin.py
@@ -1,7 +1,7 @@
 # Copyright 2020 Akretion
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import api, fields, models
+from odoo import api, fields, models, tools
 from odoo.exceptions import ValidationError
 from odoo.fields import Domain
 
@@ -59,11 +59,28 @@ class BaseSubstateMixin(models.AbstractModel):
         """Override this method to change state_value"""
         return "draft"
 
+    @api.model
+    @tools.ormcache("self._name")
+    def _get_substate_type_id(self):
+        """Return the substate type id for this model (cached).
+
+        ``_compute_field_value`` calls ``_get_substate_type`` on every computed
+        field computation, so without a cache this issues one
+        ``base.substate.type`` search per computed field read -- which adds up
+        quickly on list/kanban loads. The type per model is technical
+        configuration data that effectively never changes at runtime, so the
+        lookup is cached and invalidated when ``base.substate.type`` records
+        change (see ``BaseSubstateType``).
+        """
+        return (
+            self.env["base.substate.type"]
+            .search(Domain("model", "=", self._name), limit=1)
+            .id
+        )
+
     def _get_substate_type(self):
         """Override this method to change substate_type (get by xml id for example)"""
-        return self.env["base.substate.type"].search(
-            Domain("model", "=", self._name), limit=1
-        )
+        return self.env["base.substate.type"].browse(self._get_substate_type_id())
 
     substate_id = fields.Many2one(
         "base.substate",

--- a/base_substate/tests/sale_test.py
+++ b/base_substate/tests/sale_test.py
@@ -7,8 +7,15 @@ class BaseSubstateType(models.Model):
     _inherit = "base.substate.type"
 
     model = fields.Selection(
-        selection_add=[("base.substate.test.sale", "Sale Test")],
-        ondelete={"base.substate.test.sale": "cascade"},
+        selection_add=[
+            ("base.substate.test.sale", "Sale Test"),
+            # second value, so tests can move a type from one model to another
+            ("base.substate.test.sale.line", "Sale Line Test"),
+        ],
+        ondelete={
+            "base.substate.test.sale": "cascade",
+            "base.substate.test.sale.line": "cascade",
+        },
     )
 
 

--- a/base_substate/tests/test_base_substate.py
+++ b/base_substate/tests/test_base_substate.py
@@ -112,6 +112,39 @@ class TestBaseSubstate(CommonBaseSubstate):
             }
         )
 
+    def test_substate_type_cache_invalidation(self):
+        """The cached model -> substate type lookup follows base.substate.type."""
+        sale_test = self.sale_test_model
+        # First call fills the cache.
+        self.assertEqual(sale_test._get_substate_type(), self.sale_test_substate_type)
+
+        # Creating a type for the same model invalidates the cache. "AAA Sale"
+        # sorts before "Sale", so it becomes the one the lookup resolves to
+        # (_order = "name asc, model asc", search is limited to one record).
+        other_type = self.substate_type.create(
+            {
+                "name": "AAA Sale",
+                "model": "base.substate.test.sale",
+                "target_state_field": "state",
+            }
+        )
+        self.assertEqual(sale_test._get_substate_type(), other_type)
+
+        # Moving the type to another model invalidates the cache too.
+        other_type.write({"model": "base.substate.test.sale.line"})
+        self.assertEqual(sale_test._get_substate_type(), self.sale_test_substate_type)
+
+        # A write that cannot change the model -> type mapping keeps the cache.
+        other_type.write({"target_state_field": "state"})
+        self.assertEqual(sale_test._get_substate_type(), self.sale_test_substate_type)
+
+        other_type.write({"model": "base.substate.test.sale"})
+        self.assertEqual(sale_test._get_substate_type(), other_type)
+
+        # ... and so does unlinking.
+        other_type.unlink()
+        self.assertEqual(sale_test._get_substate_type(), self.sale_test_substate_type)
+
     def test_sale_order_substate(self):
         # Create a partner instead of using a potentially non-existent XML ID
         partner = self.env["res.partner"].create(


### PR DESCRIPTION
### Problem

`base.substate.mixin._compute_field_value` runs on **every computed-field computation** and calls `_get_substate_type()`, which issues a `base.substate.type` search each time.

On a model that mixes in `base.substate.mixin` and has several computed fields, this means **one redundant `base.substate.type` search per computed field on every record read**. It is very visible when profiling list/kanban loads of such models — a single grouped read fires the same `SELECT ... FROM base_substate_type ...` many times.

### Change

The substate type for a given model is technical configuration data that effectively never changes at runtime, so the lookup is cached:

- add `_get_substate_type_id`, an `@tools.ormcache`-d helper keyed on the model name;
- `_get_substate_type` now browses that cached id — **return value unchanged**, so existing overrides keep working;
- clear the cache on `base.substate.type` create / model-change write / unlink.

### Notes

- No functional change; the existing `base_substate` tests pass.
- Caught while profiling a kanban on a custom model using the mixin: the per-computed-field `base.substate.type` searches were a measurable chunk of the query count.