### PR TITLE
[FIX] confirmation_wizard : allow non admin user to use wizards

### DIFF
--- a/confirmation_wizard/security/ir.model.access.csv
+++ b/confirmation_wizard/security/ir.model.access.csv
@@ -1,2 +1,2 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
-access_confirmation_wizard,access.confirmation.wizard,model_confirmation_wizard,base.group_system,1,1,1,1
+access_confirmation_wizard,access.confirmation.wizard,model_confirmation_wizard,base.group_user,1,1,1,1


### PR DESCRIPTION
Rational : for the time being, only admin user can use wizard with the confirmation feature.