### PR TITLE
[18.0][IMP] base_export_manager: Add properties compatibility

### DIFF
--- a/base_export_manager/models/ir_exports_line.py
+++ b/base_export_manager/models/ir_exports_line.py
@@ -140,9 +140,10 @@ class IrExportsLine(models.Model):
                 # You could get to failing constraint while populating the
                 # fields, so we skip the uniqueness check and manually check
                 # the full constraint after the loop
-                one.with_context(skip_check=True)[one.field_n(num, True)] = (
-                    one._get_field_id(model, field_name)
-                )
+                if "." not in field_name:
+                    one.with_context(skip_check=True)[one.field_n(num, True)] = (
+                        one._get_field_id(model, field_name)
+                    )
             if any(parts):
                 # invalidate_recordset -> in order to get actual value of field 'label'
                 # in function '_check_name'
@@ -155,7 +156,7 @@ class IrExportsLine(models.Model):
         if self._context.get("skip_check"):
             return
         for one in self:
-            if not one.label:
+            if not one.label and "." not in one.name:
                 raise exceptions.ValidationError(
                     _("Field '%s' does not exist") % one.name
                 )

--- a/base_export_manager/tests/test_ir_exports_line.py
+++ b/base_export_manager/tests/test_ir_exports_line.py
@@ -3,10 +3,11 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from odoo.exceptions import ValidationError
-from odoo.tests.common import TransactionCase
+
+from odoo.addons.base.tests.common import BaseCommon
 
 
-class TestIrExportsLineCase(TransactionCase):
+class TestIrExportsLineCase(BaseCommon):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
@@ -36,6 +37,15 @@ class TestIrExportsLineCase(TransactionCase):
             self._record_create("name")
         with self.assertRaises(ValidationError):
             self._record_create("bad_error_name")
+        # You need to create the line this way and not use the _record_create() method
+        # because the properties field does not exist; by default, there are no
+        # properties in res.partner
+        self.env["ir.exports.line"].create(
+            {
+                "export_id": self.export.id,
+                "name": "field_properties.123456",
+            }
+        )
 
     def test_get_label_string(self):
         export_line = self._record_create("parent_id/name")


### PR DESCRIPTION
Add properties compatibility

Use case example:
- Create a property (for example, in a task)
- In the task list, try to export data, select a property field, and add it
- Create a new export template and save

Please @pedrobaeza and @carlos-lopez-tecnativa can you review it?

@Tecnativa TT63959