### PR TITLE
[18.0][FIX] base_substate: missing space in substate validation message

### DIFF
--- a/base_substate/__manifest__.py
+++ b/base_substate/__manifest__.py
@@ -3,7 +3,7 @@
 
 {
     "name": "Base Sub State",
-    "version": "18.0.1.0.2",
+    "version": "18.0.1.0.3",
     "category": "Tools",
     "author": "Akretion, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/server-ux",

--- a/base_substate/models/base_substate_mixin.py
+++ b/base_substate/models/base_substate_mixin.py
@@ -18,9 +18,11 @@ class BaseSubstateMixin(models.AbstractModel):
             if rec.substate_id and rec.state != target_state:
                 raise ValidationError(
                     self.env._(
-                        f"The substate {rec.substate_id.name} is not defined for"
-                        f"the state {rec_states[rec.state]} but for "
-                        f"{rec_states[target_state]}"
+                        "The substate %(name)s is not defined for the state"
+                        " %(state)s but for %(target_state)s ",
+                        name=rec.substate_id.name,
+                        state=rec_states[rec.state],
+                        target_state=rec_states[target_state],
                     )
                 )
 


### PR DESCRIPTION
The substate validation error currently reads:

> The substate **Gevalideerd** is not defined for**the** state Done but for Te factureren

### Problem

The message is built with f-strings inside `self.env._()`:

```python
self.env._(
    f"The substate {rec.substate_id.name} is not defined for"
    f"the state {rec_states[rec.state]} but for "
    f"{rec_states[target_state]}"
)
```

Two consequences:

- `"... is not defined for"` and `"the state ..."` are concatenated with no
  space in between → **`forthe`**;
- the msgid contains the interpolated values, so it can never be extracted
  nor matched against a `.po` entry. The string is indeed absent from
  `i18n/base_substate.pot`, and the message is always rendered in English
  regardless of the user language.

### Change

Restore the named placeholders that were used up to 17.0. This fixes the
missing space and makes the message translatable again — as a bonus the
existing `es` / `it` translations for this msgid apply once more.

The trailing space at the end of the msgid is kept deliberately: it is what
`es.po` / `it.po` already carry, so keeping it preserves those translations.

No functional change beyond the message text.