### PR TITLE
[18.0][FIX] base_tier_validation: cancel state compared by substring

### DIFF
--- a/base_tier_validation/models/tier_validation.py
+++ b/base_tier_validation/models/tier_validation.py
@@ -500,7 +500,12 @@ class TierValidation(models.AbstractModel):
             return False
         state_from = self._tier_validation_get_current_state_value()
         # If you change to _cancel_state
-        if self._cancel_state and state_to == self._cancel_state:
+        cancel_states = (
+            self._cancel_state
+            if isinstance(self._cancel_state, (list, tuple))
+            else [self._cancel_state]
+        )
+        if state_to in cancel_states:
             return True
         # If it is changed to _state_from and it was not in _state_from
         if state_to in self._state_from and state_from not in self._state_from:

--- a/base_tier_validation/models/tier_validation.py
+++ b/base_tier_validation/models/tier_validation.py
@@ -500,7 +500,7 @@ class TierValidation(models.AbstractModel):
             return False
         state_from = self._tier_validation_get_current_state_value()
         # If you change to _cancel_state
-        if state_to in (self._cancel_state):
+        if self._cancel_state and state_to == self._cancel_state:
             return True
         # If it is changed to _state_from and it was not in _state_from
         if state_to in self._state_from and state_from not in self._state_from:

--- a/base_tier_validation/tests/test_tier_validation.py
+++ b/base_tier_validation/tests/test_tier_validation.py
@@ -17,6 +17,15 @@ from .common import CommonTierValidation
 
 @tagged("post_install", "-at_install")
 class TierTierValidation(CommonTierValidation):
+    def test_00_allow_remove_reviews_cancel_equality(self):
+        """`state_to in (self._cancel_state)` was a substring test on a str:
+        any state whose name is a substring of the cancel state (e.g. "c",
+        "an" for "cancel") wrongly triggered review removal."""
+        rec = self.test_record
+        self.assertFalse(rec._allow_to_remove_reviews({"state": "c"}))
+        self.assertFalse(rec._allow_to_remove_reviews({"state": "an"}))
+        self.assertTrue(rec._allow_to_remove_reviews({"state": "cancel"}))
+
     def test_01_auto_validation(self):
         """When the user can validate all future reviews, it is not needed
         to request a validation, the action can be done straight forward."""


### PR DESCRIPTION
`state_to in (self._cancel_state)` parenthesizes a plain string — not a tuple — so the membership test is a **substring** check: any target state whose name happens to be a substring of the cancel state (e.g. `"c"` or `"an"` for the default `"cancel"`) wrongly returns True in `_allow_to_remove_reviews()`, silently deleting the document's reviews on unrelated state changes.

Fixed with an equality comparison (guarding the falsy `_cancel_state` case), with a regression test.

Found while migrating the module to run on Odoo 19 for an internal project.