### PR TITLE
[18.0][IMP] base_export_manager: restrict export from pivot view

### DIFF
--- a/base_export_manager/README.rst
+++ b/base_export_manager/README.rst
@@ -93,6 +93,8 @@ Once you have configured groups who cannot export an object:
 - Connect as a user of this group
 - Go to the list view of the object you disabled the export
 - Select records and open the Action menu. The "Export" is not there.
+- Go to a pivot view of the object. The "Download xlsx" button is not
+  there either.
 
 Known issues / Roadmap
 ======================
@@ -133,6 +135,9 @@ Contributors
 - Olivier Jossen <olivier.jossen@braintec-group.com>
 - Alexandre Díaz <alexandre.diaz@tecnativa.com>
 - Kevin Khao <kevin.khao@akretion.com>
+- Quartile <https://www.quartile.co>
+
+  - Morita Shinnosuke
 
 Maintainers
 -----------

--- a/base_export_manager/__manifest__.py
+++ b/base_export_manager/__manifest__.py
@@ -25,6 +25,8 @@
     "assets": {
         "web.assets_backend": [
             "base_export_manager/static/src/views/list/list_controller.esm.js",
+            "base_export_manager/static/src/views/pivot/pivot_renderer.esm.js",
+            "base_export_manager/static/src/views/pivot/pivot_controller.xml",
         ],
     },
     "installable": True,

--- a/base_export_manager/__manifest__.py
+++ b/base_export_manager/__manifest__.py
@@ -25,6 +25,8 @@
     "assets": {
         "web.assets_backend": [
             "base_export_manager/static/src/views/list/list_controller.esm.js",
+        ],
+        "web.assets_backend_lazy": [
             "base_export_manager/static/src/views/pivot/pivot_renderer.esm.js",
             "base_export_manager/static/src/views/pivot/pivot_controller.xml",
         ],

--- a/base_export_manager/readme/CONTRIBUTORS.md
+++ b/base_export_manager/readme/CONTRIBUTORS.md
@@ -8,3 +8,5 @@
 - Olivier Jossen \<<olivier.jossen@braintec-group.com>\>
 - Alexandre Díaz \<<alexandre.diaz@tecnativa.com>\>
 - Kevin Khao \<<kevin.khao@akretion.com>\>
+- Quartile \<<https://www.quartile.co>\>
+  - Morita Shinnosuke

--- a/base_export_manager/readme/USAGE.md
+++ b/base_export_manager/readme/USAGE.md
@@ -32,3 +32,5 @@ Once you have configured groups who cannot export an object:
 - Connect as a user of this group
 - Go to the list view of the object you disabled the export
 - Select records and open the Action menu. The "Export" is not there.
+- Go to a pivot view of the object. The "Download xlsx" button is not
+  there either.

--- a/base_export_manager/static/src/views/pivot/pivot_controller.xml
+++ b/base_export_manager/static/src/views/pivot/pivot_controller.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<templates xml:space="preserve">
+
+    <t t-inherit="web.PivotView.Buttons" t-inherit-mode="extension">
+        <xpath expr="//button[hasclass('o_pivot_download')]" position="attributes">
+            <attribute name="t-if">isExportEnable</attribute>
+        </xpath>
+    </t>
+
+</templates>

--- a/base_export_manager/static/src/views/pivot/pivot_renderer.esm.js
+++ b/base_export_manager/static/src/views/pivot/pivot_renderer.esm.js
@@ -1,0 +1,18 @@
+import {PivotRenderer} from "@web/views/pivot/pivot_renderer";
+const {onWillRender} = owl;
+import {patch} from "@web/core/utils/patch";
+import {session} from "@web/session";
+
+patch(PivotRenderer.prototype, {
+    setup() {
+        super.setup();
+        this.isExportEnable = true;
+        onWillRender(() => {
+            const is_export_enabled =
+                session.export_models.indexOf(this.model.metaData.resModel) !== -1;
+            if (!session.is_system && !is_export_enabled) {
+                this.isExportEnable = false;
+            }
+        });
+    },
+});


### PR DESCRIPTION
The "Export Access" access right already hides the list view's Export
action, but the pivot view's "Download xlsx" button remained visible
and usable regardless of that setting. This PR hides it the same way,
based on the models the current user is allowed to export.

Assisted-by: Claude Sonnet 5