### PR TITLE
[IMP] sequence_reset_period: document date range prerequisite

### DIFF
--- a/sequence_reset_period/readme/CONTRIBUTORS.md
+++ b/sequence_reset_period/readme/CONTRIBUTORS.md
@@ -2,3 +2,5 @@
 - Jaume Planas \<<jaume.planas@minorisa.net>\>
 - Pimolnat Suntian \<<pimolnats@ecosoft.co.th>\>
 - Sunanda Chhatbar \<<sunanda.chhatbar@initos.com>\>
+- [Calibre Consulting](https://calibreconsulting.ca/odoo/):
+  - Yuvraj Nagra

--- a/sequence_reset_period/readme/DESCRIPTION.md
+++ b/sequence_reset_period/readme/DESCRIPTION.md
@@ -1,2 +1,6 @@
 This module was written to reset the sequences on the specified times,
 because by default they are reset yearly.
+
+It adds a Range Reset option to sequences that use subsequences per date
+range, so a new subsequence starts each day, week or month instead of only
+at the start of the calendar year.

--- a/sequence_reset_period/readme/USAGE.md
+++ b/sequence_reset_period/readme/USAGE.md
@@ -1,2 +1,34 @@
-- Access sequences and configurate the model to use.
-- When sequence is computed, date_range will follow the specified rules
+## Setup
+
+- Go to Settings > Technical > Sequences & Identifiers > Sequences and open the
+  sequence you want to reset.
+- Tick **Use subsequences per date_range**. The **Range Reset** field stays
+  hidden until you do.
+- Set **Range Reset** to Daily, Weekly, Monthly or Yearly.
+
+## An existing subsequence keeps the setting dormant
+
+Odoo only builds a new subsequence when no existing one covers the current
+date. Setting Range Reset leaves the subsequences already on the record alone,
+so a sequence that still carries a 1 January to 31 December row keeps drawing
+from that row and the numbering never resets.
+
+If nothing happens after setting Range Reset, open the **Subsequences** tab and
+look at the rows. Shorten the **To** date on the row covering today, or delete
+it, and the next number drawn builds a fresh range on the new period. Editing
+rather than deleting keeps the earlier numbering on record.
+
+## Range boundaries
+
+| Range Reset | From | To |
+| --- | --- | --- |
+| Daily | the current date | the current date |
+| Weekly | Monday of the current week | the following Sunday |
+| Monthly | the 1st of the current month | the last day of that month |
+| Yearly | 1 January | 31 December |
+
+The computed range is then trimmed against neighbouring subsequences so that
+ranges never overlap. If an existing row ends between the computed start and
+today, the new range starts the day after it. If an existing row starts between
+today and the computed end, the new range ends the day before it. The first
+range after switching can therefore be shorter than a full period.


### PR DESCRIPTION
The readme for this module does not explain the one thing that stops it from
working, so a correctly configured sequence looks broken.

`_create_date_range_seq` is only called by core when no existing subsequence
covers the current date (`odoo/addons/base/models/ir_sequence.py`, `_next`).
Setting **Range Reset** does not touch the subsequences already on the record,
so a sequence that still carries a 1 January to 31 December range keeps drawing
from that range and the numbering never resets. Nothing in `USAGE.md` says so,
and the field is also hidden until **Use subsequences per date_range** is
ticked, which the readme does not mention either.

This PR is documentation only, no code change.

- `DESCRIPTION.md`: name the option the module adds.
- `USAGE.md`: setup steps, the existing-subsequence prerequisite and how to
  clear it, the range boundaries produced per period, and the trimming applied
  against neighbouring subsequences.
- `CONTRIBUTORS.md`: add the contributor.

The range boundaries and trimming behaviour are taken from
`_compute_date_from_to` and `_create_date_range_seq` in
`models/ir_sequence.py`.

Targeting 18.0. Happy to port to 17.0 and 19.0 once this is agreed. 16.0 still
uses the `.rst` fragments and would need a separate PR.
