### PR TITLE
[18.0][FIX] base_tier_validation: subscribe with subtype_ids in _notify_review_available

### DIFF
--- a/base_tier_validation/models/tier_validation.py
+++ b/base_tier_validation/models/tier_validation.py
@@ -953,9 +953,18 @@ class TierValidation(models.AbstractModel):
                     lambda r, x=rec: r.definition_id.notify_on_pending
                     and r.res_id == x.id
                 ).mapped("reviewer_ids")
-                # Subscribe reviewers and notify
+                # Subscribe reviewers to the tier-validation-requested
+                # subtype explicitly, otherwise ``message_post`` below would
+                # route to no one (the subtype is ``default=False``). Only
+                # post the message when at least one reviewer wants to be
+                # notified -- mirroring ``_notify_review_requested``.
+                if not users_to_notify:
+                    continue
                 rec.message_subscribe(
-                    partner_ids=users_to_notify.mapped("partner_id").ids
+                    partner_ids=users_to_notify.mapped("partner_id").ids,
+                    subtype_ids=self.env.ref(
+                        self._get_requested_notification_subtype()
+                    ).ids,
                 )
                 rec.message_post(
                     subtype_xmlid=self._get_requested_notification_subtype(),

--- a/base_tier_validation/tests/test_tier_validation.py
+++ b/base_tier_validation/tests/test_tier_validation.py
@@ -637,6 +637,35 @@ class TierTierValidation(CommonTierValidation):
         self.assertTrue(review_2.done_by.id is False)
         self.assertTrue(review_2.reviewed_date is False)
 
+    def test_19b_notify_review_available_no_op_when_no_users(self):
+        """``_notify_review_available`` must short-circuit (no follower
+        added, no chatter message posted) when none of the passed reviews
+        actually wants ``notify_on_pending``. This is the defensive contract
+        that prevents stray subtype messages routed to nobody.
+        """
+        TierDefinition = self.env["tier.definition"]
+        test_record = self.test_model.create({"test_field": 2.5})
+        silent_def = TierDefinition.create(
+            {
+                "model_id": self.tester_model.id,
+                "review_type": "individual",
+                "reviewer_id": self.test_user_1.id,
+                "definition_domain": "[('test_field', '=', 2.5)]",
+                "notify_on_pending": False,
+                "sequence": 10,
+                "name": "Silent definition -- no notify_on_pending",
+            }
+        )
+        reviews = test_record.request_validation()
+        silent_review = reviews.filtered(lambda r: r.definition_id == silent_def)
+        self.assertTrue(silent_review)
+
+        followers_before = test_record.message_follower_ids
+        messages_before = test_record.message_ids
+        test_record._notify_review_available(silent_review)
+        self.assertEqual(test_record.message_follower_ids, followers_before)
+        self.assertEqual(test_record.message_ids, messages_before)
+
     def test_20_no_sequence(self):
         # Create new test record
         tier_review_obj = self.env["tier.review"]


### PR DESCRIPTION
Backport of [OCA/tier-validation#21](https://github.com/OCA/tier-validation/pull/21) (partial) to 18.0:
 - https://github.com/OCA/tier-validation/pull/21/changes/6c64fd3eab4240ee34163b979cf3fa5c6a4c7e12
 - https://github.com/OCA/tier-validation/pull/21/changes/60d08727d15a0caa5dc7835fded3c1aea949dfe7
 
**Problem**

When a tier definition has Notify Reviewers on reaching Pending (notify_on_pending) enabled, the reviewer never receives anything.

The chatter shows the "A review has been requested by ..." entry, so the notification looks like it fired — but no mail.mail record is created at all, not even a queued or failed one, and message.notified_partner_ids on the posted message is empty.

notify_on_create on the same definition works correctly, which makes the failure easy to miss: the first tier is notified, later tiers silently are not.

**Reproduce**

1. Create a tier definition with notify_on_pending=True (and notify_on_create=False) with a reviewer who is not the requesting user.
2. Request validation on a matching record.
3. The review reaches pending and the chatter entry appears.
4. Settings ‣ Technical ‣ Email ‣ Emails — nothing for that record.